### PR TITLE
corrected ending errors (udp -> ud)

### DIFF
--- a/est
+++ b/est
@@ -1,5 +1,5 @@
 haarama	olete haaranud	V;ACT;PRS;PRF;POS;IND;2;PL
-haarama	ei olevat haaranudp	V;ACT;PRS;PRF;NEG;QUOT
+haarama	ei olevat haaranud	V;ACT;PRS;PRF;NEG;QUOT
 haarama	oleks haaratud	V;PASS;PRS;PRF;POS;COND
 haarama	haarasin	V;ACT;PST;POS;IND;1;SG
 haarama	haaratakse	V;PASS;PRS;POS;IND
@@ -8,7 +8,7 @@ haarama	haaratagu	V;PASS;PRS;POS;IMP
 haarama	ärgu haaraku	V;ACT;PRS;NEG;IMP;3;SG
 haarama	oli haaratud	V;PASS;PST;PRF;POS;IND
 haarama	haarasime	V;ACT;PST;POS;IND;1;PL
-haarama	ei olnud haaranudp	V;ACT;PST;PRF;NEG;IND
+haarama	ei olnud haaranud	V;ACT;PST;PRF;NEG;IND
 haarama	oleksid haaranud	V;ACT;PRS;PRF;POS;COND;2;SG
 haarama	olgu haaranud	V;ACT;PRS;PRF;POS;IMP;PL
 haarama	oli haaranud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -22,9 +22,9 @@ haarama	ärgu haaraku	V;ACT;PRS;NEG;IMP;3;PL
 haarama	olgu haaranud	V;ACT;PRS;PRF;POS;IMP;SG
 haarama	haarati	V;PASS;PST;POS;IND
 haarama	ei haaravat	V;ACT;PRS;NEG;QUOT
-haarama	ei oleks haaratudp	V;PASS;PRS;PRF;NEG;COND
+haarama	ei oleks haaratud	V;PASS;PRS;PRF;NEG;COND
 haarama	ei haaranud	V;ACT;PST;NEG;IND
-haarama	ei olevat haaratudp	V;PASS;PRS;PRF;NEG;QUOT
+haarama	ei olevat haaratud	V;PASS;PRS;PRF;NEG;QUOT
 haarama	ei haaraks	V;ACT;PRS;PRF;POS;COND;1;SG
 haarama	haaratud	V.PTCP;PASS;PST
 haarama	olid haaranud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -43,7 +43,7 @@ haarama	olgu haaratud	V;PASS;PRS;PRF;POS;IMP
 haarama	haaraks	V;ACT;PRS;POS;COND;3;SG
 haarama	haaraku	V;ACT;PRS;POS;IMP;3;PL
 haarama	ärgu olgu haaranud	V;ACT;PRS;PRF;NEG;IMP;SG
-haarama	ei ole haaranudp	V;ACT;PST;NEG;IND
+haarama	ei ole haaranud	V;ACT;PST;NEG;IND
 haarama	haarad	V;ACT;PRS;POS;IND;2;SG
 haarama	ära haara	V;ACT;PRS;NEG;IMP;2;SG
 haarama	ei haara	V;ACT;PRS;NEG;IND
@@ -71,17 +71,17 @@ haarama	ei haarata	V;PASS;PRS;NEG;IND
 haarama	haarame	V;ACT;PRS;POS;IND;1;PL
 haarama	haaran	V;ACT;PRS;POS;IND;1;SG
 haarama	ärgem haarakem	V;ACT;PRS;NEG;IMP;1;PL
-haarama	ei oleks haaranudp	V;ACT;PRS;PRF;NEG;COND
+haarama	ei oleks haaranud	V;ACT;PRS;PRF;NEG;COND
 haarama	oleksid haaranud	V;ACT;PRS;PRF;POS;COND;3;PL
 haarama	haarasite	V;ACT;PST;POS;IND;2;PL
 haarama	oleks haaranud	V;ACT;PRS;PRF;POS;COND;3;SG
 haarama	olin haaranud	V;ACT;PRS;PRF;POS;COND;1;SG
 haarama	oled haaranud	V;ACT;PRS;PRF;POS;IND;2;SG
 haarama	oli haaranud	V;ACT;PRS;PRF;POS;COND;3;SG
-haarama	ei ole haaratudp	V;PASS;PRS;PRF;NEG;IND
+haarama	ei ole haaratud	V;PASS;PRS;PRF;NEG;IND
 haarama	haaraksin	V;ACT;PRS;POS;COND;1;SG
 haarama	olen haaranud	V;ACT;PRS;PRF;POS;IND;1;SG
-haarama	ei olnud haaratudp	V;PASS;PST;PRF;NEG;IND
+haarama	ei olnud haaratud	V;PASS;PST;PRF;NEG;IND
 haarama	ärgu olgu haaratud	V;PASS;PRS;PRF;NEG;IMP
 
 haarem	haaremini	N;TERM;SG
@@ -209,7 +209,7 @@ hai	haidesse	N;IN+ALL;PL
 hai	haidelt	N;AT+ABL;PL
 
 hakkama	olete hakanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hakkama	ei olevat hakanudp	V;ACT;PRS;PRF;NEG;QUOT
+hakkama	ei olevat hakanud	V;ACT;PRS;PRF;NEG;QUOT
 hakkama	oleks hakatud	V;PASS;PRS;PRF;POS;COND
 hakkama	hakkasin	V;ACT;PST;POS;IND;1;SG
 hakkama	hakatakse	V;PASS;PRS;POS;IND
@@ -218,7 +218,7 @@ hakkama	hakatagu	V;PASS;PRS;POS;IMP
 hakkama	ärgu hakaku	V;ACT;PRS;NEG;IMP;3;SG
 hakkama	oli hakatud	V;PASS;PST;PRF;POS;IND
 hakkama	hakkasime	V;ACT;PST;POS;IND;1;PL
-hakkama	ei olnud hakanudp	V;ACT;PST;PRF;NEG;IND
+hakkama	ei olnud hakanud	V;ACT;PST;PRF;NEG;IND
 hakkama	oleksid hakanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hakkama	olgu hakanud	V;ACT;PRS;PRF;POS;IMP;PL
 hakkama	oli hakanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -232,9 +232,9 @@ hakkama	ärgu hakaku	V;ACT;PRS;NEG;IMP;3;PL
 hakkama	olgu hakanud	V;ACT;PRS;PRF;POS;IMP;SG
 hakkama	hakati	V;PASS;PST;POS;IND
 hakkama	ei hakkavat	V;ACT;PRS;NEG;QUOT
-hakkama	ei oleks hakatudp	V;PASS;PRS;PRF;NEG;COND
+hakkama	ei oleks hakatud	V;PASS;PRS;PRF;NEG;COND
 hakkama	ei hakanud	V;ACT;PST;NEG;IND
-hakkama	ei olevat hakatudp	V;PASS;PRS;PRF;NEG;QUOT
+hakkama	ei olevat hakatud	V;PASS;PRS;PRF;NEG;QUOT
 hakkama	ei hakkaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hakkama	hakatud	V.PTCP;PASS;PST
 hakkama	olid hakanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -253,7 +253,7 @@ hakkama	olgu hakatud	V;PASS;PRS;PRF;POS;IMP
 hakkama	hakkaks	V;ACT;PRS;POS;COND;3;SG
 hakkama	hakaku	V;ACT;PRS;POS;IMP;3;PL
 hakkama	ärgu olgu hakanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hakkama	ei ole hakanudp	V;ACT;PST;NEG;IND
+hakkama	ei ole hakanud	V;ACT;PST;NEG;IND
 hakkama	hakkad	V;ACT;PRS;POS;IND;2;SG
 hakkama	ära hakka	V;ACT;PRS;NEG;IMP;2;SG
 hakkama	ei hakka	V;ACT;PRS;NEG;IND
@@ -281,21 +281,21 @@ hakkama	ei hakata	V;PASS;PRS;NEG;IND
 hakkama	hakkame	V;ACT;PRS;POS;IND;1;PL
 hakkama	hakkan	V;ACT;PRS;POS;IND;1;SG
 hakkama	ärgem hakakem	V;ACT;PRS;NEG;IMP;1;PL
-hakkama	ei oleks hakanudp	V;ACT;PRS;PRF;NEG;COND
+hakkama	ei oleks hakanud	V;ACT;PRS;PRF;NEG;COND
 hakkama	oleksid hakanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hakkama	hakkasite	V;ACT;PST;POS;IND;2;PL
 hakkama	oleks hakanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hakkama	olin hakanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hakkama	oled hakanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hakkama	oli hakanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hakkama	ei ole hakatudp	V;PASS;PRS;PRF;NEG;IND
+hakkama	ei ole hakatud	V;PASS;PRS;PRF;NEG;IND
 hakkama	hakkaksin	V;ACT;PRS;POS;COND;1;SG
 hakkama	olen hakanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hakkama	ei olnud hakatudp	V;PASS;PST;PRF;NEG;IND
+hakkama	ei olnud hakatud	V;PASS;PST;PRF;NEG;IND
 hakkama	ärgu olgu hakatud	V;PASS;PRS;PRF;NEG;IMP
 
 hallitama	olete hallitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hallitama	ei olevat hallitanudp	V;ACT;PRS;PRF;NEG;QUOT
+hallitama	ei olevat hallitanud	V;ACT;PRS;PRF;NEG;QUOT
 hallitama	oleks hallitatud	V;PASS;PRS;PRF;POS;COND
 hallitama	hallitasin	V;ACT;PST;POS;IND;1;SG
 hallitama	hallitatakse	V;PASS;PRS;POS;IND
@@ -304,7 +304,7 @@ hallitama	hallitatagu	V;PASS;PRS;POS;IMP
 hallitama	ärgu hallitagu	V;ACT;PRS;NEG;IMP;3;SG
 hallitama	oli hallitatud	V;PASS;PST;PRF;POS;IND
 hallitama	hallitasime	V;ACT;PST;POS;IND;1;PL
-hallitama	ei olnud hallitanudp	V;ACT;PST;PRF;NEG;IND
+hallitama	ei olnud hallitanud	V;ACT;PST;PRF;NEG;IND
 hallitama	oleksid hallitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hallitama	olgu hallitanud	V;ACT;PRS;PRF;POS;IMP;PL
 hallitama	oli hallitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -318,9 +318,9 @@ hallitama	ärgu hallitagu	V;ACT;PRS;NEG;IMP;3;PL
 hallitama	olgu hallitanud	V;ACT;PRS;PRF;POS;IMP;SG
 hallitama	hallitati	V;PASS;PST;POS;IND
 hallitama	ei hallitavat	V;ACT;PRS;NEG;QUOT
-hallitama	ei oleks hallitatudp	V;PASS;PRS;PRF;NEG;COND
+hallitama	ei oleks hallitatud	V;PASS;PRS;PRF;NEG;COND
 hallitama	ei hallitanud	V;ACT;PST;NEG;IND
-hallitama	ei olevat hallitatudp	V;PASS;PRS;PRF;NEG;QUOT
+hallitama	ei olevat hallitatud	V;PASS;PRS;PRF;NEG;QUOT
 hallitama	ei hallitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hallitama	hallitatud	V.PTCP;PASS;PST
 hallitama	olid hallitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -339,7 +339,7 @@ hallitama	olgu hallitatud	V;PASS;PRS;PRF;POS;IMP
 hallitama	hallitaks	V;ACT;PRS;POS;COND;3;SG
 hallitama	hallitagu	V;ACT;PRS;POS;IMP;3;PL
 hallitama	ärgu olgu hallitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hallitama	ei ole hallitanudp	V;ACT;PST;NEG;IND
+hallitama	ei ole hallitanud	V;ACT;PST;NEG;IND
 hallitama	hallitad	V;ACT;PRS;POS;IND;2;SG
 hallitama	ära hallita	V;ACT;PRS;NEG;IMP;2;SG
 hallitama	ei hallita	V;ACT;PRS;NEG;IND
@@ -367,17 +367,17 @@ hallitama	ei hallitata	V;PASS;PRS;NEG;IND
 hallitama	hallitame	V;ACT;PRS;POS;IND;1;PL
 hallitama	hallitan	V;ACT;PRS;POS;IND;1;SG
 hallitama	ärgem hallitagem	V;ACT;PRS;NEG;IMP;1;PL
-hallitama	ei oleks hallitanudp	V;ACT;PRS;PRF;NEG;COND
+hallitama	ei oleks hallitanud	V;ACT;PRS;PRF;NEG;COND
 hallitama	oleksid hallitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hallitama	hallitasite	V;ACT;PST;POS;IND;2;PL
 hallitama	oleks hallitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hallitama	olin hallitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hallitama	oled hallitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hallitama	oli hallitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hallitama	ei ole hallitatudp	V;PASS;PRS;PRF;NEG;IND
+hallitama	ei ole hallitatud	V;PASS;PRS;PRF;NEG;IND
 hallitama	hallitaksin	V;ACT;PRS;POS;COND;1;SG
 hallitama	olen hallitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hallitama	ei olnud hallitatudp	V;PASS;PST;PRF;NEG;IND
+hallitama	ei olnud hallitatud	V;PASS;PST;PRF;NEG;IND
 hallitama	ärgu olgu hallitatud	V;PASS;PRS;PRF;NEG;IMP
 
 haridus	hariduseni	N;TERM;SG
@@ -412,7 +412,7 @@ haridus	haridustesse	N;IN+ALL;PL
 haridus	haridustelt	N;AT+ABL;PL
 
 harima	olete harinud	V;ACT;PRS;PRF;POS;IND;2;PL
-harima	ei olevat harinudp	V;ACT;PRS;PRF;NEG;QUOT
+harima	ei olevat harinud	V;ACT;PRS;PRF;NEG;QUOT
 harima	oleks haritud	V;PASS;PRS;PRF;POS;COND
 harima	harisin	V;ACT;PST;POS;IND;1;SG
 harima	haritakse	V;PASS;PRS;POS;IND
@@ -421,7 +421,7 @@ harima	haritagu	V;PASS;PRS;POS;IMP
 harima	ärgu harigu	V;ACT;PRS;NEG;IMP;3;SG
 harima	oli haritud	V;PASS;PST;PRF;POS;IND
 harima	harisime	V;ACT;PST;POS;IND;1;PL
-harima	ei olnud harinudp	V;ACT;PST;PRF;NEG;IND
+harima	ei olnud harinud	V;ACT;PST;PRF;NEG;IND
 harima	oleksid harinud	V;ACT;PRS;PRF;POS;COND;2;SG
 harima	olgu harinud	V;ACT;PRS;PRF;POS;IMP;PL
 harima	oli harinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -435,9 +435,9 @@ harima	ärgu harigu	V;ACT;PRS;NEG;IMP;3;PL
 harima	olgu harinud	V;ACT;PRS;PRF;POS;IMP;SG
 harima	hariti	V;PASS;PST;POS;IND
 harima	ei harivat	V;ACT;PRS;NEG;QUOT
-harima	ei oleks haritudp	V;PASS;PRS;PRF;NEG;COND
+harima	ei oleks haritud	V;PASS;PRS;PRF;NEG;COND
 harima	ei harinud	V;ACT;PST;NEG;IND
-harima	ei olevat haritudp	V;PASS;PRS;PRF;NEG;QUOT
+harima	ei olevat haritud	V;PASS;PRS;PRF;NEG;QUOT
 harima	ei hariks	V;ACT;PRS;PRF;POS;COND;1;SG
 harima	haritud	V.PTCP;PASS;PST
 harima	olid harinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -456,7 +456,7 @@ harima	olgu haritud	V;PASS;PRS;PRF;POS;IMP
 harima	hariks	V;ACT;PRS;POS;COND;3;SG
 harima	harigu	V;ACT;PRS;POS;IMP;3;PL
 harima	ärgu olgu harinud	V;ACT;PRS;PRF;NEG;IMP;SG
-harima	ei ole harinudp	V;ACT;PST;NEG;IND
+harima	ei ole harinud	V;ACT;PST;NEG;IND
 harima	harid	V;ACT;PRS;POS;IND;2;SG
 harima	ära hari	V;ACT;PRS;NEG;IMP;2;SG
 harima	ei hari	V;ACT;PRS;NEG;IND
@@ -484,21 +484,21 @@ harima	ei harita	V;PASS;PRS;NEG;IND
 harima	harime	V;ACT;PRS;POS;IND;1;PL
 harima	harin	V;ACT;PRS;POS;IND;1;SG
 harima	ärgem harigem	V;ACT;PRS;NEG;IMP;1;PL
-harima	ei oleks harinudp	V;ACT;PRS;PRF;NEG;COND
+harima	ei oleks harinud	V;ACT;PRS;PRF;NEG;COND
 harima	oleksid harinud	V;ACT;PRS;PRF;POS;COND;3;PL
 harima	harisite	V;ACT;PST;POS;IND;2;PL
 harima	oleks harinud	V;ACT;PRS;PRF;POS;COND;3;SG
 harima	olin harinud	V;ACT;PRS;PRF;POS;COND;1;SG
 harima	oled harinud	V;ACT;PRS;PRF;POS;IND;2;SG
 harima	oli harinud	V;ACT;PRS;PRF;POS;COND;3;SG
-harima	ei ole haritudp	V;PASS;PRS;PRF;NEG;IND
+harima	ei ole haritud	V;PASS;PRS;PRF;NEG;IND
 harima	hariksin	V;ACT;PRS;POS;COND;1;SG
 harima	olen harinud	V;ACT;PRS;PRF;POS;IND;1;SG
-harima	ei olnud haritudp	V;PASS;PST;PRF;NEG;IND
+harima	ei olnud haritud	V;PASS;PST;PRF;NEG;IND
 harima	ärgu olgu haritud	V;PASS;PRS;PRF;NEG;IMP
 
 harjama	olete harjanud	V;ACT;PRS;PRF;POS;IND;2;PL
-harjama	ei olevat harjanudp	V;ACT;PRS;PRF;NEG;QUOT
+harjama	ei olevat harjanud	V;ACT;PRS;PRF;NEG;QUOT
 harjama	oleks harjatud	V;PASS;PRS;PRF;POS;COND
 harjama	harjasin	V;ACT;PST;POS;IND;1;SG
 harjama	harjatakse	V;PASS;PRS;POS;IND
@@ -507,7 +507,7 @@ harjama	harjatagu	V;PASS;PRS;POS;IMP
 harjama	ärgu harjaku	V;ACT;PRS;NEG;IMP;3;SG
 harjama	oli harjatud	V;PASS;PST;PRF;POS;IND
 harjama	harjasime	V;ACT;PST;POS;IND;1;PL
-harjama	ei olnud harjanudp	V;ACT;PST;PRF;NEG;IND
+harjama	ei olnud harjanud	V;ACT;PST;PRF;NEG;IND
 harjama	oleksid harjanud	V;ACT;PRS;PRF;POS;COND;2;SG
 harjama	olgu harjanud	V;ACT;PRS;PRF;POS;IMP;PL
 harjama	oli harjanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -521,9 +521,9 @@ harjama	ärgu harjaku	V;ACT;PRS;NEG;IMP;3;PL
 harjama	olgu harjanud	V;ACT;PRS;PRF;POS;IMP;SG
 harjama	harjati	V;PASS;PST;POS;IND
 harjama	ei harjavat	V;ACT;PRS;NEG;QUOT
-harjama	ei oleks harjatudp	V;PASS;PRS;PRF;NEG;COND
+harjama	ei oleks harjatud	V;PASS;PRS;PRF;NEG;COND
 harjama	ei harjanud	V;ACT;PST;NEG;IND
-harjama	ei olevat harjatudp	V;PASS;PRS;PRF;NEG;QUOT
+harjama	ei olevat harjatud	V;PASS;PRS;PRF;NEG;QUOT
 harjama	ei harjaks	V;ACT;PRS;PRF;POS;COND;1;SG
 harjama	harjatud	V.PTCP;PASS;PST
 harjama	olid harjanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -542,7 +542,7 @@ harjama	olgu harjatud	V;PASS;PRS;PRF;POS;IMP
 harjama	harjaks	V;ACT;PRS;POS;COND;3;SG
 harjama	harjaku	V;ACT;PRS;POS;IMP;3;PL
 harjama	ärgu olgu harjanud	V;ACT;PRS;PRF;NEG;IMP;SG
-harjama	ei ole harjanudp	V;ACT;PST;NEG;IND
+harjama	ei ole harjanud	V;ACT;PST;NEG;IND
 harjama	harjad	V;ACT;PRS;POS;IND;2;SG
 harjama	ära harja	V;ACT;PRS;NEG;IMP;2;SG
 harjama	ei harja	V;ACT;PRS;NEG;IND
@@ -570,21 +570,21 @@ harjama	ei harjata	V;PASS;PRS;NEG;IND
 harjama	harjame	V;ACT;PRS;POS;IND;1;PL
 harjama	harjan	V;ACT;PRS;POS;IND;1;SG
 harjama	ärgem harjakem	V;ACT;PRS;NEG;IMP;1;PL
-harjama	ei oleks harjanudp	V;ACT;PRS;PRF;NEG;COND
+harjama	ei oleks harjanud	V;ACT;PRS;PRF;NEG;COND
 harjama	oleksid harjanud	V;ACT;PRS;PRF;POS;COND;3;PL
 harjama	harjasite	V;ACT;PST;POS;IND;2;PL
 harjama	oleks harjanud	V;ACT;PRS;PRF;POS;COND;3;SG
 harjama	olin harjanud	V;ACT;PRS;PRF;POS;COND;1;SG
 harjama	oled harjanud	V;ACT;PRS;PRF;POS;IND;2;SG
 harjama	oli harjanud	V;ACT;PRS;PRF;POS;COND;3;SG
-harjama	ei ole harjatudp	V;PASS;PRS;PRF;NEG;IND
+harjama	ei ole harjatud	V;PASS;PRS;PRF;NEG;IND
 harjama	harjaksin	V;ACT;PRS;POS;COND;1;SG
 harjama	olen harjanud	V;ACT;PRS;PRF;POS;IND;1;SG
-harjama	ei olnud harjatudp	V;PASS;PST;PRF;NEG;IND
+harjama	ei olnud harjatud	V;PASS;PST;PRF;NEG;IND
 harjama	ärgu olgu harjatud	V;PASS;PRS;PRF;NEG;IMP
 
 harjutama	olete harjutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-harjutama	ei olevat harjutanudp	V;ACT;PRS;PRF;NEG;QUOT
+harjutama	ei olevat harjutanud	V;ACT;PRS;PRF;NEG;QUOT
 harjutama	oleks harjutatud	V;PASS;PRS;PRF;POS;COND
 harjutama	harjutasin	V;ACT;PST;POS;IND;1;SG
 harjutama	harjutatakse	V;PASS;PRS;POS;IND
@@ -593,7 +593,7 @@ harjutama	harjutatagu	V;PASS;PRS;POS;IMP
 harjutama	ärgu harjutagu	V;ACT;PRS;NEG;IMP;3;SG
 harjutama	oli harjutatud	V;PASS;PST;PRF;POS;IND
 harjutama	harjutasime	V;ACT;PST;POS;IND;1;PL
-harjutama	ei olnud harjutanudp	V;ACT;PST;PRF;NEG;IND
+harjutama	ei olnud harjutanud	V;ACT;PST;PRF;NEG;IND
 harjutama	oleksid harjutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 harjutama	olgu harjutanud	V;ACT;PRS;PRF;POS;IMP;PL
 harjutama	oli harjutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -607,9 +607,9 @@ harjutama	ärgu harjutagu	V;ACT;PRS;NEG;IMP;3;PL
 harjutama	olgu harjutanud	V;ACT;PRS;PRF;POS;IMP;SG
 harjutama	harjutati	V;PASS;PST;POS;IND
 harjutama	ei harjutavat	V;ACT;PRS;NEG;QUOT
-harjutama	ei oleks harjutatudp	V;PASS;PRS;PRF;NEG;COND
+harjutama	ei oleks harjutatud	V;PASS;PRS;PRF;NEG;COND
 harjutama	ei harjutanud	V;ACT;PST;NEG;IND
-harjutama	ei olevat harjutatudp	V;PASS;PRS;PRF;NEG;QUOT
+harjutama	ei olevat harjutatud	V;PASS;PRS;PRF;NEG;QUOT
 harjutama	ei harjutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 harjutama	harjutatud	V.PTCP;PASS;PST
 harjutama	olid harjutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -628,7 +628,7 @@ harjutama	olgu harjutatud	V;PASS;PRS;PRF;POS;IMP
 harjutama	harjutaks	V;ACT;PRS;POS;COND;3;SG
 harjutama	harjutagu	V;ACT;PRS;POS;IMP;3;PL
 harjutama	ärgu olgu harjutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-harjutama	ei ole harjutanudp	V;ACT;PST;NEG;IND
+harjutama	ei ole harjutanud	V;ACT;PST;NEG;IND
 harjutama	harjutad	V;ACT;PRS;POS;IND;2;SG
 harjutama	ära harjuta	V;ACT;PRS;NEG;IMP;2;SG
 harjutama	ei harjuta	V;ACT;PRS;NEG;IND
@@ -656,17 +656,17 @@ harjutama	ei harjutata	V;PASS;PRS;NEG;IND
 harjutama	harjutame	V;ACT;PRS;POS;IND;1;PL
 harjutama	harjutan	V;ACT;PRS;POS;IND;1;SG
 harjutama	ärgem harjutagem	V;ACT;PRS;NEG;IMP;1;PL
-harjutama	ei oleks harjutanudp	V;ACT;PRS;PRF;NEG;COND
+harjutama	ei oleks harjutanud	V;ACT;PRS;PRF;NEG;COND
 harjutama	oleksid harjutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 harjutama	harjutasite	V;ACT;PST;POS;IND;2;PL
 harjutama	oleks harjutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 harjutama	olin harjutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 harjutama	oled harjutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 harjutama	oli harjutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-harjutama	ei ole harjutatudp	V;PASS;PRS;PRF;NEG;IND
+harjutama	ei ole harjutatud	V;PASS;PRS;PRF;NEG;IND
 harjutama	harjutaksin	V;ACT;PRS;POS;COND;1;SG
 harjutama	olen harjutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-harjutama	ei olnud harjutatudp	V;PASS;PST;PRF;NEG;IND
+harjutama	ei olnud harjutatud	V;PASS;PST;PRF;NEG;IND
 harjutama	ärgu olgu harjutatud	V;PASS;PRS;PRF;NEG;IMP
 
 harjutus	harjutuseni	N;TERM;SG
@@ -794,7 +794,7 @@ heinakuu	heinakuudesse	N;IN+ALL;PL
 heinakuu	heinakuudelt	N;AT+ABL;PL
 
 heitma	olete heitnud	V;ACT;PRS;PRF;POS;IND;2;PL
-heitma	ei olevat heitnudp	V;ACT;PRS;PRF;NEG;QUOT
+heitma	ei olevat heitnud	V;ACT;PRS;PRF;NEG;QUOT
 heitma	oleks heidetud	V;PASS;PRS;PRF;POS;COND
 heitma	heitsin	V;ACT;PST;POS;IND;1;SG
 heitma	heidetakse	V;PASS;PRS;POS;IND
@@ -803,7 +803,7 @@ heitma	heidetagu	V;PASS;PRS;POS;IMP
 heitma	ärgu heitku	V;ACT;PRS;NEG;IMP;3;SG
 heitma	oli heidetud	V;PASS;PST;PRF;POS;IND
 heitma	heitsime	V;ACT;PST;POS;IND;1;PL
-heitma	ei olnud heitnudp	V;ACT;PST;PRF;NEG;IND
+heitma	ei olnud heitnud	V;ACT;PST;PRF;NEG;IND
 heitma	oleksid heitnud	V;ACT;PRS;PRF;POS;COND;2;SG
 heitma	olgu heitnud	V;ACT;PRS;PRF;POS;IMP;PL
 heitma	oli heitnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -817,9 +817,9 @@ heitma	ärgu heitku	V;ACT;PRS;NEG;IMP;3;PL
 heitma	olgu heitnud	V;ACT;PRS;PRF;POS;IMP;SG
 heitma	heideti	V;PASS;PST;POS;IND
 heitma	ei heitvat	V;ACT;PRS;NEG;QUOT
-heitma	ei oleks heidetudp	V;PASS;PRS;PRF;NEG;COND
+heitma	ei oleks heidetud	V;PASS;PRS;PRF;NEG;COND
 heitma	ei heitnud	V;ACT;PST;NEG;IND
-heitma	ei olevat heidetudp	V;PASS;PRS;PRF;NEG;QUOT
+heitma	ei olevat heidetud	V;PASS;PRS;PRF;NEG;QUOT
 heitma	ei heidaks	V;ACT;PRS;PRF;POS;COND;1;SG
 heitma	heidetud	V.PTCP;PASS;PST
 heitma	olid heitnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -838,7 +838,7 @@ heitma	olgu heidetud	V;PASS;PRS;PRF;POS;IMP
 heitma	heidaks	V;ACT;PRS;POS;COND;3;SG
 heitma	heitku	V;ACT;PRS;POS;IMP;3;PL
 heitma	ärgu olgu heitnud	V;ACT;PRS;PRF;NEG;IMP;SG
-heitma	ei ole heitnudp	V;ACT;PST;NEG;IND
+heitma	ei ole heitnud	V;ACT;PST;NEG;IND
 heitma	heidad	V;ACT;PRS;POS;IND;2;SG
 heitma	ära heida	V;ACT;PRS;NEG;IMP;2;SG
 heitma	ei heida	V;ACT;PRS;NEG;IND
@@ -866,17 +866,17 @@ heitma	ei heideta	V;PASS;PRS;NEG;IND
 heitma	heidame	V;ACT;PRS;POS;IND;1;PL
 heitma	heidan	V;ACT;PRS;POS;IND;1;SG
 heitma	ärgem heitkem	V;ACT;PRS;NEG;IMP;1;PL
-heitma	ei oleks heitnudp	V;ACT;PRS;PRF;NEG;COND
+heitma	ei oleks heitnud	V;ACT;PRS;PRF;NEG;COND
 heitma	oleksid heitnud	V;ACT;PRS;PRF;POS;COND;3;PL
 heitma	heitsite	V;ACT;PST;POS;IND;2;PL
 heitma	oleks heitnud	V;ACT;PRS;PRF;POS;COND;3;SG
 heitma	olin heitnud	V;ACT;PRS;PRF;POS;COND;1;SG
 heitma	oled heitnud	V;ACT;PRS;PRF;POS;IND;2;SG
 heitma	oli heitnud	V;ACT;PRS;PRF;POS;COND;3;SG
-heitma	ei ole heidetudp	V;PASS;PRS;PRF;NEG;IND
+heitma	ei ole heidetud	V;PASS;PRS;PRF;NEG;IND
 heitma	heidaksin	V;ACT;PRS;POS;COND;1;SG
 heitma	olen heitnud	V;ACT;PRS;PRF;POS;IND;1;SG
-heitma	ei olnud heidetudp	V;PASS;PST;PRF;NEG;IND
+heitma	ei olnud heidetud	V;PASS;PST;PRF;NEG;IND
 heitma	ärgu olgu heidetud	V;PASS;PRS;PRF;NEG;IMP
 
 helilooja	heliloojani	N;TERM;SG
@@ -911,7 +911,7 @@ helilooja	heliloojatesse	N;IN+ALL;PL
 helilooja	heliloojatelt	N;AT+ABL;PL
 
 helistama	olete helistanud	V;ACT;PRS;PRF;POS;IND;2;PL
-helistama	ei olevat helistanudp	V;ACT;PRS;PRF;NEG;QUOT
+helistama	ei olevat helistanud	V;ACT;PRS;PRF;NEG;QUOT
 helistama	oleks helistatud	V;PASS;PRS;PRF;POS;COND
 helistama	helistasin	V;ACT;PST;POS;IND;1;SG
 helistama	helistatakse	V;PASS;PRS;POS;IND
@@ -920,7 +920,7 @@ helistama	helistatagu	V;PASS;PRS;POS;IMP
 helistama	ärgu helistagu	V;ACT;PRS;NEG;IMP;3;SG
 helistama	oli helistatud	V;PASS;PST;PRF;POS;IND
 helistama	helistasime	V;ACT;PST;POS;IND;1;PL
-helistama	ei olnud helistanudp	V;ACT;PST;PRF;NEG;IND
+helistama	ei olnud helistanud	V;ACT;PST;PRF;NEG;IND
 helistama	oleksid helistanud	V;ACT;PRS;PRF;POS;COND;2;SG
 helistama	olgu helistanud	V;ACT;PRS;PRF;POS;IMP;PL
 helistama	oli helistanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -934,9 +934,9 @@ helistama	ärgu helistagu	V;ACT;PRS;NEG;IMP;3;PL
 helistama	olgu helistanud	V;ACT;PRS;PRF;POS;IMP;SG
 helistama	helistati	V;PASS;PST;POS;IND
 helistama	ei helistavat	V;ACT;PRS;NEG;QUOT
-helistama	ei oleks helistatudp	V;PASS;PRS;PRF;NEG;COND
+helistama	ei oleks helistatud	V;PASS;PRS;PRF;NEG;COND
 helistama	ei helistanud	V;ACT;PST;NEG;IND
-helistama	ei olevat helistatudp	V;PASS;PRS;PRF;NEG;QUOT
+helistama	ei olevat helistatud	V;PASS;PRS;PRF;NEG;QUOT
 helistama	ei helistaks	V;ACT;PRS;PRF;POS;COND;1;SG
 helistama	helistatud	V.PTCP;PASS;PST
 helistama	olid helistanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -955,7 +955,7 @@ helistama	olgu helistatud	V;PASS;PRS;PRF;POS;IMP
 helistama	helistaks	V;ACT;PRS;POS;COND;3;SG
 helistama	helistagu	V;ACT;PRS;POS;IMP;3;PL
 helistama	ärgu olgu helistanud	V;ACT;PRS;PRF;NEG;IMP;SG
-helistama	ei ole helistanudp	V;ACT;PST;NEG;IND
+helistama	ei ole helistanud	V;ACT;PST;NEG;IND
 helistama	helistad	V;ACT;PRS;POS;IND;2;SG
 helistama	ära helista	V;ACT;PRS;NEG;IMP;2;SG
 helistama	ei helista	V;ACT;PRS;NEG;IND
@@ -983,17 +983,17 @@ helistama	ei helistata	V;PASS;PRS;NEG;IND
 helistama	helistame	V;ACT;PRS;POS;IND;1;PL
 helistama	helistan	V;ACT;PRS;POS;IND;1;SG
 helistama	ärgem helistagem	V;ACT;PRS;NEG;IMP;1;PL
-helistama	ei oleks helistanudp	V;ACT;PRS;PRF;NEG;COND
+helistama	ei oleks helistanud	V;ACT;PRS;PRF;NEG;COND
 helistama	oleksid helistanud	V;ACT;PRS;PRF;POS;COND;3;PL
 helistama	helistasite	V;ACT;PST;POS;IND;2;PL
 helistama	oleks helistanud	V;ACT;PRS;PRF;POS;COND;3;SG
 helistama	olin helistanud	V;ACT;PRS;PRF;POS;COND;1;SG
 helistama	oled helistanud	V;ACT;PRS;PRF;POS;IND;2;SG
 helistama	oli helistanud	V;ACT;PRS;PRF;POS;COND;3;SG
-helistama	ei ole helistatudp	V;PASS;PRS;PRF;NEG;IND
+helistama	ei ole helistatud	V;PASS;PRS;PRF;NEG;IND
 helistama	helistaksin	V;ACT;PRS;POS;COND;1;SG
 helistama	olen helistanud	V;ACT;PRS;PRF;POS;IND;1;SG
-helistama	ei olnud helistatudp	V;PASS;PST;PRF;NEG;IND
+helistama	ei olnud helistatud	V;PASS;PST;PRF;NEG;IND
 helistama	ärgu olgu helistatud	V;PASS;PRS;PRF;NEG;IMP
 
 helmekuu	helmekuuni	N;TERM;SG
@@ -1028,7 +1028,7 @@ helmekuu	helmekuudesse	N;IN+ALL;PL
 helmekuu	helmekuudelt	N;AT+ABL;PL
 
 higistama	olete higistanud	V;ACT;PRS;PRF;POS;IND;2;PL
-higistama	ei olevat higistanudp	V;ACT;PRS;PRF;NEG;QUOT
+higistama	ei olevat higistanud	V;ACT;PRS;PRF;NEG;QUOT
 higistama	oleks higistatud	V;PASS;PRS;PRF;POS;COND
 higistama	higistasin	V;ACT;PST;POS;IND;1;SG
 higistama	higistatakse	V;PASS;PRS;POS;IND
@@ -1037,7 +1037,7 @@ higistama	higistatagu	V;PASS;PRS;POS;IMP
 higistama	ärgu higistagu	V;ACT;PRS;NEG;IMP;3;SG
 higistama	oli higistatud	V;PASS;PST;PRF;POS;IND
 higistama	higistasime	V;ACT;PST;POS;IND;1;PL
-higistama	ei olnud higistanudp	V;ACT;PST;PRF;NEG;IND
+higistama	ei olnud higistanud	V;ACT;PST;PRF;NEG;IND
 higistama	oleksid higistanud	V;ACT;PRS;PRF;POS;COND;2;SG
 higistama	olgu higistanud	V;ACT;PRS;PRF;POS;IMP;PL
 higistama	oli higistanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1051,9 +1051,9 @@ higistama	ärgu higistagu	V;ACT;PRS;NEG;IMP;3;PL
 higistama	olgu higistanud	V;ACT;PRS;PRF;POS;IMP;SG
 higistama	higistati	V;PASS;PST;POS;IND
 higistama	ei higistavat	V;ACT;PRS;NEG;QUOT
-higistama	ei oleks higistatudp	V;PASS;PRS;PRF;NEG;COND
+higistama	ei oleks higistatud	V;PASS;PRS;PRF;NEG;COND
 higistama	ei higistanud	V;ACT;PST;NEG;IND
-higistama	ei olevat higistatudp	V;PASS;PRS;PRF;NEG;QUOT
+higistama	ei olevat higistatud	V;PASS;PRS;PRF;NEG;QUOT
 higistama	ei higistaks	V;ACT;PRS;PRF;POS;COND;1;SG
 higistama	higistatud	V.PTCP;PASS;PST
 higistama	olid higistanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1072,7 +1072,7 @@ higistama	olgu higistatud	V;PASS;PRS;PRF;POS;IMP
 higistama	higistaks	V;ACT;PRS;POS;COND;3;SG
 higistama	higistagu	V;ACT;PRS;POS;IMP;3;PL
 higistama	ärgu olgu higistanud	V;ACT;PRS;PRF;NEG;IMP;SG
-higistama	ei ole higistanudp	V;ACT;PST;NEG;IND
+higistama	ei ole higistanud	V;ACT;PST;NEG;IND
 higistama	higistad	V;ACT;PRS;POS;IND;2;SG
 higistama	ära higista	V;ACT;PRS;NEG;IMP;2;SG
 higistama	ei higista	V;ACT;PRS;NEG;IND
@@ -1100,17 +1100,17 @@ higistama	ei higistata	V;PASS;PRS;NEG;IND
 higistama	higistame	V;ACT;PRS;POS;IND;1;PL
 higistama	higistan	V;ACT;PRS;POS;IND;1;SG
 higistama	ärgem higistagem	V;ACT;PRS;NEG;IMP;1;PL
-higistama	ei oleks higistanudp	V;ACT;PRS;PRF;NEG;COND
+higistama	ei oleks higistanud	V;ACT;PRS;PRF;NEG;COND
 higistama	oleksid higistanud	V;ACT;PRS;PRF;POS;COND;3;PL
 higistama	higistasite	V;ACT;PST;POS;IND;2;PL
 higistama	oleks higistanud	V;ACT;PRS;PRF;POS;COND;3;SG
 higistama	olin higistanud	V;ACT;PRS;PRF;POS;COND;1;SG
 higistama	oled higistanud	V;ACT;PRS;PRF;POS;IND;2;SG
 higistama	oli higistanud	V;ACT;PRS;PRF;POS;COND;3;SG
-higistama	ei ole higistatudp	V;PASS;PRS;PRF;NEG;IND
+higistama	ei ole higistatud	V;PASS;PRS;PRF;NEG;IND
 higistama	higistaksin	V;ACT;PRS;POS;COND;1;SG
 higistama	olen higistanud	V;ACT;PRS;PRF;POS;IND;1;SG
-higistama	ei olnud higistatudp	V;PASS;PST;PRF;NEG;IND
+higistama	ei olnud higistatud	V;PASS;PST;PRF;NEG;IND
 higistama	ärgu olgu higistatud	V;PASS;PRS;PRF;NEG;IMP
 
 hiinlane	hiinlaseni	N;TERM;SG
@@ -1176,7 +1176,7 @@ hiir	hiirtesse	N;IN+ALL;PL
 hiir	hiirtelt	N;AT+ABL;PL
 
 hirmuma	olete hirmunud	V;ACT;PRS;PRF;POS;IND;2;PL
-hirmuma	ei olevat hirmunudp	V;ACT;PRS;PRF;NEG;QUOT
+hirmuma	ei olevat hirmunud	V;ACT;PRS;PRF;NEG;QUOT
 hirmuma	oleks hirmutud	V;PASS;PRS;PRF;POS;COND
 hirmuma	hirmusin	V;ACT;PST;POS;IND;1;SG
 hirmuma	hirmutakse	V;PASS;PRS;POS;IND
@@ -1185,7 +1185,7 @@ hirmuma	hirmutagu	V;PASS;PRS;POS;IMP
 hirmuma	ärgu hirmugu	V;ACT;PRS;NEG;IMP;3;SG
 hirmuma	oli hirmutud	V;PASS;PST;PRF;POS;IND
 hirmuma	hirmusime	V;ACT;PST;POS;IND;1;PL
-hirmuma	ei olnud hirmunudp	V;ACT;PST;PRF;NEG;IND
+hirmuma	ei olnud hirmunud	V;ACT;PST;PRF;NEG;IND
 hirmuma	oleksid hirmunud	V;ACT;PRS;PRF;POS;COND;2;SG
 hirmuma	olgu hirmunud	V;ACT;PRS;PRF;POS;IMP;PL
 hirmuma	oli hirmunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1199,9 +1199,9 @@ hirmuma	ärgu hirmugu	V;ACT;PRS;NEG;IMP;3;PL
 hirmuma	olgu hirmunud	V;ACT;PRS;PRF;POS;IMP;SG
 hirmuma	hirmuti	V;PASS;PST;POS;IND
 hirmuma	ei hirmuvat	V;ACT;PRS;NEG;QUOT
-hirmuma	ei oleks hirmutudp	V;PASS;PRS;PRF;NEG;COND
+hirmuma	ei oleks hirmutud	V;PASS;PRS;PRF;NEG;COND
 hirmuma	ei hirmunud	V;ACT;PST;NEG;IND
-hirmuma	ei olevat hirmutudp	V;PASS;PRS;PRF;NEG;QUOT
+hirmuma	ei olevat hirmutud	V;PASS;PRS;PRF;NEG;QUOT
 hirmuma	ei hirmuks	V;ACT;PRS;PRF;POS;COND;1;SG
 hirmuma	hirmutud	V.PTCP;PASS;PST
 hirmuma	olid hirmunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1220,7 +1220,7 @@ hirmuma	olgu hirmutud	V;PASS;PRS;PRF;POS;IMP
 hirmuma	hirmuks	V;ACT;PRS;POS;COND;3;SG
 hirmuma	hirmugu	V;ACT;PRS;POS;IMP;3;PL
 hirmuma	ärgu olgu hirmunud	V;ACT;PRS;PRF;NEG;IMP;SG
-hirmuma	ei ole hirmunudp	V;ACT;PST;NEG;IND
+hirmuma	ei ole hirmunud	V;ACT;PST;NEG;IND
 hirmuma	hirmud	V;ACT;PRS;POS;IND;2;SG
 hirmuma	ära hirmu	V;ACT;PRS;NEG;IMP;2;SG
 hirmuma	ei hirmu	V;ACT;PRS;NEG;IND
@@ -1248,17 +1248,17 @@ hirmuma	ei hirmuta	V;PASS;PRS;NEG;IND
 hirmuma	hirmume	V;ACT;PRS;POS;IND;1;PL
 hirmuma	hirmun	V;ACT;PRS;POS;IND;1;SG
 hirmuma	ärgem hirmugem	V;ACT;PRS;NEG;IMP;1;PL
-hirmuma	ei oleks hirmunudp	V;ACT;PRS;PRF;NEG;COND
+hirmuma	ei oleks hirmunud	V;ACT;PRS;PRF;NEG;COND
 hirmuma	oleksid hirmunud	V;ACT;PRS;PRF;POS;COND;3;PL
 hirmuma	hirmusite	V;ACT;PST;POS;IND;2;PL
 hirmuma	oleks hirmunud	V;ACT;PRS;PRF;POS;COND;3;SG
 hirmuma	olin hirmunud	V;ACT;PRS;PRF;POS;COND;1;SG
 hirmuma	oled hirmunud	V;ACT;PRS;PRF;POS;IND;2;SG
 hirmuma	oli hirmunud	V;ACT;PRS;PRF;POS;COND;3;SG
-hirmuma	ei ole hirmutudp	V;PASS;PRS;PRF;NEG;IND
+hirmuma	ei ole hirmutud	V;PASS;PRS;PRF;NEG;IND
 hirmuma	hirmuksin	V;ACT;PRS;POS;COND;1;SG
 hirmuma	olen hirmunud	V;ACT;PRS;PRF;POS;IND;1;SG
-hirmuma	ei olnud hirmutudp	V;PASS;PST;PRF;NEG;IND
+hirmuma	ei olnud hirmutud	V;PASS;PST;PRF;NEG;IND
 hirmuma	ärgu olgu hirmutud	V;PASS;PRS;PRF;NEG;IMP
 
 hispaanlane	hispaanlaseni	N;TERM;SG
@@ -1324,7 +1324,7 @@ hobune	hobustesse	N;IN+ALL;PL
 hobune	hobustelt	N;AT+ABL;PL
 
 hoiatama	olete hoiatanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hoiatama	ei olevat hoiatanudp	V;ACT;PRS;PRF;NEG;QUOT
+hoiatama	ei olevat hoiatanud	V;ACT;PRS;PRF;NEG;QUOT
 hoiatama	oleks hoiatatud	V;PASS;PRS;PRF;POS;COND
 hoiatama	hoiatasin	V;ACT;PST;POS;IND;1;SG
 hoiatama	hoiatatakse	V;PASS;PRS;POS;IND
@@ -1333,7 +1333,7 @@ hoiatama	hoiatatagu	V;PASS;PRS;POS;IMP
 hoiatama	ärgu hoiatagu	V;ACT;PRS;NEG;IMP;3;SG
 hoiatama	oli hoiatatud	V;PASS;PST;PRF;POS;IND
 hoiatama	hoiatasime	V;ACT;PST;POS;IND;1;PL
-hoiatama	ei olnud hoiatanudp	V;ACT;PST;PRF;NEG;IND
+hoiatama	ei olnud hoiatanud	V;ACT;PST;PRF;NEG;IND
 hoiatama	oleksid hoiatanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hoiatama	olgu hoiatanud	V;ACT;PRS;PRF;POS;IMP;PL
 hoiatama	oli hoiatanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1347,9 +1347,9 @@ hoiatama	ärgu hoiatagu	V;ACT;PRS;NEG;IMP;3;PL
 hoiatama	olgu hoiatanud	V;ACT;PRS;PRF;POS;IMP;SG
 hoiatama	hoiatati	V;PASS;PST;POS;IND
 hoiatama	ei hoiatavat	V;ACT;PRS;NEG;QUOT
-hoiatama	ei oleks hoiatatudp	V;PASS;PRS;PRF;NEG;COND
+hoiatama	ei oleks hoiatatud	V;PASS;PRS;PRF;NEG;COND
 hoiatama	ei hoiatanud	V;ACT;PST;NEG;IND
-hoiatama	ei olevat hoiatatudp	V;PASS;PRS;PRF;NEG;QUOT
+hoiatama	ei olevat hoiatatud	V;PASS;PRS;PRF;NEG;QUOT
 hoiatama	ei hoiataks	V;ACT;PRS;PRF;POS;COND;1;SG
 hoiatama	hoiatatud	V.PTCP;PASS;PST
 hoiatama	olid hoiatanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1368,7 +1368,7 @@ hoiatama	olgu hoiatatud	V;PASS;PRS;PRF;POS;IMP
 hoiatama	hoiataks	V;ACT;PRS;POS;COND;3;SG
 hoiatama	hoiatagu	V;ACT;PRS;POS;IMP;3;PL
 hoiatama	ärgu olgu hoiatanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hoiatama	ei ole hoiatanudp	V;ACT;PST;NEG;IND
+hoiatama	ei ole hoiatanud	V;ACT;PST;NEG;IND
 hoiatama	hoiatad	V;ACT;PRS;POS;IND;2;SG
 hoiatama	ära hoiata	V;ACT;PRS;NEG;IMP;2;SG
 hoiatama	ei hoiata	V;ACT;PRS;NEG;IND
@@ -1396,17 +1396,17 @@ hoiatama	ei hoiatata	V;PASS;PRS;NEG;IND
 hoiatama	hoiatame	V;ACT;PRS;POS;IND;1;PL
 hoiatama	hoiatan	V;ACT;PRS;POS;IND;1;SG
 hoiatama	ärgem hoiatagem	V;ACT;PRS;NEG;IMP;1;PL
-hoiatama	ei oleks hoiatanudp	V;ACT;PRS;PRF;NEG;COND
+hoiatama	ei oleks hoiatanud	V;ACT;PRS;PRF;NEG;COND
 hoiatama	oleksid hoiatanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hoiatama	hoiatasite	V;ACT;PST;POS;IND;2;PL
 hoiatama	oleks hoiatanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hoiatama	olin hoiatanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hoiatama	oled hoiatanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hoiatama	oli hoiatanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hoiatama	ei ole hoiatatudp	V;PASS;PRS;PRF;NEG;IND
+hoiatama	ei ole hoiatatud	V;PASS;PRS;PRF;NEG;IND
 hoiatama	hoiataksin	V;ACT;PRS;POS;COND;1;SG
 hoiatama	olen hoiatanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hoiatama	ei olnud hoiatatudp	V;PASS;PST;PRF;NEG;IND
+hoiatama	ei olnud hoiatatud	V;PASS;PST;PRF;NEG;IND
 hoiatama	ärgu olgu hoiatatud	V;PASS;PRS;PRF;NEG;IMP
 
 hoidja	hoidjani	N;TERM;SG
@@ -1441,7 +1441,7 @@ hoidja	hoidjatesse	N;IN+ALL;PL
 hoidja	hoidjatelt	N;AT+ABL;PL
 
 hoidma	olete hoidnud	V;ACT;PRS;PRF;POS;IND;2;PL
-hoidma	ei olevat hoidnudp	V;ACT;PRS;PRF;NEG;QUOT
+hoidma	ei olevat hoidnud	V;ACT;PRS;PRF;NEG;QUOT
 hoidma	oleks hoietud	V;PASS;PRS;PRF;POS;COND
 hoidma	hoidsin	V;ACT;PST;POS;IND;1;SG
 hoidma	hoietakse	V;PASS;PRS;POS;IND
@@ -1450,7 +1450,7 @@ hoidma	hoietagu	V;PASS;PRS;POS;IMP
 hoidma	ärgu hoidku	V;ACT;PRS;NEG;IMP;3;SG
 hoidma	oli hoietud	V;PASS;PST;PRF;POS;IND
 hoidma	hoidsime	V;ACT;PST;POS;IND;1;PL
-hoidma	ei olnud hoidnudp	V;ACT;PST;PRF;NEG;IND
+hoidma	ei olnud hoidnud	V;ACT;PST;PRF;NEG;IND
 hoidma	oleksid hoidnud	V;ACT;PRS;PRF;POS;COND;2;SG
 hoidma	olgu hoidnud	V;ACT;PRS;PRF;POS;IMP;PL
 hoidma	oli hoidnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1464,9 +1464,9 @@ hoidma	ärgu hoidku	V;ACT;PRS;NEG;IMP;3;PL
 hoidma	olgu hoidnud	V;ACT;PRS;PRF;POS;IMP;SG
 hoidma	hoieti	V;PASS;PST;POS;IND
 hoidma	ei hoidvat	V;ACT;PRS;NEG;QUOT
-hoidma	ei oleks hoietudp	V;PASS;PRS;PRF;NEG;COND
+hoidma	ei oleks hoietud	V;PASS;PRS;PRF;NEG;COND
 hoidma	ei hoidnud	V;ACT;PST;NEG;IND
-hoidma	ei olevat hoietudp	V;PASS;PRS;PRF;NEG;QUOT
+hoidma	ei olevat hoietud	V;PASS;PRS;PRF;NEG;QUOT
 hoidma	ei hoiaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hoidma	hoietud	V.PTCP;PASS;PST
 hoidma	olid hoidnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1485,7 +1485,7 @@ hoidma	olgu hoietud	V;PASS;PRS;PRF;POS;IMP
 hoidma	hoiaks	V;ACT;PRS;POS;COND;3;SG
 hoidma	hoidku	V;ACT;PRS;POS;IMP;3;PL
 hoidma	ärgu olgu hoidnud	V;ACT;PRS;PRF;NEG;IMP;SG
-hoidma	ei ole hoidnudp	V;ACT;PST;NEG;IND
+hoidma	ei ole hoidnud	V;ACT;PST;NEG;IND
 hoidma	hoiad	V;ACT;PRS;POS;IND;2;SG
 hoidma	ära hoia	V;ACT;PRS;NEG;IMP;2;SG
 hoidma	ei hoia	V;ACT;PRS;NEG;IND
@@ -1513,21 +1513,21 @@ hoidma	ei hoieta	V;PASS;PRS;NEG;IND
 hoidma	hoiame	V;ACT;PRS;POS;IND;1;PL
 hoidma	hoian	V;ACT;PRS;POS;IND;1;SG
 hoidma	ärgem hoidkem	V;ACT;PRS;NEG;IMP;1;PL
-hoidma	ei oleks hoidnudp	V;ACT;PRS;PRF;NEG;COND
+hoidma	ei oleks hoidnud	V;ACT;PRS;PRF;NEG;COND
 hoidma	oleksid hoidnud	V;ACT;PRS;PRF;POS;COND;3;PL
 hoidma	hoidsite	V;ACT;PST;POS;IND;2;PL
 hoidma	oleks hoidnud	V;ACT;PRS;PRF;POS;COND;3;SG
 hoidma	olin hoidnud	V;ACT;PRS;PRF;POS;COND;1;SG
 hoidma	oled hoidnud	V;ACT;PRS;PRF;POS;IND;2;SG
 hoidma	oli hoidnud	V;ACT;PRS;PRF;POS;COND;3;SG
-hoidma	ei ole hoietudp	V;PASS;PRS;PRF;NEG;IND
+hoidma	ei ole hoietud	V;PASS;PRS;PRF;NEG;IND
 hoidma	hoiaksin	V;ACT;PRS;POS;COND;1;SG
 hoidma	olen hoidnud	V;ACT;PRS;PRF;POS;IND;1;SG
-hoidma	ei olnud hoietudp	V;PASS;PST;PRF;NEG;IND
+hoidma	ei olnud hoietud	V;PASS;PST;PRF;NEG;IND
 hoidma	ärgu olgu hoietud	V;PASS;PRS;PRF;NEG;IMP
 
 hoiduma	olete hoidunud	V;ACT;PRS;PRF;POS;IND;2;PL
-hoiduma	ei olevat hoidunudp	V;ACT;PRS;PRF;NEG;QUOT
+hoiduma	ei olevat hoidunud	V;ACT;PRS;PRF;NEG;QUOT
 hoiduma	oleks hoidutud	V;PASS;PRS;PRF;POS;COND
 hoiduma	hoidusin	V;ACT;PST;POS;IND;1;SG
 hoiduma	hoidutakse	V;PASS;PRS;POS;IND
@@ -1536,7 +1536,7 @@ hoiduma	hoidutagu	V;PASS;PRS;POS;IMP
 hoiduma	ärgu hoidugu	V;ACT;PRS;NEG;IMP;3;SG
 hoiduma	oli hoidutud	V;PASS;PST;PRF;POS;IND
 hoiduma	hoidusime	V;ACT;PST;POS;IND;1;PL
-hoiduma	ei olnud hoidunudp	V;ACT;PST;PRF;NEG;IND
+hoiduma	ei olnud hoidunud	V;ACT;PST;PRF;NEG;IND
 hoiduma	oleksid hoidunud	V;ACT;PRS;PRF;POS;COND;2;SG
 hoiduma	olgu hoidunud	V;ACT;PRS;PRF;POS;IMP;PL
 hoiduma	oli hoidunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1550,9 +1550,9 @@ hoiduma	ärgu hoidugu	V;ACT;PRS;NEG;IMP;3;PL
 hoiduma	olgu hoidunud	V;ACT;PRS;PRF;POS;IMP;SG
 hoiduma	hoiduti	V;PASS;PST;POS;IND
 hoiduma	ei hoiduvat	V;ACT;PRS;NEG;QUOT
-hoiduma	ei oleks hoidutudp	V;PASS;PRS;PRF;NEG;COND
+hoiduma	ei oleks hoidutud	V;PASS;PRS;PRF;NEG;COND
 hoiduma	ei hoidunud	V;ACT;PST;NEG;IND
-hoiduma	ei olevat hoidutudp	V;PASS;PRS;PRF;NEG;QUOT
+hoiduma	ei olevat hoidutud	V;PASS;PRS;PRF;NEG;QUOT
 hoiduma	ei hoiduks	V;ACT;PRS;PRF;POS;COND;1;SG
 hoiduma	hoidutud	V.PTCP;PASS;PST
 hoiduma	olid hoidunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1571,7 +1571,7 @@ hoiduma	olgu hoidutud	V;PASS;PRS;PRF;POS;IMP
 hoiduma	hoiduks	V;ACT;PRS;POS;COND;3;SG
 hoiduma	hoidugu	V;ACT;PRS;POS;IMP;3;PL
 hoiduma	ärgu olgu hoidunud	V;ACT;PRS;PRF;NEG;IMP;SG
-hoiduma	ei ole hoidunudp	V;ACT;PST;NEG;IND
+hoiduma	ei ole hoidunud	V;ACT;PST;NEG;IND
 hoiduma	hoidud	V;ACT;PRS;POS;IND;2;SG
 hoiduma	ära hoidu	V;ACT;PRS;NEG;IMP;2;SG
 hoiduma	ei hoidu	V;ACT;PRS;NEG;IND
@@ -1599,17 +1599,17 @@ hoiduma	ei hoiduta	V;PASS;PRS;NEG;IND
 hoiduma	hoidume	V;ACT;PRS;POS;IND;1;PL
 hoiduma	hoidun	V;ACT;PRS;POS;IND;1;SG
 hoiduma	ärgem hoidugem	V;ACT;PRS;NEG;IMP;1;PL
-hoiduma	ei oleks hoidunudp	V;ACT;PRS;PRF;NEG;COND
+hoiduma	ei oleks hoidunud	V;ACT;PRS;PRF;NEG;COND
 hoiduma	oleksid hoidunud	V;ACT;PRS;PRF;POS;COND;3;PL
 hoiduma	hoidusite	V;ACT;PST;POS;IND;2;PL
 hoiduma	oleks hoidunud	V;ACT;PRS;PRF;POS;COND;3;SG
 hoiduma	olin hoidunud	V;ACT;PRS;PRF;POS;COND;1;SG
 hoiduma	oled hoidunud	V;ACT;PRS;PRF;POS;IND;2;SG
 hoiduma	oli hoidunud	V;ACT;PRS;PRF;POS;COND;3;SG
-hoiduma	ei ole hoidutudp	V;PASS;PRS;PRF;NEG;IND
+hoiduma	ei ole hoidutud	V;PASS;PRS;PRF;NEG;IND
 hoiduma	hoiduksin	V;ACT;PRS;POS;COND;1;SG
 hoiduma	olen hoidunud	V;ACT;PRS;PRF;POS;IND;1;SG
-hoiduma	ei olnud hoidutudp	V;PASS;PST;PRF;NEG;IND
+hoiduma	ei olnud hoidutud	V;PASS;PST;PRF;NEG;IND
 hoiduma	ärgu olgu hoidutud	V;PASS;PRS;PRF;NEG;IMP
 
 holmium	holmiumini	N;TERM;SG
@@ -1675,7 +1675,7 @@ hommik	hommikutesse	N;IN+ALL;PL
 hommik	hommikutelt	N;AT+ABL;PL
 
 hukkama	olete hukanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hukkama	ei olevat hukanudp	V;ACT;PRS;PRF;NEG;QUOT
+hukkama	ei olevat hukanud	V;ACT;PRS;PRF;NEG;QUOT
 hukkama	oleks hukatud	V;PASS;PRS;PRF;POS;COND
 hukkama	hukkasin	V;ACT;PST;POS;IND;1;SG
 hukkama	hukatakse	V;PASS;PRS;POS;IND
@@ -1684,7 +1684,7 @@ hukkama	hukatagu	V;PASS;PRS;POS;IMP
 hukkama	ärgu hukaku	V;ACT;PRS;NEG;IMP;3;SG
 hukkama	oli hukatud	V;PASS;PST;PRF;POS;IND
 hukkama	hukkasime	V;ACT;PST;POS;IND;1;PL
-hukkama	ei olnud hukanudp	V;ACT;PST;PRF;NEG;IND
+hukkama	ei olnud hukanud	V;ACT;PST;PRF;NEG;IND
 hukkama	oleksid hukanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hukkama	olgu hukanud	V;ACT;PRS;PRF;POS;IMP;PL
 hukkama	oli hukanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1698,9 +1698,9 @@ hukkama	ärgu hukaku	V;ACT;PRS;NEG;IMP;3;PL
 hukkama	olgu hukanud	V;ACT;PRS;PRF;POS;IMP;SG
 hukkama	hukati	V;PASS;PST;POS;IND
 hukkama	ei hukkavat	V;ACT;PRS;NEG;QUOT
-hukkama	ei oleks hukatudp	V;PASS;PRS;PRF;NEG;COND
+hukkama	ei oleks hukatud	V;PASS;PRS;PRF;NEG;COND
 hukkama	ei hukanud	V;ACT;PST;NEG;IND
-hukkama	ei olevat hukatudp	V;PASS;PRS;PRF;NEG;QUOT
+hukkama	ei olevat hukatud	V;PASS;PRS;PRF;NEG;QUOT
 hukkama	ei hukkaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hukkama	hukatud	V.PTCP;PASS;PST
 hukkama	olid hukanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1719,7 +1719,7 @@ hukkama	olgu hukatud	V;PASS;PRS;PRF;POS;IMP
 hukkama	hukkaks	V;ACT;PRS;POS;COND;3;SG
 hukkama	hukaku	V;ACT;PRS;POS;IMP;3;PL
 hukkama	ärgu olgu hukanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hukkama	ei ole hukanudp	V;ACT;PST;NEG;IND
+hukkama	ei ole hukanud	V;ACT;PST;NEG;IND
 hukkama	hukkad	V;ACT;PRS;POS;IND;2;SG
 hukkama	ära hukka	V;ACT;PRS;NEG;IMP;2;SG
 hukkama	ei hukka	V;ACT;PRS;NEG;IND
@@ -1747,21 +1747,21 @@ hukkama	ei hukata	V;PASS;PRS;NEG;IND
 hukkama	hukkame	V;ACT;PRS;POS;IND;1;PL
 hukkama	hukkan	V;ACT;PRS;POS;IND;1;SG
 hukkama	ärgem hukakem	V;ACT;PRS;NEG;IMP;1;PL
-hukkama	ei oleks hukanudp	V;ACT;PRS;PRF;NEG;COND
+hukkama	ei oleks hukanud	V;ACT;PRS;PRF;NEG;COND
 hukkama	oleksid hukanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hukkama	hukkasite	V;ACT;PST;POS;IND;2;PL
 hukkama	oleks hukanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hukkama	olin hukanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hukkama	oled hukanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hukkama	oli hukanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hukkama	ei ole hukatudp	V;PASS;PRS;PRF;NEG;IND
+hukkama	ei ole hukatud	V;PASS;PRS;PRF;NEG;IND
 hukkama	hukkaksin	V;ACT;PRS;POS;COND;1;SG
 hukkama	olen hukanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hukkama	ei olnud hukatudp	V;PASS;PST;PRF;NEG;IND
+hukkama	ei olnud hukatud	V;PASS;PST;PRF;NEG;IND
 hukkama	ärgu olgu hukatud	V;PASS;PRS;PRF;NEG;IMP
 
 häirima	olete häirinud	V;ACT;PRS;PRF;POS;IND;2;PL
-häirima	ei olevat häirinudp	V;ACT;PRS;PRF;NEG;QUOT
+häirima	ei olevat häirinud	V;ACT;PRS;PRF;NEG;QUOT
 häirima	oleks häiritud	V;PASS;PRS;PRF;POS;COND
 häirima	häirisin	V;ACT;PST;POS;IND;1;SG
 häirima	häiritakse	V;PASS;PRS;POS;IND
@@ -1770,7 +1770,7 @@ häirima	häiritagu	V;PASS;PRS;POS;IMP
 häirima	ärgu häirigu	V;ACT;PRS;NEG;IMP;3;SG
 häirima	oli häiritud	V;PASS;PST;PRF;POS;IND
 häirima	häirisime	V;ACT;PST;POS;IND;1;PL
-häirima	ei olnud häirinudp	V;ACT;PST;PRF;NEG;IND
+häirima	ei olnud häirinud	V;ACT;PST;PRF;NEG;IND
 häirima	oleksid häirinud	V;ACT;PRS;PRF;POS;COND;2;SG
 häirima	olgu häirinud	V;ACT;PRS;PRF;POS;IMP;PL
 häirima	oli häirinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1784,9 +1784,9 @@ häirima	ärgu häirigu	V;ACT;PRS;NEG;IMP;3;PL
 häirima	olgu häirinud	V;ACT;PRS;PRF;POS;IMP;SG
 häirima	häiriti	V;PASS;PST;POS;IND
 häirima	ei häirivat	V;ACT;PRS;NEG;QUOT
-häirima	ei oleks häiritudp	V;PASS;PRS;PRF;NEG;COND
+häirima	ei oleks häiritud	V;PASS;PRS;PRF;NEG;COND
 häirima	ei häirinud	V;ACT;PST;NEG;IND
-häirima	ei olevat häiritudp	V;PASS;PRS;PRF;NEG;QUOT
+häirima	ei olevat häiritud	V;PASS;PRS;PRF;NEG;QUOT
 häirima	ei häiriks	V;ACT;PRS;PRF;POS;COND;1;SG
 häirima	häiritud	V.PTCP;PASS;PST
 häirima	olid häirinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1805,7 +1805,7 @@ häirima	olgu häiritud	V;PASS;PRS;PRF;POS;IMP
 häirima	häiriks	V;ACT;PRS;POS;COND;3;SG
 häirima	häirigu	V;ACT;PRS;POS;IMP;3;PL
 häirima	ärgu olgu häirinud	V;ACT;PRS;PRF;NEG;IMP;SG
-häirima	ei ole häirinudp	V;ACT;PST;NEG;IND
+häirima	ei ole häirinud	V;ACT;PST;NEG;IND
 häirima	häirid	V;ACT;PRS;POS;IND;2;SG
 häirima	ära häiri	V;ACT;PRS;NEG;IMP;2;SG
 häirima	ei häiri	V;ACT;PRS;NEG;IND
@@ -1833,21 +1833,21 @@ häirima	ei häirita	V;PASS;PRS;NEG;IND
 häirima	häirime	V;ACT;PRS;POS;IND;1;PL
 häirima	häirin	V;ACT;PRS;POS;IND;1;SG
 häirima	ärgem häirigem	V;ACT;PRS;NEG;IMP;1;PL
-häirima	ei oleks häirinudp	V;ACT;PRS;PRF;NEG;COND
+häirima	ei oleks häirinud	V;ACT;PRS;PRF;NEG;COND
 häirima	oleksid häirinud	V;ACT;PRS;PRF;POS;COND;3;PL
 häirima	häirisite	V;ACT;PST;POS;IND;2;PL
 häirima	oleks häirinud	V;ACT;PRS;PRF;POS;COND;3;SG
 häirima	olin häirinud	V;ACT;PRS;PRF;POS;COND;1;SG
 häirima	oled häirinud	V;ACT;PRS;PRF;POS;IND;2;SG
 häirima	oli häirinud	V;ACT;PRS;PRF;POS;COND;3;SG
-häirima	ei ole häiritudp	V;PASS;PRS;PRF;NEG;IND
+häirima	ei ole häiritud	V;PASS;PRS;PRF;NEG;IND
 häirima	häiriksin	V;ACT;PRS;POS;COND;1;SG
 häirima	olen häirinud	V;ACT;PRS;PRF;POS;IND;1;SG
-häirima	ei olnud häiritudp	V;PASS;PST;PRF;NEG;IND
+häirima	ei olnud häiritud	V;PASS;PST;PRF;NEG;IND
 häirima	ärgu olgu häiritud	V;PASS;PRS;PRF;NEG;IMP
 
 hääletama	olete hääletanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hääletama	ei olevat hääletanudp	V;ACT;PRS;PRF;NEG;QUOT
+hääletama	ei olevat hääletanud	V;ACT;PRS;PRF;NEG;QUOT
 hääletama	oleks hääletatud	V;PASS;PRS;PRF;POS;COND
 hääletama	hääletasin	V;ACT;PST;POS;IND;1;SG
 hääletama	hääletatakse	V;PASS;PRS;POS;IND
@@ -1856,7 +1856,7 @@ hääletama	hääletatagu	V;PASS;PRS;POS;IMP
 hääletama	ärgu hääletagu	V;ACT;PRS;NEG;IMP;3;SG
 hääletama	oli hääletatud	V;PASS;PST;PRF;POS;IND
 hääletama	hääletasime	V;ACT;PST;POS;IND;1;PL
-hääletama	ei olnud hääletanudp	V;ACT;PST;PRF;NEG;IND
+hääletama	ei olnud hääletanud	V;ACT;PST;PRF;NEG;IND
 hääletama	oleksid hääletanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hääletama	olgu hääletanud	V;ACT;PRS;PRF;POS;IMP;PL
 hääletama	oli hääletanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -1870,9 +1870,9 @@ hääletama	ärgu hääletagu	V;ACT;PRS;NEG;IMP;3;PL
 hääletama	olgu hääletanud	V;ACT;PRS;PRF;POS;IMP;SG
 hääletama	hääletati	V;PASS;PST;POS;IND
 hääletama	ei hääletavat	V;ACT;PRS;NEG;QUOT
-hääletama	ei oleks hääletatudp	V;PASS;PRS;PRF;NEG;COND
+hääletama	ei oleks hääletatud	V;PASS;PRS;PRF;NEG;COND
 hääletama	ei hääletanud	V;ACT;PST;NEG;IND
-hääletama	ei olevat hääletatudp	V;PASS;PRS;PRF;NEG;QUOT
+hääletama	ei olevat hääletatud	V;PASS;PRS;PRF;NEG;QUOT
 hääletama	ei hääletaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hääletama	hääletatud	V.PTCP;PASS;PST
 hääletama	olid hääletanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -1891,7 +1891,7 @@ hääletama	olgu hääletatud	V;PASS;PRS;PRF;POS;IMP
 hääletama	hääletaks	V;ACT;PRS;POS;COND;3;SG
 hääletama	hääletagu	V;ACT;PRS;POS;IMP;3;PL
 hääletama	ärgu olgu hääletanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hääletama	ei ole hääletanudp	V;ACT;PST;NEG;IND
+hääletama	ei ole hääletanud	V;ACT;PST;NEG;IND
 hääletama	hääletad	V;ACT;PRS;POS;IND;2;SG
 hääletama	ära hääleta	V;ACT;PRS;NEG;IMP;2;SG
 hääletama	ei hääleta	V;ACT;PRS;NEG;IND
@@ -1919,17 +1919,17 @@ hääletama	ei hääletata	V;PASS;PRS;NEG;IND
 hääletama	hääletame	V;ACT;PRS;POS;IND;1;PL
 hääletama	hääletan	V;ACT;PRS;POS;IND;1;SG
 hääletama	ärgem hääletagem	V;ACT;PRS;NEG;IMP;1;PL
-hääletama	ei oleks hääletanudp	V;ACT;PRS;PRF;NEG;COND
+hääletama	ei oleks hääletanud	V;ACT;PRS;PRF;NEG;COND
 hääletama	oleksid hääletanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hääletama	hääletasite	V;ACT;PST;POS;IND;2;PL
 hääletama	oleks hääletanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hääletama	olin hääletanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hääletama	oled hääletanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hääletama	oli hääletanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hääletama	ei ole hääletatudp	V;PASS;PRS;PRF;NEG;IND
+hääletama	ei ole hääletatud	V;PASS;PRS;PRF;NEG;IND
 hääletama	hääletaksin	V;ACT;PRS;POS;COND;1;SG
 hääletama	olen hääletanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hääletama	ei olnud hääletatudp	V;PASS;PST;PRF;NEG;IND
+hääletama	ei olnud hääletatud	V;PASS;PST;PRF;NEG;IND
 hääletama	ärgu olgu hääletatud	V;PASS;PRS;PRF;NEG;IMP
 
 hõbe	hõbedani	N;TERM;SG
@@ -2026,7 +2026,7 @@ hõberebane	hõberebastesse	N;IN+ALL;PL
 hõberebane	hõberebastelt	N;AT+ABL;PL
 
 hõivama	olete hõivanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hõivama	ei olevat hõivanudp	V;ACT;PRS;PRF;NEG;QUOT
+hõivama	ei olevat hõivanud	V;ACT;PRS;PRF;NEG;QUOT
 hõivama	oleks hõivatud	V;PASS;PRS;PRF;POS;COND
 hõivama	hõivasin	V;ACT;PST;POS;IND;1;SG
 hõivama	hõivatakse	V;PASS;PRS;POS;IND
@@ -2035,7 +2035,7 @@ hõivama	hõivatagu	V;PASS;PRS;POS;IMP
 hõivama	ärgu hõivaku	V;ACT;PRS;NEG;IMP;3;SG
 hõivama	oli hõivatud	V;PASS;PST;PRF;POS;IND
 hõivama	hõivasime	V;ACT;PST;POS;IND;1;PL
-hõivama	ei olnud hõivanudp	V;ACT;PST;PRF;NEG;IND
+hõivama	ei olnud hõivanud	V;ACT;PST;PRF;NEG;IND
 hõivama	oleksid hõivanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hõivama	olgu hõivanud	V;ACT;PRS;PRF;POS;IMP;PL
 hõivama	oli hõivanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -2049,9 +2049,9 @@ hõivama	ärgu hõivaku	V;ACT;PRS;NEG;IMP;3;PL
 hõivama	olgu hõivanud	V;ACT;PRS;PRF;POS;IMP;SG
 hõivama	hõivati	V;PASS;PST;POS;IND
 hõivama	ei hõivavat	V;ACT;PRS;NEG;QUOT
-hõivama	ei oleks hõivatudp	V;PASS;PRS;PRF;NEG;COND
+hõivama	ei oleks hõivatud	V;PASS;PRS;PRF;NEG;COND
 hõivama	ei hõivanud	V;ACT;PST;NEG;IND
-hõivama	ei olevat hõivatudp	V;PASS;PRS;PRF;NEG;QUOT
+hõivama	ei olevat hõivatud	V;PASS;PRS;PRF;NEG;QUOT
 hõivama	ei hõivaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hõivama	hõivatud	V.PTCP;PASS;PST
 hõivama	olid hõivanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -2070,7 +2070,7 @@ hõivama	olgu hõivatud	V;PASS;PRS;PRF;POS;IMP
 hõivama	hõivaks	V;ACT;PRS;POS;COND;3;SG
 hõivama	hõivaku	V;ACT;PRS;POS;IMP;3;PL
 hõivama	ärgu olgu hõivanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hõivama	ei ole hõivanudp	V;ACT;PST;NEG;IND
+hõivama	ei ole hõivanud	V;ACT;PST;NEG;IND
 hõivama	hõivad	V;ACT;PRS;POS;IND;2;SG
 hõivama	ära hõiva	V;ACT;PRS;NEG;IMP;2;SG
 hõivama	ei hõiva	V;ACT;PRS;NEG;IND
@@ -2098,17 +2098,17 @@ hõivama	ei hõivata	V;PASS;PRS;NEG;IND
 hõivama	hõivame	V;ACT;PRS;POS;IND;1;PL
 hõivama	hõivan	V;ACT;PRS;POS;IND;1;SG
 hõivama	ärgem hõivakem	V;ACT;PRS;NEG;IMP;1;PL
-hõivama	ei oleks hõivanudp	V;ACT;PRS;PRF;NEG;COND
+hõivama	ei oleks hõivanud	V;ACT;PRS;PRF;NEG;COND
 hõivama	oleksid hõivanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hõivama	hõivasite	V;ACT;PST;POS;IND;2;PL
 hõivama	oleks hõivanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hõivama	olin hõivanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hõivama	oled hõivanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hõivama	oli hõivanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hõivama	ei ole hõivatudp	V;PASS;PRS;PRF;NEG;IND
+hõivama	ei ole hõivatud	V;PASS;PRS;PRF;NEG;IND
 hõivama	hõivaksin	V;ACT;PRS;POS;COND;1;SG
 hõivama	olen hõivanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hõivama	ei olnud hõivatudp	V;PASS;PST;PRF;NEG;IND
+hõivama	ei olnud hõivatud	V;PASS;PST;PRF;NEG;IND
 hõivama	ärgu olgu hõivatud	V;PASS;PRS;PRF;NEG;IMP
 
 hõlmkuu	hõlmkuuni	N;TERM;SG
@@ -2205,7 +2205,7 @@ höövel	höövlitesse	N;IN+ALL;PL
 höövel	höövlitelt	N;AT+ABL;PL
 
 hööveldama	olete hööveldanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hööveldama	ei olevat hööveldanudp	V;ACT;PRS;PRF;NEG;QUOT
+hööveldama	ei olevat hööveldanud	V;ACT;PRS;PRF;NEG;QUOT
 hööveldama	oleks hööveldatud	V;PASS;PRS;PRF;POS;COND
 hööveldama	hööveldasin	V;ACT;PST;POS;IND;1;SG
 hööveldama	hööveldatakse	V;PASS;PRS;POS;IND
@@ -2214,7 +2214,7 @@ hööveldama	hööveldatagu	V;PASS;PRS;POS;IMP
 hööveldama	ärgu hööveldagu	V;ACT;PRS;NEG;IMP;3;SG
 hööveldama	oli hööveldatud	V;PASS;PST;PRF;POS;IND
 hööveldama	hööveldasime	V;ACT;PST;POS;IND;1;PL
-hööveldama	ei olnud hööveldanudp	V;ACT;PST;PRF;NEG;IND
+hööveldama	ei olnud hööveldanud	V;ACT;PST;PRF;NEG;IND
 hööveldama	oleksid hööveldanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hööveldama	olgu hööveldanud	V;ACT;PRS;PRF;POS;IMP;PL
 hööveldama	oli hööveldanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -2228,9 +2228,9 @@ hööveldama	ärgu hööveldagu	V;ACT;PRS;NEG;IMP;3;PL
 hööveldama	olgu hööveldanud	V;ACT;PRS;PRF;POS;IMP;SG
 hööveldama	hööveldati	V;PASS;PST;POS;IND
 hööveldama	ei hööveldavat	V;ACT;PRS;NEG;QUOT
-hööveldama	ei oleks hööveldatudp	V;PASS;PRS;PRF;NEG;COND
+hööveldama	ei oleks hööveldatud	V;PASS;PRS;PRF;NEG;COND
 hööveldama	ei hööveldanud	V;ACT;PST;NEG;IND
-hööveldama	ei olevat hööveldatudp	V;PASS;PRS;PRF;NEG;QUOT
+hööveldama	ei olevat hööveldatud	V;PASS;PRS;PRF;NEG;QUOT
 hööveldama	ei hööveldaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hööveldama	hööveldatud	V.PTCP;PASS;PST
 hööveldama	olid hööveldanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -2249,7 +2249,7 @@ hööveldama	olgu hööveldatud	V;PASS;PRS;PRF;POS;IMP
 hööveldama	hööveldaks	V;ACT;PRS;POS;COND;3;SG
 hööveldama	hööveldagu	V;ACT;PRS;POS;IMP;3;PL
 hööveldama	ärgu olgu hööveldanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hööveldama	ei ole hööveldanudp	V;ACT;PST;NEG;IND
+hööveldama	ei ole hööveldanud	V;ACT;PST;NEG;IND
 hööveldama	hööveldad	V;ACT;PRS;POS;IND;2;SG
 hööveldama	ära höövelda	V;ACT;PRS;NEG;IMP;2;SG
 hööveldama	ei höövelda	V;ACT;PRS;NEG;IND
@@ -2277,21 +2277,21 @@ hööveldama	ei hööveldata	V;PASS;PRS;NEG;IND
 hööveldama	hööveldame	V;ACT;PRS;POS;IND;1;PL
 hööveldama	hööveldan	V;ACT;PRS;POS;IND;1;SG
 hööveldama	ärgem hööveldagem	V;ACT;PRS;NEG;IMP;1;PL
-hööveldama	ei oleks hööveldanudp	V;ACT;PRS;PRF;NEG;COND
+hööveldama	ei oleks hööveldanud	V;ACT;PRS;PRF;NEG;COND
 hööveldama	oleksid hööveldanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hööveldama	hööveldasite	V;ACT;PST;POS;IND;2;PL
 hööveldama	oleks hööveldanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hööveldama	olin hööveldanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hööveldama	oled hööveldanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hööveldama	oli hööveldanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hööveldama	ei ole hööveldatudp	V;PASS;PRS;PRF;NEG;IND
+hööveldama	ei ole hööveldatud	V;PASS;PRS;PRF;NEG;IND
 hööveldama	hööveldaksin	V;ACT;PRS;POS;COND;1;SG
 hööveldama	olen hööveldanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hööveldama	ei olnud hööveldatudp	V;PASS;PST;PRF;NEG;IND
+hööveldama	ei olnud hööveldatud	V;PASS;PST;PRF;NEG;IND
 hööveldama	ärgu olgu hööveldatud	V;PASS;PRS;PRF;NEG;IMP
 
 hüppama	olete hüpanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hüppama	ei olevat hüpanudp	V;ACT;PRS;PRF;NEG;QUOT
+hüppama	ei olevat hüpanud	V;ACT;PRS;PRF;NEG;QUOT
 hüppama	oleks hüpatud	V;PASS;PRS;PRF;POS;COND
 hüppama	hüppasin	V;ACT;PST;POS;IND;1;SG
 hüppama	hüpatakse	V;PASS;PRS;POS;IND
@@ -2300,7 +2300,7 @@ hüppama	hüpatagu	V;PASS;PRS;POS;IMP
 hüppama	ärgu hüpaku	V;ACT;PRS;NEG;IMP;3;SG
 hüppama	oli hüpatud	V;PASS;PST;PRF;POS;IND
 hüppama	hüppasime	V;ACT;PST;POS;IND;1;PL
-hüppama	ei olnud hüpanudp	V;ACT;PST;PRF;NEG;IND
+hüppama	ei olnud hüpanud	V;ACT;PST;PRF;NEG;IND
 hüppama	oleksid hüpanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hüppama	olgu hüpanud	V;ACT;PRS;PRF;POS;IMP;PL
 hüppama	oli hüpanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -2314,9 +2314,9 @@ hüppama	ärgu hüpaku	V;ACT;PRS;NEG;IMP;3;PL
 hüppama	olgu hüpanud	V;ACT;PRS;PRF;POS;IMP;SG
 hüppama	hüpati	V;PASS;PST;POS;IND
 hüppama	ei hüppavat	V;ACT;PRS;NEG;QUOT
-hüppama	ei oleks hüpatudp	V;PASS;PRS;PRF;NEG;COND
+hüppama	ei oleks hüpatud	V;PASS;PRS;PRF;NEG;COND
 hüppama	ei hüpanud	V;ACT;PST;NEG;IND
-hüppama	ei olevat hüpatudp	V;PASS;PRS;PRF;NEG;QUOT
+hüppama	ei olevat hüpatud	V;PASS;PRS;PRF;NEG;QUOT
 hüppama	ei hüppaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hüppama	hüpatud	V.PTCP;PASS;PST
 hüppama	olid hüpanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -2335,7 +2335,7 @@ hüppama	olgu hüpatud	V;PASS;PRS;PRF;POS;IMP
 hüppama	hüppaks	V;ACT;PRS;POS;COND;3;SG
 hüppama	hüpaku	V;ACT;PRS;POS;IMP;3;PL
 hüppama	ärgu olgu hüpanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hüppama	ei ole hüpanudp	V;ACT;PST;NEG;IND
+hüppama	ei ole hüpanud	V;ACT;PST;NEG;IND
 hüppama	hüppad	V;ACT;PRS;POS;IND;2;SG
 hüppama	ära hüppa	V;ACT;PRS;NEG;IMP;2;SG
 hüppama	ei hüppa	V;ACT;PRS;NEG;IND
@@ -2363,21 +2363,21 @@ hüppama	ei hüpata	V;PASS;PRS;NEG;IND
 hüppama	hüppame	V;ACT;PRS;POS;IND;1;PL
 hüppama	hüppan	V;ACT;PRS;POS;IND;1;SG
 hüppama	ärgem hüpakem	V;ACT;PRS;NEG;IMP;1;PL
-hüppama	ei oleks hüpanudp	V;ACT;PRS;PRF;NEG;COND
+hüppama	ei oleks hüpanud	V;ACT;PRS;PRF;NEG;COND
 hüppama	oleksid hüpanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hüppama	hüppasite	V;ACT;PST;POS;IND;2;PL
 hüppama	oleks hüpanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hüppama	olin hüpanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hüppama	oled hüpanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hüppama	oli hüpanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hüppama	ei ole hüpatudp	V;PASS;PRS;PRF;NEG;IND
+hüppama	ei ole hüpatud	V;PASS;PRS;PRF;NEG;IND
 hüppama	hüppaksin	V;ACT;PRS;POS;COND;1;SG
 hüppama	olen hüpanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hüppama	ei olnud hüpatudp	V;PASS;PST;PRF;NEG;IND
+hüppama	ei olnud hüpatud	V;PASS;PST;PRF;NEG;IND
 hüppama	ärgu olgu hüpatud	V;PASS;PRS;PRF;NEG;IMP
 
 hüvitama	olete hüvitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-hüvitama	ei olevat hüvitanudp	V;ACT;PRS;PRF;NEG;QUOT
+hüvitama	ei olevat hüvitanud	V;ACT;PRS;PRF;NEG;QUOT
 hüvitama	oleks hüvitatud	V;PASS;PRS;PRF;POS;COND
 hüvitama	hüvitasin	V;ACT;PST;POS;IND;1;SG
 hüvitama	hüvitatakse	V;PASS;PRS;POS;IND
@@ -2386,7 +2386,7 @@ hüvitama	hüvitatagu	V;PASS;PRS;POS;IMP
 hüvitama	ärgu hüvitagu	V;ACT;PRS;NEG;IMP;3;SG
 hüvitama	oli hüvitatud	V;PASS;PST;PRF;POS;IND
 hüvitama	hüvitasime	V;ACT;PST;POS;IND;1;PL
-hüvitama	ei olnud hüvitanudp	V;ACT;PST;PRF;NEG;IND
+hüvitama	ei olnud hüvitanud	V;ACT;PST;PRF;NEG;IND
 hüvitama	oleksid hüvitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 hüvitama	olgu hüvitanud	V;ACT;PRS;PRF;POS;IMP;PL
 hüvitama	oli hüvitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -2400,9 +2400,9 @@ hüvitama	ärgu hüvitagu	V;ACT;PRS;NEG;IMP;3;PL
 hüvitama	olgu hüvitanud	V;ACT;PRS;PRF;POS;IMP;SG
 hüvitama	hüvitati	V;PASS;PST;POS;IND
 hüvitama	ei hüvitavat	V;ACT;PRS;NEG;QUOT
-hüvitama	ei oleks hüvitatudp	V;PASS;PRS;PRF;NEG;COND
+hüvitama	ei oleks hüvitatud	V;PASS;PRS;PRF;NEG;COND
 hüvitama	ei hüvitanud	V;ACT;PST;NEG;IND
-hüvitama	ei olevat hüvitatudp	V;PASS;PRS;PRF;NEG;QUOT
+hüvitama	ei olevat hüvitatud	V;PASS;PRS;PRF;NEG;QUOT
 hüvitama	ei hüvitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hüvitama	hüvitatud	V.PTCP;PASS;PST
 hüvitama	olid hüvitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -2421,7 +2421,7 @@ hüvitama	olgu hüvitatud	V;PASS;PRS;PRF;POS;IMP
 hüvitama	hüvitaks	V;ACT;PRS;POS;COND;3;SG
 hüvitama	hüvitagu	V;ACT;PRS;POS;IMP;3;PL
 hüvitama	ärgu olgu hüvitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-hüvitama	ei ole hüvitanudp	V;ACT;PST;NEG;IND
+hüvitama	ei ole hüvitanud	V;ACT;PST;NEG;IND
 hüvitama	hüvitad	V;ACT;PRS;POS;IND;2;SG
 hüvitama	ära hüvita	V;ACT;PRS;NEG;IMP;2;SG
 hüvitama	ei hüvita	V;ACT;PRS;NEG;IND
@@ -2449,21 +2449,21 @@ hüvitama	ei hüvitata	V;PASS;PRS;NEG;IND
 hüvitama	hüvitame	V;ACT;PRS;POS;IND;1;PL
 hüvitama	hüvitan	V;ACT;PRS;POS;IND;1;SG
 hüvitama	ärgem hüvitagem	V;ACT;PRS;NEG;IMP;1;PL
-hüvitama	ei oleks hüvitanudp	V;ACT;PRS;PRF;NEG;COND
+hüvitama	ei oleks hüvitanud	V;ACT;PRS;PRF;NEG;COND
 hüvitama	oleksid hüvitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 hüvitama	hüvitasite	V;ACT;PST;POS;IND;2;PL
 hüvitama	oleks hüvitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 hüvitama	olin hüvitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 hüvitama	oled hüvitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 hüvitama	oli hüvitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-hüvitama	ei ole hüvitatudp	V;PASS;PRS;PRF;NEG;IND
+hüvitama	ei ole hüvitatud	V;PASS;PRS;PRF;NEG;IND
 hüvitama	hüvitaksin	V;ACT;PRS;POS;COND;1;SG
 hüvitama	olen hüvitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-hüvitama	ei olnud hüvitatudp	V;PASS;PST;PRF;NEG;IND
+hüvitama	ei olnud hüvitatud	V;PASS;PST;PRF;NEG;IND
 hüvitama	ärgu olgu hüvitatud	V;PASS;PRS;PRF;NEG;IMP
 
 hüüdma	olete hüüdnud	V;ACT;PRS;PRF;POS;IND;2;PL
-hüüdma	ei olevat hüüdnudp	V;ACT;PRS;PRF;NEG;QUOT
+hüüdma	ei olevat hüüdnud	V;ACT;PRS;PRF;NEG;QUOT
 hüüdma	oleks hüüetud	V;PASS;PRS;PRF;POS;COND
 hüüdma	hüüdsin	V;ACT;PST;POS;IND;1;SG
 hüüdma	hüüetakse	V;PASS;PRS;POS;IND
@@ -2472,7 +2472,7 @@ hüüdma	hüüetagu	V;PASS;PRS;POS;IMP
 hüüdma	ärgu hüüdku	V;ACT;PRS;NEG;IMP;3;SG
 hüüdma	oli hüüetud	V;PASS;PST;PRF;POS;IND
 hüüdma	hüüdsime	V;ACT;PST;POS;IND;1;PL
-hüüdma	ei olnud hüüdnudp	V;ACT;PST;PRF;NEG;IND
+hüüdma	ei olnud hüüdnud	V;ACT;PST;PRF;NEG;IND
 hüüdma	oleksid hüüdnud	V;ACT;PRS;PRF;POS;COND;2;SG
 hüüdma	olgu hüüdnud	V;ACT;PRS;PRF;POS;IMP;PL
 hüüdma	oli hüüdnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -2486,9 +2486,9 @@ hüüdma	ärgu hüüdku	V;ACT;PRS;NEG;IMP;3;PL
 hüüdma	olgu hüüdnud	V;ACT;PRS;PRF;POS;IMP;SG
 hüüdma	hüüeti	V;PASS;PST;POS;IND
 hüüdma	ei hüüdvat	V;ACT;PRS;NEG;QUOT
-hüüdma	ei oleks hüüetudp	V;PASS;PRS;PRF;NEG;COND
+hüüdma	ei oleks hüüetud	V;PASS;PRS;PRF;NEG;COND
 hüüdma	ei hüüdnud	V;ACT;PST;NEG;IND
-hüüdma	ei olevat hüüetudp	V;PASS;PRS;PRF;NEG;QUOT
+hüüdma	ei olevat hüüetud	V;PASS;PRS;PRF;NEG;QUOT
 hüüdma	ei hüüaks	V;ACT;PRS;PRF;POS;COND;1;SG
 hüüdma	hüüetud	V.PTCP;PASS;PST
 hüüdma	olid hüüdnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -2507,7 +2507,7 @@ hüüdma	olgu hüüetud	V;PASS;PRS;PRF;POS;IMP
 hüüdma	hüüaks	V;ACT;PRS;POS;COND;3;SG
 hüüdma	hüüdku	V;ACT;PRS;POS;IMP;3;PL
 hüüdma	ärgu olgu hüüdnud	V;ACT;PRS;PRF;NEG;IMP;SG
-hüüdma	ei ole hüüdnudp	V;ACT;PST;NEG;IND
+hüüdma	ei ole hüüdnud	V;ACT;PST;NEG;IND
 hüüdma	hüüad	V;ACT;PRS;POS;IND;2;SG
 hüüdma	ära hüüa	V;ACT;PRS;NEG;IMP;2;SG
 hüüdma	ei hüüa	V;ACT;PRS;NEG;IND
@@ -2535,17 +2535,17 @@ hüüdma	ei hüüeta	V;PASS;PRS;NEG;IND
 hüüdma	hüüame	V;ACT;PRS;POS;IND;1;PL
 hüüdma	hüüan	V;ACT;PRS;POS;IND;1;SG
 hüüdma	ärgem hüüdkem	V;ACT;PRS;NEG;IMP;1;PL
-hüüdma	ei oleks hüüdnudp	V;ACT;PRS;PRF;NEG;COND
+hüüdma	ei oleks hüüdnud	V;ACT;PRS;PRF;NEG;COND
 hüüdma	oleksid hüüdnud	V;ACT;PRS;PRF;POS;COND;3;PL
 hüüdma	hüüdsite	V;ACT;PST;POS;IND;2;PL
 hüüdma	oleks hüüdnud	V;ACT;PRS;PRF;POS;COND;3;SG
 hüüdma	olin hüüdnud	V;ACT;PRS;PRF;POS;COND;1;SG
 hüüdma	oled hüüdnud	V;ACT;PRS;PRF;POS;IND;2;SG
 hüüdma	oli hüüdnud	V;ACT;PRS;PRF;POS;COND;3;SG
-hüüdma	ei ole hüüetudp	V;PASS;PRS;PRF;NEG;IND
+hüüdma	ei ole hüüetud	V;PASS;PRS;PRF;NEG;IND
 hüüdma	hüüaksin	V;ACT;PRS;POS;COND;1;SG
 hüüdma	olen hüüdnud	V;ACT;PRS;PRF;POS;IND;1;SG
-hüüdma	ei olnud hüüetudp	V;PASS;PST;PRF;NEG;IND
+hüüdma	ei olnud hüüetud	V;PASS;PST;PRF;NEG;IND
 hüüdma	ärgu olgu hüüetud	V;PASS;PRS;PRF;NEG;IMP
 
 idee	ideeni	N;TERM;SG
@@ -2704,7 +2704,7 @@ ilves	ilvestesse	N;IN+ALL;PL
 ilves	ilvestelt	N;AT+ABL;PL
 
 imema	olete imenud	V;ACT;PRS;PRF;POS;IND;2;PL
-imema	ei olevat imenudp	V;ACT;PRS;PRF;NEG;QUOT
+imema	ei olevat imenud	V;ACT;PRS;PRF;NEG;QUOT
 imema	oleks imetud	V;PASS;PRS;PRF;POS;COND
 imema	imesin	V;ACT;PST;POS;IND;1;SG
 imema	imetakse	V;PASS;PRS;POS;IND
@@ -2713,7 +2713,7 @@ imema	imetagu	V;PASS;PRS;POS;IMP
 imema	ärgu imegu	V;ACT;PRS;NEG;IMP;3;SG
 imema	oli imetud	V;PASS;PST;PRF;POS;IND
 imema	imes	V;ACT;PST;POS;IND;1;PL
-imema	ei olnud imenudp	V;ACT;PST;PRF;NEG;IND
+imema	ei olnud imenud	V;ACT;PST;PRF;NEG;IND
 imema	oleksid imenud	V;ACT;PRS;PRF;POS;COND;2;SG
 imema	olgu imenud	V;ACT;PRS;PRF;POS;IMP;PL
 imema	oli imenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -2727,9 +2727,9 @@ imema	ärgu imegu	V;ACT;PRS;NEG;IMP;3;PL
 imema	olgu imenud	V;ACT;PRS;PRF;POS;IMP;SG
 imema	imeti	V;PASS;PST;POS;IND
 imema	ei imevat	V;ACT;PRS;NEG;QUOT
-imema	ei oleks imetudp	V;PASS;PRS;PRF;NEG;COND
+imema	ei oleks imetud	V;PASS;PRS;PRF;NEG;COND
 imema	ei imenud	V;ACT;PST;NEG;IND
-imema	ei olevat imetudp	V;PASS;PRS;PRF;NEG;QUOT
+imema	ei olevat imetud	V;PASS;PRS;PRF;NEG;QUOT
 imema	ei imeks	V;ACT;PRS;PRF;POS;COND;1;SG
 imema	imetud	V.PTCP;PASS;PST
 imema	olid imenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -2748,7 +2748,7 @@ imema	olgu imetud	V;PASS;PRS;PRF;POS;IMP
 imema	imeks	V;ACT;PRS;POS;COND;3;SG
 imema	imegu	V;ACT;PRS;POS;IMP;3;PL
 imema	ärgu olgu imenud	V;ACT;PRS;PRF;NEG;IMP;SG
-imema	ei ole imenudp	V;ACT;PST;NEG;IND
+imema	ei ole imenud	V;ACT;PST;NEG;IND
 imema	imed	V;ACT;PRS;POS;IND;2;SG
 imema	ära ime	V;ACT;PRS;NEG;IMP;2;SG
 imema	ei ime	V;ACT;PRS;NEG;IND
@@ -2776,17 +2776,17 @@ imema	ei imeta	V;PASS;PRS;NEG;IND
 imema	imeme	V;ACT;PRS;POS;IND;1;PL
 imema	imen	V;ACT;PRS;POS;IND;1;SG
 imema	ärgem imegem	V;ACT;PRS;NEG;IMP;1;PL
-imema	ei oleks imenudp	V;ACT;PRS;PRF;NEG;COND
+imema	ei oleks imenud	V;ACT;PRS;PRF;NEG;COND
 imema	oleksid imenud	V;ACT;PRS;PRF;POS;COND;3;PL
 imema	imesite	V;ACT;PST;POS;IND;2;PL
 imema	oleks imenud	V;ACT;PRS;PRF;POS;COND;3;SG
 imema	olin imenud	V;ACT;PRS;PRF;POS;COND;1;SG
 imema	oled imenud	V;ACT;PRS;PRF;POS;IND;2;SG
 imema	oli imenud	V;ACT;PRS;PRF;POS;COND;3;SG
-imema	ei ole imetudp	V;PASS;PRS;PRF;NEG;IND
+imema	ei ole imetud	V;PASS;PRS;PRF;NEG;IND
 imema	imeksin	V;ACT;PRS;POS;COND;1;SG
 imema	olen imenud	V;ACT;PRS;PRF;POS;IND;1;SG
-imema	ei olnud imetudp	V;PASS;PST;PRF;NEG;IND
+imema	ei olnud imetud	V;PASS;PST;PRF;NEG;IND
 imema	ärgu olgu imetud	V;PASS;PRS;PRF;NEG;IMP
 
 imetaja	imetajani	N;TERM;SG
@@ -2821,7 +2821,7 @@ imetaja	imetajatesse	N;IN+ALL;PL
 imetaja	imetajatelt	N;AT+ABL;PL
 
 imetama	olete imetanud	V;ACT;PRS;PRF;POS;IND;2;PL
-imetama	ei olevat imetanudp	V;ACT;PRS;PRF;NEG;QUOT
+imetama	ei olevat imetanud	V;ACT;PRS;PRF;NEG;QUOT
 imetama	oleks imetatud	V;PASS;PRS;PRF;POS;COND
 imetama	imetasin	V;ACT;PST;POS;IND;1;SG
 imetama	imetatakse	V;PASS;PRS;POS;IND
@@ -2830,7 +2830,7 @@ imetama	imetatagu	V;PASS;PRS;POS;IMP
 imetama	ärgu imetagu	V;ACT;PRS;NEG;IMP;3;SG
 imetama	oli imetatud	V;PASS;PST;PRF;POS;IND
 imetama	imetasime	V;ACT;PST;POS;IND;1;PL
-imetama	ei olnud imetanudp	V;ACT;PST;PRF;NEG;IND
+imetama	ei olnud imetanud	V;ACT;PST;PRF;NEG;IND
 imetama	oleksid imetanud	V;ACT;PRS;PRF;POS;COND;2;SG
 imetama	olgu imetanud	V;ACT;PRS;PRF;POS;IMP;PL
 imetama	oli imetanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -2844,9 +2844,9 @@ imetama	ärgu imetagu	V;ACT;PRS;NEG;IMP;3;PL
 imetama	olgu imetanud	V;ACT;PRS;PRF;POS;IMP;SG
 imetama	imetati	V;PASS;PST;POS;IND
 imetama	ei imetavat	V;ACT;PRS;NEG;QUOT
-imetama	ei oleks imetatudp	V;PASS;PRS;PRF;NEG;COND
+imetama	ei oleks imetatud	V;PASS;PRS;PRF;NEG;COND
 imetama	ei imetanud	V;ACT;PST;NEG;IND
-imetama	ei olevat imetatudp	V;PASS;PRS;PRF;NEG;QUOT
+imetama	ei olevat imetatud	V;PASS;PRS;PRF;NEG;QUOT
 imetama	ei imetaks	V;ACT;PRS;PRF;POS;COND;1;SG
 imetama	imetatud	V.PTCP;PASS;PST
 imetama	olid imetanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -2865,7 +2865,7 @@ imetama	olgu imetatud	V;PASS;PRS;PRF;POS;IMP
 imetama	imetaks	V;ACT;PRS;POS;COND;3;SG
 imetama	imetagu	V;ACT;PRS;POS;IMP;3;PL
 imetama	ärgu olgu imetanud	V;ACT;PRS;PRF;NEG;IMP;SG
-imetama	ei ole imetanudp	V;ACT;PST;NEG;IND
+imetama	ei ole imetanud	V;ACT;PST;NEG;IND
 imetama	imetad	V;ACT;PRS;POS;IND;2;SG
 imetama	ära imeta	V;ACT;PRS;NEG;IMP;2;SG
 imetama	ei imeta	V;ACT;PRS;NEG;IND
@@ -2893,17 +2893,17 @@ imetama	ei imetata	V;PASS;PRS;NEG;IND
 imetama	imetame	V;ACT;PRS;POS;IND;1;PL
 imetama	imetan	V;ACT;PRS;POS;IND;1;SG
 imetama	ärgem imetagem	V;ACT;PRS;NEG;IMP;1;PL
-imetama	ei oleks imetanudp	V;ACT;PRS;PRF;NEG;COND
+imetama	ei oleks imetanud	V;ACT;PRS;PRF;NEG;COND
 imetama	oleksid imetanud	V;ACT;PRS;PRF;POS;COND;3;PL
 imetama	imetasite	V;ACT;PST;POS;IND;2;PL
 imetama	oleks imetanud	V;ACT;PRS;PRF;POS;COND;3;SG
 imetama	olin imetanud	V;ACT;PRS;PRF;POS;COND;1;SG
 imetama	oled imetanud	V;ACT;PRS;PRF;POS;IND;2;SG
 imetama	oli imetanud	V;ACT;PRS;PRF;POS;COND;3;SG
-imetama	ei ole imetatudp	V;PASS;PRS;PRF;NEG;IND
+imetama	ei ole imetatud	V;PASS;PRS;PRF;NEG;IND
 imetama	imetaksin	V;ACT;PRS;POS;COND;1;SG
 imetama	olen imetanud	V;ACT;PRS;PRF;POS;IND;1;SG
-imetama	ei olnud imetatudp	V;PASS;PST;PRF;NEG;IND
+imetama	ei olnud imetatud	V;PASS;PST;PRF;NEG;IND
 imetama	ärgu olgu imetatud	V;PASS;PRS;PRF;NEG;IMP
 
 imik	imikuni	N;TERM;SG
@@ -3341,7 +3341,7 @@ islandlane	islandlastesse	N;IN+ALL;PL
 islandlane	islandlastelt	N;AT+ABL;PL
 
 istuma	olete istunud	V;ACT;PRS;PRF;POS;IND;2;PL
-istuma	ei olevat istunudp	V;ACT;PRS;PRF;NEG;QUOT
+istuma	ei olevat istunud	V;ACT;PRS;PRF;NEG;QUOT
 istuma	oleks istutud	V;PASS;PRS;PRF;POS;COND
 istuma	istusin	V;ACT;PST;POS;IND;1;SG
 istuma	istutakse	V;PASS;PRS;POS;IND
@@ -3350,7 +3350,7 @@ istuma	istutagu	V;PASS;PRS;POS;IMP
 istuma	ärgu istugu	V;ACT;PRS;NEG;IMP;3;SG
 istuma	oli istutud	V;PASS;PST;PRF;POS;IND
 istuma	istusime	V;ACT;PST;POS;IND;1;PL
-istuma	ei olnud istunudp	V;ACT;PST;PRF;NEG;IND
+istuma	ei olnud istunud	V;ACT;PST;PRF;NEG;IND
 istuma	oleksid istunud	V;ACT;PRS;PRF;POS;COND;2;SG
 istuma	olgu istunud	V;ACT;PRS;PRF;POS;IMP;PL
 istuma	oli istunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -3364,9 +3364,9 @@ istuma	ärgu istugu	V;ACT;PRS;NEG;IMP;3;PL
 istuma	olgu istunud	V;ACT;PRS;PRF;POS;IMP;SG
 istuma	istuti	V;PASS;PST;POS;IND
 istuma	ei istuvat	V;ACT;PRS;NEG;QUOT
-istuma	ei oleks istutudp	V;PASS;PRS;PRF;NEG;COND
+istuma	ei oleks istutud	V;PASS;PRS;PRF;NEG;COND
 istuma	ei istunud	V;ACT;PST;NEG;IND
-istuma	ei olevat istutudp	V;PASS;PRS;PRF;NEG;QUOT
+istuma	ei olevat istutud	V;PASS;PRS;PRF;NEG;QUOT
 istuma	ei istuks	V;ACT;PRS;PRF;POS;COND;1;SG
 istuma	istutud	V.PTCP;PASS;PST
 istuma	olid istunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -3385,7 +3385,7 @@ istuma	olgu istutud	V;PASS;PRS;PRF;POS;IMP
 istuma	istuks	V;ACT;PRS;POS;COND;3;SG
 istuma	istugu	V;ACT;PRS;POS;IMP;3;PL
 istuma	ärgu olgu istunud	V;ACT;PRS;PRF;NEG;IMP;SG
-istuma	ei ole istunudp	V;ACT;PST;NEG;IND
+istuma	ei ole istunud	V;ACT;PST;NEG;IND
 istuma	istud	V;ACT;PRS;POS;IND;2;SG
 istuma	ära istu	V;ACT;PRS;NEG;IMP;2;SG
 istuma	ei istu	V;ACT;PRS;NEG;IND
@@ -3413,17 +3413,17 @@ istuma	ei istuta	V;PASS;PRS;NEG;IND
 istuma	istume	V;ACT;PRS;POS;IND;1;PL
 istuma	istun	V;ACT;PRS;POS;IND;1;SG
 istuma	ärgem istugem	V;ACT;PRS;NEG;IMP;1;PL
-istuma	ei oleks istunudp	V;ACT;PRS;PRF;NEG;COND
+istuma	ei oleks istunud	V;ACT;PRS;PRF;NEG;COND
 istuma	oleksid istunud	V;ACT;PRS;PRF;POS;COND;3;PL
 istuma	istusite	V;ACT;PST;POS;IND;2;PL
 istuma	oleks istunud	V;ACT;PRS;PRF;POS;COND;3;SG
 istuma	olin istunud	V;ACT;PRS;PRF;POS;COND;1;SG
 istuma	oled istunud	V;ACT;PRS;PRF;POS;IND;2;SG
 istuma	oli istunud	V;ACT;PRS;PRF;POS;COND;3;SG
-istuma	ei ole istutudp	V;PASS;PRS;PRF;NEG;IND
+istuma	ei ole istutud	V;PASS;PRS;PRF;NEG;IND
 istuma	istuksin	V;ACT;PRS;POS;COND;1;SG
 istuma	olen istunud	V;ACT;PRS;PRF;POS;IND;1;SG
-istuma	ei olnud istutudp	V;PASS;PST;PRF;NEG;IND
+istuma	ei olnud istutud	V;PASS;PST;PRF;NEG;IND
 istuma	ärgu olgu istutud	V;PASS;PRS;PRF;NEG;IMP
 
 itaallane	itaallaseni	N;TERM;SG
@@ -3458,7 +3458,7 @@ itaallane	itaallastesse	N;IN+ALL;PL
 itaallane	itaallastelt	N;AT+ABL;PL
 
 itsitama	olete itsitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-itsitama	ei olevat itsitanudp	V;ACT;PRS;PRF;NEG;QUOT
+itsitama	ei olevat itsitanud	V;ACT;PRS;PRF;NEG;QUOT
 itsitama	oleks itsitatud	V;PASS;PRS;PRF;POS;COND
 itsitama	itsitasin	V;ACT;PST;POS;IND;1;SG
 itsitama	itsitatakse	V;PASS;PRS;POS;IND
@@ -3467,7 +3467,7 @@ itsitama	itsitatagu	V;PASS;PRS;POS;IMP
 itsitama	ärgu itsitagu	V;ACT;PRS;NEG;IMP;3;SG
 itsitama	oli itsitatud	V;PASS;PST;PRF;POS;IND
 itsitama	itsitasime	V;ACT;PST;POS;IND;1;PL
-itsitama	ei olnud itsitanudp	V;ACT;PST;PRF;NEG;IND
+itsitama	ei olnud itsitanud	V;ACT;PST;PRF;NEG;IND
 itsitama	oleksid itsitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 itsitama	olgu itsitanud	V;ACT;PRS;PRF;POS;IMP;PL
 itsitama	oli itsitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -3481,9 +3481,9 @@ itsitama	ärgu itsitagu	V;ACT;PRS;NEG;IMP;3;PL
 itsitama	olgu itsitanud	V;ACT;PRS;PRF;POS;IMP;SG
 itsitama	itsitati	V;PASS;PST;POS;IND
 itsitama	ei itsitavat	V;ACT;PRS;NEG;QUOT
-itsitama	ei oleks itsitatudp	V;PASS;PRS;PRF;NEG;COND
+itsitama	ei oleks itsitatud	V;PASS;PRS;PRF;NEG;COND
 itsitama	ei itsitanud	V;ACT;PST;NEG;IND
-itsitama	ei olevat itsitatudp	V;PASS;PRS;PRF;NEG;QUOT
+itsitama	ei olevat itsitatud	V;PASS;PRS;PRF;NEG;QUOT
 itsitama	ei itsitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 itsitama	itsitatud	V.PTCP;PASS;PST
 itsitama	olid itsitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -3502,7 +3502,7 @@ itsitama	olgu itsitatud	V;PASS;PRS;PRF;POS;IMP
 itsitama	itsitaks	V;ACT;PRS;POS;COND;3;SG
 itsitama	itsitagu	V;ACT;PRS;POS;IMP;3;PL
 itsitama	ärgu olgu itsitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-itsitama	ei ole itsitanudp	V;ACT;PST;NEG;IND
+itsitama	ei ole itsitanud	V;ACT;PST;NEG;IND
 itsitama	itsitad	V;ACT;PRS;POS;IND;2;SG
 itsitama	ära itsita	V;ACT;PRS;NEG;IMP;2;SG
 itsitama	ei itsita	V;ACT;PRS;NEG;IND
@@ -3530,17 +3530,17 @@ itsitama	ei itsitata	V;PASS;PRS;NEG;IND
 itsitama	itsitame	V;ACT;PRS;POS;IND;1;PL
 itsitama	itsitan	V;ACT;PRS;POS;IND;1;SG
 itsitama	ärgem itsitagem	V;ACT;PRS;NEG;IMP;1;PL
-itsitama	ei oleks itsitanudp	V;ACT;PRS;PRF;NEG;COND
+itsitama	ei oleks itsitanud	V;ACT;PRS;PRF;NEG;COND
 itsitama	oleksid itsitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 itsitama	itsitasite	V;ACT;PST;POS;IND;2;PL
 itsitama	oleks itsitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 itsitama	olin itsitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 itsitama	oled itsitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 itsitama	oli itsitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-itsitama	ei ole itsitatudp	V;PASS;PRS;PRF;NEG;IND
+itsitama	ei ole itsitatud	V;PASS;PRS;PRF;NEG;IND
 itsitama	itsitaksin	V;ACT;PRS;POS;COND;1;SG
 itsitama	olen itsitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-itsitama	ei olnud itsitatudp	V;PASS;PST;PRF;NEG;IND
+itsitama	ei olnud itsitatud	V;PASS;PST;PRF;NEG;IND
 itsitama	ärgu olgu itsitatud	V;PASS;PRS;PRF;NEG;IMP
 
 jaanuar	jaanuarini	N;TERM;SG
@@ -3606,7 +3606,7 @@ jaapanlane	jaapanlastesse	N;IN+ALL;PL
 jaapanlane	jaapanlastelt	N;AT+ABL;PL
 
 jaatama	olete jaatanud	V;ACT;PRS;PRF;POS;IND;2;PL
-jaatama	ei olevat jaatanudp	V;ACT;PRS;PRF;NEG;QUOT
+jaatama	ei olevat jaatanud	V;ACT;PRS;PRF;NEG;QUOT
 jaatama	oleks jaatatud	V;PASS;PRS;PRF;POS;COND
 jaatama	jaatasin	V;ACT;PST;POS;IND;1;SG
 jaatama	jaatatakse	V;PASS;PRS;POS;IND
@@ -3615,7 +3615,7 @@ jaatama	jaatatagu	V;PASS;PRS;POS;IMP
 jaatama	ärgu jaatagu	V;ACT;PRS;NEG;IMP;3;SG
 jaatama	oli jaatatud	V;PASS;PST;PRF;POS;IND
 jaatama	jaatasime	V;ACT;PST;POS;IND;1;PL
-jaatama	ei olnud jaatanudp	V;ACT;PST;PRF;NEG;IND
+jaatama	ei olnud jaatanud	V;ACT;PST;PRF;NEG;IND
 jaatama	oleksid jaatanud	V;ACT;PRS;PRF;POS;COND;2;SG
 jaatama	olgu jaatanud	V;ACT;PRS;PRF;POS;IMP;PL
 jaatama	oli jaatanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -3629,9 +3629,9 @@ jaatama	ärgu jaatagu	V;ACT;PRS;NEG;IMP;3;PL
 jaatama	olgu jaatanud	V;ACT;PRS;PRF;POS;IMP;SG
 jaatama	jaatati	V;PASS;PST;POS;IND
 jaatama	ei jaatavat	V;ACT;PRS;NEG;QUOT
-jaatama	ei oleks jaatatudp	V;PASS;PRS;PRF;NEG;COND
+jaatama	ei oleks jaatatud	V;PASS;PRS;PRF;NEG;COND
 jaatama	ei jaatanud	V;ACT;PST;NEG;IND
-jaatama	ei olevat jaatatudp	V;PASS;PRS;PRF;NEG;QUOT
+jaatama	ei olevat jaatatud	V;PASS;PRS;PRF;NEG;QUOT
 jaatama	ei jaataks	V;ACT;PRS;PRF;POS;COND;1;SG
 jaatama	jaatatud	V.PTCP;PASS;PST
 jaatama	olid jaatanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -3650,7 +3650,7 @@ jaatama	olgu jaatatud	V;PASS;PRS;PRF;POS;IMP
 jaatama	jaataks	V;ACT;PRS;POS;COND;3;SG
 jaatama	jaatagu	V;ACT;PRS;POS;IMP;3;PL
 jaatama	ärgu olgu jaatanud	V;ACT;PRS;PRF;NEG;IMP;SG
-jaatama	ei ole jaatanudp	V;ACT;PST;NEG;IND
+jaatama	ei ole jaatanud	V;ACT;PST;NEG;IND
 jaatama	jaatad	V;ACT;PRS;POS;IND;2;SG
 jaatama	ära jaata	V;ACT;PRS;NEG;IMP;2;SG
 jaatama	ei jaata	V;ACT;PRS;NEG;IND
@@ -3678,17 +3678,17 @@ jaatama	ei jaatata	V;PASS;PRS;NEG;IND
 jaatama	jaatame	V;ACT;PRS;POS;IND;1;PL
 jaatama	jaatan	V;ACT;PRS;POS;IND;1;SG
 jaatama	ärgem jaatagem	V;ACT;PRS;NEG;IMP;1;PL
-jaatama	ei oleks jaatanudp	V;ACT;PRS;PRF;NEG;COND
+jaatama	ei oleks jaatanud	V;ACT;PRS;PRF;NEG;COND
 jaatama	oleksid jaatanud	V;ACT;PRS;PRF;POS;COND;3;PL
 jaatama	jaatasite	V;ACT;PST;POS;IND;2;PL
 jaatama	oleks jaatanud	V;ACT;PRS;PRF;POS;COND;3;SG
 jaatama	olin jaatanud	V;ACT;PRS;PRF;POS;COND;1;SG
 jaatama	oled jaatanud	V;ACT;PRS;PRF;POS;IND;2;SG
 jaatama	oli jaatanud	V;ACT;PRS;PRF;POS;COND;3;SG
-jaatama	ei ole jaatatudp	V;PASS;PRS;PRF;NEG;IND
+jaatama	ei ole jaatatud	V;PASS;PRS;PRF;NEG;IND
 jaatama	jaataksin	V;ACT;PRS;POS;COND;1;SG
 jaatama	olen jaatanud	V;ACT;PRS;PRF;POS;IND;1;SG
-jaatama	ei olnud jaatatudp	V;PASS;PST;PRF;NEG;IND
+jaatama	ei olnud jaatatud	V;PASS;PST;PRF;NEG;IND
 jaatama	ärgu olgu jaatatud	V;PASS;PRS;PRF;NEG;IMP
 
 jaatav	jaatavani	N;TERM;SG
@@ -3847,7 +3847,7 @@ joodik	joodikutesse	N;IN+ALL;PL
 joodik	joodikutelt	N;AT+ABL;PL
 
 jooma	olete joonud	V;ACT;PRS;PRF;POS;IND;2;PL
-jooma	ei olevat joonudp	V;ACT;PRS;PRF;NEG;QUOT
+jooma	ei olevat joonud	V;ACT;PRS;PRF;NEG;QUOT
 jooma	oleks joodud	V;PASS;PRS;PRF;POS;COND
 jooma	jõin	V;ACT;PST;POS;IND;1;SG
 jooma	juuakse	V;PASS;PRS;POS;IND
@@ -3856,7 +3856,7 @@ jooma	joodagu	V;PASS;PRS;POS;IMP
 jooma	ärgu joogu	V;ACT;PRS;NEG;IMP;3;SG
 jooma	oli joodud	V;PASS;PST;PRF;POS;IND
 jooma	jõime	V;ACT;PST;POS;IND;1;PL
-jooma	ei olnud joonudp	V;ACT;PST;PRF;NEG;IND
+jooma	ei olnud joonud	V;ACT;PST;PRF;NEG;IND
 jooma	oleksid joonud	V;ACT;PRS;PRF;POS;COND;2;SG
 jooma	olgu joonud	V;ACT;PRS;PRF;POS;IMP;PL
 jooma	oli joonud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -3870,9 +3870,9 @@ jooma	ärgu joogu	V;ACT;PRS;NEG;IMP;3;PL
 jooma	olgu joonud	V;ACT;PRS;PRF;POS;IMP;SG
 jooma	joodi	V;PASS;PST;POS;IND
 jooma	ei joovat	V;ACT;PRS;NEG;QUOT
-jooma	ei oleks joodudp	V;PASS;PRS;PRF;NEG;COND
+jooma	ei oleks joodud	V;PASS;PRS;PRF;NEG;COND
 jooma	ei joonud	V;ACT;PST;NEG;IND
-jooma	ei olevat joodudp	V;PASS;PRS;PRF;NEG;QUOT
+jooma	ei olevat joodud	V;PASS;PRS;PRF;NEG;QUOT
 jooma	ei jooks	V;ACT;PRS;PRF;POS;COND;1;SG
 jooma	joodud	V.PTCP;PASS;PST
 jooma	olid joonud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -3891,7 +3891,7 @@ jooma	olgu joodud	V;PASS;PRS;PRF;POS;IMP
 jooma	jooks	V;ACT;PRS;POS;COND;3;SG
 jooma	joogu	V;ACT;PRS;POS;IMP;3;PL
 jooma	ärgu olgu joonud	V;ACT;PRS;PRF;NEG;IMP;SG
-jooma	ei ole joonudp	V;ACT;PST;NEG;IND
+jooma	ei ole joonud	V;ACT;PST;NEG;IND
 jooma	jood	V;ACT;PRS;POS;IND;2;SG
 jooma	ära joo	V;ACT;PRS;NEG;IMP;2;SG
 jooma	ei joo	V;ACT;PRS;NEG;IND
@@ -3919,17 +3919,17 @@ jooma	ei jooda	V;PASS;PRS;NEG;IND
 jooma	joome	V;ACT;PRS;POS;IND;1;PL
 jooma	joon	V;ACT;PRS;POS;IND;1;SG
 jooma	ärgem joogem	V;ACT;PRS;NEG;IMP;1;PL
-jooma	ei oleks joonudp	V;ACT;PRS;PRF;NEG;COND
+jooma	ei oleks joonud	V;ACT;PRS;PRF;NEG;COND
 jooma	oleksid joonud	V;ACT;PRS;PRF;POS;COND;3;PL
 jooma	jõite	V;ACT;PST;POS;IND;2;PL
 jooma	oleks joonud	V;ACT;PRS;PRF;POS;COND;3;SG
 jooma	olin joonud	V;ACT;PRS;PRF;POS;COND;1;SG
 jooma	oled joonud	V;ACT;PRS;PRF;POS;IND;2;SG
 jooma	oli joonud	V;ACT;PRS;PRF;POS;COND;3;SG
-jooma	ei ole joodudp	V;PASS;PRS;PRF;NEG;IND
+jooma	ei ole joodud	V;PASS;PRS;PRF;NEG;IND
 jooma	jooksin	V;ACT;PRS;POS;COND;1;SG
 jooma	olen joonud	V;ACT;PRS;PRF;POS;IND;1;SG
-jooma	ei olnud joodudp	V;PASS;PST;PRF;NEG;IND
+jooma	ei olnud joodud	V;PASS;PST;PRF;NEG;IND
 jooma	ärgu olgu joodud	V;PASS;PRS;PRF;NEG;IMP
 
 jugapuu	jugapuuni	N;TERM;SG
@@ -4088,7 +4088,7 @@ juuni	juunidesse	N;IN+ALL;PL
 juuni	juunidelt	N;AT+ABL;PL
 
 järgnema	olete järgnenud	V;ACT;PRS;PRF;POS;IND;2;PL
-järgnema	ei olevat järgnenudp	V;ACT;PRS;PRF;NEG;QUOT
+järgnema	ei olevat järgnenud	V;ACT;PRS;PRF;NEG;QUOT
 järgnema	oleks järgnetud	V;PASS;PRS;PRF;POS;COND
 järgnema	järgnesin	V;ACT;PST;POS;IND;1;SG
 järgnema	järgnetakse	V;PASS;PRS;POS;IND
@@ -4097,7 +4097,7 @@ järgnema	järgnetagu	V;PASS;PRS;POS;IMP
 järgnema	ärgu järgnegu	V;ACT;PRS;NEG;IMP;3;SG
 järgnema	oli järgnetud	V;PASS;PST;PRF;POS;IND
 järgnema	järgnesime	V;ACT;PST;POS;IND;1;PL
-järgnema	ei olnud järgnenudp	V;ACT;PST;PRF;NEG;IND
+järgnema	ei olnud järgnenud	V;ACT;PST;PRF;NEG;IND
 järgnema	oleksid järgnenud	V;ACT;PRS;PRF;POS;COND;2;SG
 järgnema	olgu järgnenud	V;ACT;PRS;PRF;POS;IMP;PL
 järgnema	oli järgnenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -4111,9 +4111,9 @@ järgnema	ärgu järgnegu	V;ACT;PRS;NEG;IMP;3;PL
 järgnema	olgu järgnenud	V;ACT;PRS;PRF;POS;IMP;SG
 järgnema	järgneti	V;PASS;PST;POS;IND
 järgnema	ei järgnevat	V;ACT;PRS;NEG;QUOT
-järgnema	ei oleks järgnetudp	V;PASS;PRS;PRF;NEG;COND
+järgnema	ei oleks järgnetud	V;PASS;PRS;PRF;NEG;COND
 järgnema	ei järgnenud	V;ACT;PST;NEG;IND
-järgnema	ei olevat järgnetudp	V;PASS;PRS;PRF;NEG;QUOT
+järgnema	ei olevat järgnetud	V;PASS;PRS;PRF;NEG;QUOT
 järgnema	ei järgneks	V;ACT;PRS;PRF;POS;COND;1;SG
 järgnema	järgnetud	V.PTCP;PASS;PST
 järgnema	olid järgnenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -4132,7 +4132,7 @@ järgnema	olgu järgnetud	V;PASS;PRS;PRF;POS;IMP
 järgnema	järgneks	V;ACT;PRS;POS;COND;3;SG
 järgnema	järgnegu	V;ACT;PRS;POS;IMP;3;PL
 järgnema	ärgu olgu järgnenud	V;ACT;PRS;PRF;NEG;IMP;SG
-järgnema	ei ole järgnenudp	V;ACT;PST;NEG;IND
+järgnema	ei ole järgnenud	V;ACT;PST;NEG;IND
 järgnema	järgned	V;ACT;PRS;POS;IND;2;SG
 järgnema	ära järgne	V;ACT;PRS;NEG;IMP;2;SG
 järgnema	ei järgne	V;ACT;PRS;NEG;IND
@@ -4160,17 +4160,17 @@ järgnema	ei järgneta	V;PASS;PRS;NEG;IND
 järgnema	järgneme	V;ACT;PRS;POS;IND;1;PL
 järgnema	järgnen	V;ACT;PRS;POS;IND;1;SG
 järgnema	ärgem järgnegem	V;ACT;PRS;NEG;IMP;1;PL
-järgnema	ei oleks järgnenudp	V;ACT;PRS;PRF;NEG;COND
+järgnema	ei oleks järgnenud	V;ACT;PRS;PRF;NEG;COND
 järgnema	oleksid järgnenud	V;ACT;PRS;PRF;POS;COND;3;PL
 järgnema	järgnesite	V;ACT;PST;POS;IND;2;PL
 järgnema	oleks järgnenud	V;ACT;PRS;PRF;POS;COND;3;SG
 järgnema	olin järgnenud	V;ACT;PRS;PRF;POS;COND;1;SG
 järgnema	oled järgnenud	V;ACT;PRS;PRF;POS;IND;2;SG
 järgnema	oli järgnenud	V;ACT;PRS;PRF;POS;COND;3;SG
-järgnema	ei ole järgnetudp	V;PASS;PRS;PRF;NEG;IND
+järgnema	ei ole järgnetud	V;PASS;PRS;PRF;NEG;IND
 järgnema	järgneksin	V;ACT;PRS;POS;COND;1;SG
 järgnema	olen järgnenud	V;ACT;PRS;PRF;POS;IND;1;SG
-järgnema	ei olnud järgnetudp	V;PASS;PST;PRF;NEG;IND
+järgnema	ei olnud järgnetud	V;PASS;PST;PRF;NEG;IND
 järgnema	ärgu olgu järgnetud	V;PASS;PRS;PRF;NEG;IMP
 
 järjehoidja	järjehoidjani	N;TERM;SG
@@ -4205,7 +4205,7 @@ järjehoidja	järjehoidjatesse	N;IN+ALL;PL
 järjehoidja	järjehoidjatelt	N;AT+ABL;PL
 
 jätma	olete jätnud	V;ACT;PRS;PRF;POS;IND;2;PL
-jätma	ei olevat jätnudp	V;ACT;PRS;PRF;NEG;QUOT
+jätma	ei olevat jätnud	V;ACT;PRS;PRF;NEG;QUOT
 jätma	oleks jätetud	V;PASS;PRS;PRF;POS;COND
 jätma	jätsin	V;ACT;PST;POS;IND;1;SG
 jätma	jätetakse	V;PASS;PRS;POS;IND
@@ -4214,7 +4214,7 @@ jätma	jätetagu	V;PASS;PRS;POS;IMP
 jätma	ärgu jätku	V;ACT;PRS;NEG;IMP;3;SG
 jätma	oli jätetud	V;PASS;PST;PRF;POS;IND
 jätma	jätsime	V;ACT;PST;POS;IND;1;PL
-jätma	ei olnud jätnudp	V;ACT;PST;PRF;NEG;IND
+jätma	ei olnud jätnud	V;ACT;PST;PRF;NEG;IND
 jätma	oleksid jätnud	V;ACT;PRS;PRF;POS;COND;2;SG
 jätma	olgu jätnud	V;ACT;PRS;PRF;POS;IMP;PL
 jätma	oli jätnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -4228,9 +4228,9 @@ jätma	ärgu jätku	V;ACT;PRS;NEG;IMP;3;PL
 jätma	olgu jätnud	V;ACT;PRS;PRF;POS;IMP;SG
 jätma	jäteti	V;PASS;PST;POS;IND
 jätma	ei jätvat	V;ACT;PRS;NEG;QUOT
-jätma	ei oleks jätetudp	V;PASS;PRS;PRF;NEG;COND
+jätma	ei oleks jätetud	V;PASS;PRS;PRF;NEG;COND
 jätma	ei jätnud	V;ACT;PST;NEG;IND
-jätma	ei olevat jätetudp	V;PASS;PRS;PRF;NEG;QUOT
+jätma	ei olevat jätetud	V;PASS;PRS;PRF;NEG;QUOT
 jätma	ei jätaks	V;ACT;PRS;PRF;POS;COND;1;SG
 jätma	jätetud	V.PTCP;PASS;PST
 jätma	olid jätnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -4249,7 +4249,7 @@ jätma	olgu jätetud	V;PASS;PRS;PRF;POS;IMP
 jätma	jätaks	V;ACT;PRS;POS;COND;3;SG
 jätma	jätku	V;ACT;PRS;POS;IMP;3;PL
 jätma	ärgu olgu jätnud	V;ACT;PRS;PRF;NEG;IMP;SG
-jätma	ei ole jätnudp	V;ACT;PST;NEG;IND
+jätma	ei ole jätnud	V;ACT;PST;NEG;IND
 jätma	jätad	V;ACT;PRS;POS;IND;2;SG
 jätma	ära jäta	V;ACT;PRS;NEG;IMP;2;SG
 jätma	ei jäta	V;ACT;PRS;NEG;IND
@@ -4277,17 +4277,17 @@ jätma	ei jäteta	V;PASS;PRS;NEG;IND
 jätma	jätame	V;ACT;PRS;POS;IND;1;PL
 jätma	jätan	V;ACT;PRS;POS;IND;1;SG
 jätma	ärgem jätkem	V;ACT;PRS;NEG;IMP;1;PL
-jätma	ei oleks jätnudp	V;ACT;PRS;PRF;NEG;COND
+jätma	ei oleks jätnud	V;ACT;PRS;PRF;NEG;COND
 jätma	oleksid jätnud	V;ACT;PRS;PRF;POS;COND;3;PL
 jätma	jätsite	V;ACT;PST;POS;IND;2;PL
 jätma	oleks jätnud	V;ACT;PRS;PRF;POS;COND;3;SG
 jätma	olin jätnud	V;ACT;PRS;PRF;POS;COND;1;SG
 jätma	oled jätnud	V;ACT;PRS;PRF;POS;IND;2;SG
 jätma	oli jätnud	V;ACT;PRS;PRF;POS;COND;3;SG
-jätma	ei ole jätetudp	V;PASS;PRS;PRF;NEG;IND
+jätma	ei ole jätetud	V;PASS;PRS;PRF;NEG;IND
 jätma	jätaksin	V;ACT;PRS;POS;COND;1;SG
 jätma	olen jätnud	V;ACT;PRS;PRF;POS;IND;1;SG
-jätma	ei olnud jätetudp	V;PASS;PST;PRF;NEG;IND
+jätma	ei olnud jätetud	V;PASS;PST;PRF;NEG;IND
 jätma	ärgu olgu jätetud	V;PASS;PRS;PRF;NEG;IMP
 
 jääkaru	jääkaruni	N;TERM;SG
@@ -4322,7 +4322,7 @@ jääkaru	jääkarudesse	N;IN+ALL;PL
 jääkaru	jääkarudelt	N;AT+ABL;PL
 
 jääma	olete jäänud	V;ACT;PRS;PRF;POS;IND;2;PL
-jääma	ei olevat jäänudp	V;ACT;PRS;PRF;NEG;QUOT
+jääma	ei olevat jäänud	V;ACT;PRS;PRF;NEG;QUOT
 jääma	oleks jäädud	V;PASS;PRS;PRF;POS;COND
 jääma	jäin	V;ACT;PST;POS;IND;1;SG
 jääma	jäädakse	V;PASS;PRS;POS;IND
@@ -4331,7 +4331,7 @@ jääma	jäädagu	V;PASS;PRS;POS;IMP
 jääma	ärgu jäägu	V;ACT;PRS;NEG;IMP;3;SG
 jääma	oli jäädud	V;PASS;PST;PRF;POS;IND
 jääma	jäime	V;ACT;PST;POS;IND;1;PL
-jääma	ei olnud jäänudp	V;ACT;PST;PRF;NEG;IND
+jääma	ei olnud jäänud	V;ACT;PST;PRF;NEG;IND
 jääma	oleksid jäänud	V;ACT;PRS;PRF;POS;COND;2;SG
 jääma	olgu jäänud	V;ACT;PRS;PRF;POS;IMP;PL
 jääma	oli jäänud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -4345,9 +4345,9 @@ jääma	ärgu jäägu	V;ACT;PRS;NEG;IMP;3;PL
 jääma	olgu jäänud	V;ACT;PRS;PRF;POS;IMP;SG
 jääma	jäädi	V;PASS;PST;POS;IND
 jääma	ei jäävat	V;ACT;PRS;NEG;QUOT
-jääma	ei oleks jäädudp	V;PASS;PRS;PRF;NEG;COND
+jääma	ei oleks jäädud	V;PASS;PRS;PRF;NEG;COND
 jääma	ei jäänud	V;ACT;PST;NEG;IND
-jääma	ei olevat jäädudp	V;PASS;PRS;PRF;NEG;QUOT
+jääma	ei olevat jäädud	V;PASS;PRS;PRF;NEG;QUOT
 jääma	ei jääks	V;ACT;PRS;PRF;POS;COND;1;SG
 jääma	jäädud	V.PTCP;PASS;PST
 jääma	olid jäänud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -4366,7 +4366,7 @@ jääma	olgu jäädud	V;PASS;PRS;PRF;POS;IMP
 jääma	jääks	V;ACT;PRS;POS;COND;3;SG
 jääma	jäägu	V;ACT;PRS;POS;IMP;3;PL
 jääma	ärgu olgu jäänud	V;ACT;PRS;PRF;NEG;IMP;SG
-jääma	ei ole jäänudp	V;ACT;PST;NEG;IND
+jääma	ei ole jäänud	V;ACT;PST;NEG;IND
 jääma	jääd	V;ACT;PRS;POS;IND;2;SG
 jääma	ära jää	V;ACT;PRS;NEG;IMP;2;SG
 jääma	ei jää	V;ACT;PRS;NEG;IND
@@ -4394,17 +4394,17 @@ jääma	ei jääda	V;PASS;PRS;NEG;IND
 jääma	jääme	V;ACT;PRS;POS;IND;1;PL
 jääma	jään	V;ACT;PRS;POS;IND;1;SG
 jääma	ärgem jäägem	V;ACT;PRS;NEG;IMP;1;PL
-jääma	ei oleks jäänudp	V;ACT;PRS;PRF;NEG;COND
+jääma	ei oleks jäänud	V;ACT;PRS;PRF;NEG;COND
 jääma	oleksid jäänud	V;ACT;PRS;PRF;POS;COND;3;PL
 jääma	jäite	V;ACT;PST;POS;IND;2;PL
 jääma	oleks jäänud	V;ACT;PRS;PRF;POS;COND;3;SG
 jääma	olin jäänud	V;ACT;PRS;PRF;POS;COND;1;SG
 jääma	oled jäänud	V;ACT;PRS;PRF;POS;IND;2;SG
 jääma	oli jäänud	V;ACT;PRS;PRF;POS;COND;3;SG
-jääma	ei ole jäädudp	V;PASS;PRS;PRF;NEG;IND
+jääma	ei ole jäädud	V;PASS;PRS;PRF;NEG;IND
 jääma	jääksin	V;ACT;PRS;POS;COND;1;SG
 jääma	olen jäänud	V;ACT;PRS;PRF;POS;IND;1;SG
-jääma	ei olnud jäädudp	V;PASS;PST;PRF;NEG;IND
+jääma	ei olnud jäädud	V;PASS;PST;PRF;NEG;IND
 jääma	ärgu olgu jäädud	V;PASS;PRS;PRF;NEG;IMP
 
 jääpurikas	jääpurikani	N;TERM;SG
@@ -4439,7 +4439,7 @@ jääpurikas	jääpurikatesse	N;IN+ALL;PL
 jääpurikas	jääpurikatelt	N;AT+ABL;PL
 
 jäätama	olete jäätanud	V;ACT;PRS;PRF;POS;IND;2;PL
-jäätama	ei olevat jäätanudp	V;ACT;PRS;PRF;NEG;QUOT
+jäätama	ei olevat jäätanud	V;ACT;PRS;PRF;NEG;QUOT
 jäätama	oleks jäätatud	V;PASS;PRS;PRF;POS;COND
 jäätama	jäätasin	V;ACT;PST;POS;IND;1;SG
 jäätama	jäätatakse	V;PASS;PRS;POS;IND
@@ -4448,7 +4448,7 @@ jäätama	jäätatagu	V;PASS;PRS;POS;IMP
 jäätama	ärgu jäätagu	V;ACT;PRS;NEG;IMP;3;SG
 jäätama	oli jäätatud	V;PASS;PST;PRF;POS;IND
 jäätama	jäätasime	V;ACT;PST;POS;IND;1;PL
-jäätama	ei olnud jäätanudp	V;ACT;PST;PRF;NEG;IND
+jäätama	ei olnud jäätanud	V;ACT;PST;PRF;NEG;IND
 jäätama	oleksid jäätanud	V;ACT;PRS;PRF;POS;COND;2;SG
 jäätama	olgu jäätanud	V;ACT;PRS;PRF;POS;IMP;PL
 jäätama	oli jäätanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -4462,9 +4462,9 @@ jäätama	ärgu jäätagu	V;ACT;PRS;NEG;IMP;3;PL
 jäätama	olgu jäätanud	V;ACT;PRS;PRF;POS;IMP;SG
 jäätama	jäätati	V;PASS;PST;POS;IND
 jäätama	ei jäätavat	V;ACT;PRS;NEG;QUOT
-jäätama	ei oleks jäätatudp	V;PASS;PRS;PRF;NEG;COND
+jäätama	ei oleks jäätatud	V;PASS;PRS;PRF;NEG;COND
 jäätama	ei jäätanud	V;ACT;PST;NEG;IND
-jäätama	ei olevat jäätatudp	V;PASS;PRS;PRF;NEG;QUOT
+jäätama	ei olevat jäätatud	V;PASS;PRS;PRF;NEG;QUOT
 jäätama	ei jäätaks	V;ACT;PRS;PRF;POS;COND;1;SG
 jäätama	jäätatud	V.PTCP;PASS;PST
 jäätama	olid jäätanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -4483,7 +4483,7 @@ jäätama	olgu jäätatud	V;PASS;PRS;PRF;POS;IMP
 jäätama	jäätaks	V;ACT;PRS;POS;COND;3;SG
 jäätama	jäätagu	V;ACT;PRS;POS;IMP;3;PL
 jäätama	ärgu olgu jäätanud	V;ACT;PRS;PRF;NEG;IMP;SG
-jäätama	ei ole jäätanudp	V;ACT;PST;NEG;IND
+jäätama	ei ole jäätanud	V;ACT;PST;NEG;IND
 jäätama	jäätad	V;ACT;PRS;POS;IND;2;SG
 jäätama	ära jääta	V;ACT;PRS;NEG;IMP;2;SG
 jäätama	ei jääta	V;ACT;PRS;NEG;IND
@@ -4511,17 +4511,17 @@ jäätama	ei jäätata	V;PASS;PRS;NEG;IND
 jäätama	jäätame	V;ACT;PRS;POS;IND;1;PL
 jäätama	jäätan	V;ACT;PRS;POS;IND;1;SG
 jäätama	ärgem jäätagem	V;ACT;PRS;NEG;IMP;1;PL
-jäätama	ei oleks jäätanudp	V;ACT;PRS;PRF;NEG;COND
+jäätama	ei oleks jäätanud	V;ACT;PRS;PRF;NEG;COND
 jäätama	oleksid jäätanud	V;ACT;PRS;PRF;POS;COND;3;PL
 jäätama	jäätasite	V;ACT;PST;POS;IND;2;PL
 jäätama	oleks jäätanud	V;ACT;PRS;PRF;POS;COND;3;SG
 jäätama	olin jäätanud	V;ACT;PRS;PRF;POS;COND;1;SG
 jäätama	oled jäätanud	V;ACT;PRS;PRF;POS;IND;2;SG
 jäätama	oli jäätanud	V;ACT;PRS;PRF;POS;COND;3;SG
-jäätama	ei ole jäätatudp	V;PASS;PRS;PRF;NEG;IND
+jäätama	ei ole jäätatud	V;PASS;PRS;PRF;NEG;IND
 jäätama	jäätaksin	V;ACT;PRS;POS;COND;1;SG
 jäätama	olen jäätanud	V;ACT;PRS;PRF;POS;IND;1;SG
-jäätama	ei olnud jäätatudp	V;PASS;PST;PRF;NEG;IND
+jäätama	ei olnud jäätatud	V;PASS;PST;PRF;NEG;IND
 jäätama	ärgu olgu jäätatud	V;PASS;PRS;PRF;NEG;IMP
 
 jäätis	jäätiseni	N;TERM;SG
@@ -4587,7 +4587,7 @@ jäätisemasin	jäätisemasinatesse	N;IN+ALL;PL
 jäätisemasin	jäätisemasinatelt	N;AT+ABL;PL
 
 jäätuma	olete jäätunud	V;ACT;PRS;PRF;POS;IND;2;PL
-jäätuma	ei olevat jäätunudp	V;ACT;PRS;PRF;NEG;QUOT
+jäätuma	ei olevat jäätunud	V;ACT;PRS;PRF;NEG;QUOT
 jäätuma	oleks jäätutud	V;PASS;PRS;PRF;POS;COND
 jäätuma	jäätusin	V;ACT;PST;POS;IND;1;SG
 jäätuma	jäätutakse	V;PASS;PRS;POS;IND
@@ -4596,7 +4596,7 @@ jäätuma	jäätutagu	V;PASS;PRS;POS;IMP
 jäätuma	ärgu jäätugu	V;ACT;PRS;NEG;IMP;3;SG
 jäätuma	oli jäätutud	V;PASS;PST;PRF;POS;IND
 jäätuma	jäätusime	V;ACT;PST;POS;IND;1;PL
-jäätuma	ei olnud jäätunudp	V;ACT;PST;PRF;NEG;IND
+jäätuma	ei olnud jäätunud	V;ACT;PST;PRF;NEG;IND
 jäätuma	oleksid jäätunud	V;ACT;PRS;PRF;POS;COND;2;SG
 jäätuma	olgu jäätunud	V;ACT;PRS;PRF;POS;IMP;PL
 jäätuma	oli jäätunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -4610,9 +4610,9 @@ jäätuma	ärgu jäätugu	V;ACT;PRS;NEG;IMP;3;PL
 jäätuma	olgu jäätunud	V;ACT;PRS;PRF;POS;IMP;SG
 jäätuma	jäätuti	V;PASS;PST;POS;IND
 jäätuma	ei jäätuvat	V;ACT;PRS;NEG;QUOT
-jäätuma	ei oleks jäätutudp	V;PASS;PRS;PRF;NEG;COND
+jäätuma	ei oleks jäätutud	V;PASS;PRS;PRF;NEG;COND
 jäätuma	ei jäätunud	V;ACT;PST;NEG;IND
-jäätuma	ei olevat jäätutudp	V;PASS;PRS;PRF;NEG;QUOT
+jäätuma	ei olevat jäätutud	V;PASS;PRS;PRF;NEG;QUOT
 jäätuma	ei jäätuks	V;ACT;PRS;PRF;POS;COND;1;SG
 jäätuma	jäätutud	V.PTCP;PASS;PST
 jäätuma	olid jäätunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -4631,7 +4631,7 @@ jäätuma	olgu jäätutud	V;PASS;PRS;PRF;POS;IMP
 jäätuma	jäätuks	V;ACT;PRS;POS;COND;3;SG
 jäätuma	jäätugu	V;ACT;PRS;POS;IMP;3;PL
 jäätuma	ärgu olgu jäätunud	V;ACT;PRS;PRF;NEG;IMP;SG
-jäätuma	ei ole jäätunudp	V;ACT;PST;NEG;IND
+jäätuma	ei ole jäätunud	V;ACT;PST;NEG;IND
 jäätuma	jäätud	V;ACT;PRS;POS;IND;2;SG
 jäätuma	ära jäätu	V;ACT;PRS;NEG;IMP;2;SG
 jäätuma	ei jäätu	V;ACT;PRS;NEG;IND
@@ -4659,17 +4659,17 @@ jäätuma	ei jäätuta	V;PASS;PRS;NEG;IND
 jäätuma	jäätume	V;ACT;PRS;POS;IND;1;PL
 jäätuma	jäätun	V;ACT;PRS;POS;IND;1;SG
 jäätuma	ärgem jäätugem	V;ACT;PRS;NEG;IMP;1;PL
-jäätuma	ei oleks jäätunudp	V;ACT;PRS;PRF;NEG;COND
+jäätuma	ei oleks jäätunud	V;ACT;PRS;PRF;NEG;COND
 jäätuma	oleksid jäätunud	V;ACT;PRS;PRF;POS;COND;3;PL
 jäätuma	jäätusite	V;ACT;PST;POS;IND;2;PL
 jäätuma	oleks jäätunud	V;ACT;PRS;PRF;POS;COND;3;SG
 jäätuma	olin jäätunud	V;ACT;PRS;PRF;POS;COND;1;SG
 jäätuma	oled jäätunud	V;ACT;PRS;PRF;POS;IND;2;SG
 jäätuma	oli jäätunud	V;ACT;PRS;PRF;POS;COND;3;SG
-jäätuma	ei ole jäätutudp	V;PASS;PRS;PRF;NEG;IND
+jäätuma	ei ole jäätutud	V;PASS;PRS;PRF;NEG;IND
 jäätuma	jäätuksin	V;ACT;PRS;POS;COND;1;SG
 jäätuma	olen jäätunud	V;ACT;PRS;PRF;POS;IND;1;SG
-jäätuma	ei olnud jäätutudp	V;PASS;PST;PRF;NEG;IND
+jäätuma	ei olnud jäätutud	V;PASS;PST;PRF;NEG;IND
 jäätuma	ärgu olgu jäätutud	V;PASS;PRS;PRF;NEG;IMP
 
 jäääär	jääääreni	N;TERM;SG
@@ -5324,7 +5324,7 @@ kaenal	kaenaldesse	N;IN+ALL;PL
 kaenal	kaenaldelt	N;AT+ABL;PL
 
 kaevama	olete kaevanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kaevama	ei olevat kaevanudp	V;ACT;PRS;PRF;NEG;QUOT
+kaevama	ei olevat kaevanud	V;ACT;PRS;PRF;NEG;QUOT
 kaevama	oleks kaevatud	V;PASS;PRS;PRF;POS;COND
 kaevama	kaevasin	V;ACT;PST;POS;IND;1;SG
 kaevama	kaevatakse	V;PASS;PRS;POS;IND
@@ -5333,7 +5333,7 @@ kaevama	kaevatagu	V;PASS;PRS;POS;IMP
 kaevama	ärgu kaevaku	V;ACT;PRS;NEG;IMP;3;SG
 kaevama	oli kaevatud	V;PASS;PST;PRF;POS;IND
 kaevama	kaevasime	V;ACT;PST;POS;IND;1;PL
-kaevama	ei olnud kaevanudp	V;ACT;PST;PRF;NEG;IND
+kaevama	ei olnud kaevanud	V;ACT;PST;PRF;NEG;IND
 kaevama	oleksid kaevanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kaevama	olgu kaevanud	V;ACT;PRS;PRF;POS;IMP;PL
 kaevama	oli kaevanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -5347,9 +5347,9 @@ kaevama	ärgu kaevaku	V;ACT;PRS;NEG;IMP;3;PL
 kaevama	olgu kaevanud	V;ACT;PRS;PRF;POS;IMP;SG
 kaevama	kaevati	V;PASS;PST;POS;IND
 kaevama	ei kaevavat	V;ACT;PRS;NEG;QUOT
-kaevama	ei oleks kaevatudp	V;PASS;PRS;PRF;NEG;COND
+kaevama	ei oleks kaevatud	V;PASS;PRS;PRF;NEG;COND
 kaevama	ei kaevanud	V;ACT;PST;NEG;IND
-kaevama	ei olevat kaevatudp	V;PASS;PRS;PRF;NEG;QUOT
+kaevama	ei olevat kaevatud	V;PASS;PRS;PRF;NEG;QUOT
 kaevama	ei kaevaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kaevama	kaevatud	V.PTCP;PASS;PST
 kaevama	olid kaevanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -5368,7 +5368,7 @@ kaevama	olgu kaevatud	V;PASS;PRS;PRF;POS;IMP
 kaevama	kaevaks	V;ACT;PRS;POS;COND;3;SG
 kaevama	kaevaku	V;ACT;PRS;POS;IMP;3;PL
 kaevama	ärgu olgu kaevanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kaevama	ei ole kaevanudp	V;ACT;PST;NEG;IND
+kaevama	ei ole kaevanud	V;ACT;PST;NEG;IND
 kaevama	kaevad	V;ACT;PRS;POS;IND;2;SG
 kaevama	ära kaeva	V;ACT;PRS;NEG;IMP;2;SG
 kaevama	ei kaeva	V;ACT;PRS;NEG;IND
@@ -5396,17 +5396,17 @@ kaevama	ei kaevata	V;PASS;PRS;NEG;IND
 kaevama	kaevame	V;ACT;PRS;POS;IND;1;PL
 kaevama	kaevan	V;ACT;PRS;POS;IND;1;SG
 kaevama	ärgem kaevakem	V;ACT;PRS;NEG;IMP;1;PL
-kaevama	ei oleks kaevanudp	V;ACT;PRS;PRF;NEG;COND
+kaevama	ei oleks kaevanud	V;ACT;PRS;PRF;NEG;COND
 kaevama	oleksid kaevanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kaevama	kaevasite	V;ACT;PST;POS;IND;2;PL
 kaevama	oleks kaevanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kaevama	olin kaevanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kaevama	oled kaevanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kaevama	oli kaevanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kaevama	ei ole kaevatudp	V;PASS;PRS;PRF;NEG;IND
+kaevama	ei ole kaevatud	V;PASS;PRS;PRF;NEG;IND
 kaevama	kaevaksin	V;ACT;PRS;POS;COND;1;SG
 kaevama	olen kaevanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kaevama	ei olnud kaevatudp	V;PASS;PST;PRF;NEG;IND
+kaevama	ei olnud kaevatud	V;PASS;PST;PRF;NEG;IND
 kaevama	ärgu olgu kaevatud	V;PASS;PRS;PRF;NEG;IMP
 
 kaevur	kaevurini	N;TERM;SG
@@ -5596,7 +5596,7 @@ kajakas	kajakatesse	N;IN+ALL;PL
 kajakas	kajakatelt	N;AT+ABL;PL
 
 kajastama	olete kajastanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kajastama	ei olevat kajastanudp	V;ACT;PRS;PRF;NEG;QUOT
+kajastama	ei olevat kajastanud	V;ACT;PRS;PRF;NEG;QUOT
 kajastama	oleks kajastatud	V;PASS;PRS;PRF;POS;COND
 kajastama	kajastasin	V;ACT;PST;POS;IND;1;SG
 kajastama	kajastatakse	V;PASS;PRS;POS;IND
@@ -5605,7 +5605,7 @@ kajastama	kajastatagu	V;PASS;PRS;POS;IMP
 kajastama	ärgu kajastagu	V;ACT;PRS;NEG;IMP;3;SG
 kajastama	oli kajastatud	V;PASS;PST;PRF;POS;IND
 kajastama	kajastasime	V;ACT;PST;POS;IND;1;PL
-kajastama	ei olnud kajastanudp	V;ACT;PST;PRF;NEG;IND
+kajastama	ei olnud kajastanud	V;ACT;PST;PRF;NEG;IND
 kajastama	oleksid kajastanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kajastama	olgu kajastanud	V;ACT;PRS;PRF;POS;IMP;PL
 kajastama	oli kajastanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -5619,9 +5619,9 @@ kajastama	ärgu kajastagu	V;ACT;PRS;NEG;IMP;3;PL
 kajastama	olgu kajastanud	V;ACT;PRS;PRF;POS;IMP;SG
 kajastama	kajastati	V;PASS;PST;POS;IND
 kajastama	ei kajastavat	V;ACT;PRS;NEG;QUOT
-kajastama	ei oleks kajastatudp	V;PASS;PRS;PRF;NEG;COND
+kajastama	ei oleks kajastatud	V;PASS;PRS;PRF;NEG;COND
 kajastama	ei kajastanud	V;ACT;PST;NEG;IND
-kajastama	ei olevat kajastatudp	V;PASS;PRS;PRF;NEG;QUOT
+kajastama	ei olevat kajastatud	V;PASS;PRS;PRF;NEG;QUOT
 kajastama	ei kajastaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kajastama	kajastatud	V.PTCP;PASS;PST
 kajastama	olid kajastanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -5640,7 +5640,7 @@ kajastama	olgu kajastatud	V;PASS;PRS;PRF;POS;IMP
 kajastama	kajastaks	V;ACT;PRS;POS;COND;3;SG
 kajastama	kajastagu	V;ACT;PRS;POS;IMP;3;PL
 kajastama	ärgu olgu kajastanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kajastama	ei ole kajastanudp	V;ACT;PST;NEG;IND
+kajastama	ei ole kajastanud	V;ACT;PST;NEG;IND
 kajastama	kajastad	V;ACT;PRS;POS;IND;2;SG
 kajastama	ära kajasta	V;ACT;PRS;NEG;IMP;2;SG
 kajastama	ei kajasta	V;ACT;PRS;NEG;IND
@@ -5668,21 +5668,21 @@ kajastama	ei kajastata	V;PASS;PRS;NEG;IND
 kajastama	kajastame	V;ACT;PRS;POS;IND;1;PL
 kajastama	kajastan	V;ACT;PRS;POS;IND;1;SG
 kajastama	ärgem kajastagem	V;ACT;PRS;NEG;IMP;1;PL
-kajastama	ei oleks kajastanudp	V;ACT;PRS;PRF;NEG;COND
+kajastama	ei oleks kajastanud	V;ACT;PRS;PRF;NEG;COND
 kajastama	oleksid kajastanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kajastama	kajastasite	V;ACT;PST;POS;IND;2;PL
 kajastama	oleks kajastanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kajastama	olin kajastanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kajastama	oled kajastanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kajastama	oli kajastanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kajastama	ei ole kajastatudp	V;PASS;PRS;PRF;NEG;IND
+kajastama	ei ole kajastatud	V;PASS;PRS;PRF;NEG;IND
 kajastama	kajastaksin	V;ACT;PRS;POS;COND;1;SG
 kajastama	olen kajastanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kajastama	ei olnud kajastatudp	V;PASS;PST;PRF;NEG;IND
+kajastama	ei olnud kajastatud	V;PASS;PST;PRF;NEG;IND
 kajastama	ärgu olgu kajastatud	V;PASS;PRS;PRF;NEG;IMP
 
 kaklema	olete kakelnud	V;ACT;PRS;PRF;POS;IND;2;PL
-kaklema	ei olevat kakelnudp	V;ACT;PRS;PRF;NEG;QUOT
+kaklema	ei olevat kakelnud	V;ACT;PRS;PRF;NEG;QUOT
 kaklema	oleks kakeldud	V;PASS;PRS;PRF;POS;COND
 kaklema	kaklesin	V;ACT;PST;POS;IND;1;SG
 kaklema	kakeldakse	V;PASS;PRS;POS;IND
@@ -5691,7 +5691,7 @@ kaklema	kakeldagu	V;PASS;PRS;POS;IMP
 kaklema	ärgu kakelgu	V;ACT;PRS;NEG;IMP;3;SG
 kaklema	oli kakeldud	V;PASS;PST;PRF;POS;IND
 kaklema	kaklesime	V;ACT;PST;POS;IND;1;PL
-kaklema	ei olnud kakelnudp	V;ACT;PST;PRF;NEG;IND
+kaklema	ei olnud kakelnud	V;ACT;PST;PRF;NEG;IND
 kaklema	oleksid kakelnud	V;ACT;PRS;PRF;POS;COND;2;SG
 kaklema	olgu kakelnud	V;ACT;PRS;PRF;POS;IMP;PL
 kaklema	oli kakelnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -5705,9 +5705,9 @@ kaklema	ärgu kakelgu	V;ACT;PRS;NEG;IMP;3;PL
 kaklema	olgu kakelnud	V;ACT;PRS;PRF;POS;IMP;SG
 kaklema	kakeldi	V;PASS;PST;POS;IND
 kaklema	ei kaklevat	V;ACT;PRS;NEG;QUOT
-kaklema	ei oleks kakeldudp	V;PASS;PRS;PRF;NEG;COND
+kaklema	ei oleks kakeldud	V;PASS;PRS;PRF;NEG;COND
 kaklema	ei kakelnud	V;ACT;PST;NEG;IND
-kaklema	ei olevat kakeldudp	V;PASS;PRS;PRF;NEG;QUOT
+kaklema	ei olevat kakeldud	V;PASS;PRS;PRF;NEG;QUOT
 kaklema	ei kakleks	V;ACT;PRS;PRF;POS;COND;1;SG
 kaklema	kakeldud	V.PTCP;PASS;PST
 kaklema	olid kakelnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -5726,7 +5726,7 @@ kaklema	olgu kakeldud	V;PASS;PRS;PRF;POS;IMP
 kaklema	kakleks	V;ACT;PRS;POS;COND;3;SG
 kaklema	kakelgu	V;ACT;PRS;POS;IMP;3;PL
 kaklema	ärgu olgu kakelnud	V;ACT;PRS;PRF;NEG;IMP;SG
-kaklema	ei ole kakelnudp	V;ACT;PST;NEG;IND
+kaklema	ei ole kakelnud	V;ACT;PST;NEG;IND
 kaklema	kakled	V;ACT;PRS;POS;IND;2;SG
 kaklema	ära kakle	V;ACT;PRS;NEG;IMP;2;SG
 kaklema	ei kakle	V;ACT;PRS;NEG;IND
@@ -5754,17 +5754,17 @@ kaklema	ei kakelda	V;PASS;PRS;NEG;IND
 kaklema	kakleme	V;ACT;PRS;POS;IND;1;PL
 kaklema	kaklen	V;ACT;PRS;POS;IND;1;SG
 kaklema	ärgem kakelgem	V;ACT;PRS;NEG;IMP;1;PL
-kaklema	ei oleks kakelnudp	V;ACT;PRS;PRF;NEG;COND
+kaklema	ei oleks kakelnud	V;ACT;PRS;PRF;NEG;COND
 kaklema	oleksid kakelnud	V;ACT;PRS;PRF;POS;COND;3;PL
 kaklema	kaklesite	V;ACT;PST;POS;IND;2;PL
 kaklema	oleks kakelnud	V;ACT;PRS;PRF;POS;COND;3;SG
 kaklema	olin kakelnud	V;ACT;PRS;PRF;POS;COND;1;SG
 kaklema	oled kakelnud	V;ACT;PRS;PRF;POS;IND;2;SG
 kaklema	oli kakelnud	V;ACT;PRS;PRF;POS;COND;3;SG
-kaklema	ei ole kakeldudp	V;PASS;PRS;PRF;NEG;IND
+kaklema	ei ole kakeldud	V;PASS;PRS;PRF;NEG;IND
 kaklema	kakleksin	V;ACT;PRS;POS;COND;1;SG
 kaklema	olen kakelnud	V;ACT;PRS;PRF;POS;IND;1;SG
-kaklema	ei olnud kakeldudp	V;PASS;PST;PRF;NEG;IND
+kaklema	ei olnud kakeldud	V;PASS;PST;PRF;NEG;IND
 kaklema	ärgu olgu kakeldud	V;PASS;PRS;PRF;NEG;IMP
 
 kaklus	kakluseni	N;TERM;SG
@@ -5861,7 +5861,7 @@ kala	kaladesse	N;IN+ALL;PL
 kala	kaladelt	N;AT+ABL;PL
 
 kalastama	olete kalastanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kalastama	ei olevat kalastanudp	V;ACT;PRS;PRF;NEG;QUOT
+kalastama	ei olevat kalastanud	V;ACT;PRS;PRF;NEG;QUOT
 kalastama	oleks kalastatud	V;PASS;PRS;PRF;POS;COND
 kalastama	kalastasin	V;ACT;PST;POS;IND;1;SG
 kalastama	kalastatakse	V;PASS;PRS;POS;IND
@@ -5870,7 +5870,7 @@ kalastama	kalastatagu	V;PASS;PRS;POS;IMP
 kalastama	ärgu kalastagu	V;ACT;PRS;NEG;IMP;3;SG
 kalastama	oli kalastatud	V;PASS;PST;PRF;POS;IND
 kalastama	kalastasime	V;ACT;PST;POS;IND;1;PL
-kalastama	ei olnud kalastanudp	V;ACT;PST;PRF;NEG;IND
+kalastama	ei olnud kalastanud	V;ACT;PST;PRF;NEG;IND
 kalastama	oleksid kalastanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kalastama	olgu kalastanud	V;ACT;PRS;PRF;POS;IMP;PL
 kalastama	oli kalastanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -5884,9 +5884,9 @@ kalastama	ärgu kalastagu	V;ACT;PRS;NEG;IMP;3;PL
 kalastama	olgu kalastanud	V;ACT;PRS;PRF;POS;IMP;SG
 kalastama	kalastati	V;PASS;PST;POS;IND
 kalastama	ei kalastavat	V;ACT;PRS;NEG;QUOT
-kalastama	ei oleks kalastatudp	V;PASS;PRS;PRF;NEG;COND
+kalastama	ei oleks kalastatud	V;PASS;PRS;PRF;NEG;COND
 kalastama	ei kalastanud	V;ACT;PST;NEG;IND
-kalastama	ei olevat kalastatudp	V;PASS;PRS;PRF;NEG;QUOT
+kalastama	ei olevat kalastatud	V;PASS;PRS;PRF;NEG;QUOT
 kalastama	ei kalastaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kalastama	kalastatud	V.PTCP;PASS;PST
 kalastama	olid kalastanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -5905,7 +5905,7 @@ kalastama	olgu kalastatud	V;PASS;PRS;PRF;POS;IMP
 kalastama	kalastaks	V;ACT;PRS;POS;COND;3;SG
 kalastama	kalastagu	V;ACT;PRS;POS;IMP;3;PL
 kalastama	ärgu olgu kalastanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kalastama	ei ole kalastanudp	V;ACT;PST;NEG;IND
+kalastama	ei ole kalastanud	V;ACT;PST;NEG;IND
 kalastama	kalastad	V;ACT;PRS;POS;IND;2;SG
 kalastama	ära kalasta	V;ACT;PRS;NEG;IMP;2;SG
 kalastama	ei kalasta	V;ACT;PRS;NEG;IND
@@ -5933,17 +5933,17 @@ kalastama	ei kalastata	V;PASS;PRS;NEG;IND
 kalastama	kalastame	V;ACT;PRS;POS;IND;1;PL
 kalastama	kalastan	V;ACT;PRS;POS;IND;1;SG
 kalastama	ärgem kalastagem	V;ACT;PRS;NEG;IMP;1;PL
-kalastama	ei oleks kalastanudp	V;ACT;PRS;PRF;NEG;COND
+kalastama	ei oleks kalastanud	V;ACT;PRS;PRF;NEG;COND
 kalastama	oleksid kalastanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kalastama	kalastasite	V;ACT;PST;POS;IND;2;PL
 kalastama	oleks kalastanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kalastama	olin kalastanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kalastama	oled kalastanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kalastama	oli kalastanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kalastama	ei ole kalastatudp	V;PASS;PRS;PRF;NEG;IND
+kalastama	ei ole kalastatud	V;PASS;PRS;PRF;NEG;IND
 kalastama	kalastaksin	V;ACT;PRS;POS;COND;1;SG
 kalastama	olen kalastanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kalastama	ei olnud kalastatudp	V;PASS;PST;PRF;NEG;IND
+kalastama	ei olnud kalastatud	V;PASS;PST;PRF;NEG;IND
 kalastama	ärgu olgu kalastatud	V;PASS;PRS;PRF;NEG;IMP
 
 kalifornium	kaliforniumini	N;TERM;SG
@@ -6102,7 +6102,7 @@ kallis	kallitesse	N;IN+ALL;PL
 kallis	kallitelt	N;AT+ABL;PL
 
 kallistama	olete kallistanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kallistama	ei olevat kallistanudp	V;ACT;PRS;PRF;NEG;QUOT
+kallistama	ei olevat kallistanud	V;ACT;PRS;PRF;NEG;QUOT
 kallistama	oleks kallistatud	V;PASS;PRS;PRF;POS;COND
 kallistama	kallistasin	V;ACT;PST;POS;IND;1;SG
 kallistama	kallistatakse	V;PASS;PRS;POS;IND
@@ -6111,7 +6111,7 @@ kallistama	kallistatagu	V;PASS;PRS;POS;IMP
 kallistama	ärgu kallistagu	V;ACT;PRS;NEG;IMP;3;SG
 kallistama	oli kallistatud	V;PASS;PST;PRF;POS;IND
 kallistama	kallistasime	V;ACT;PST;POS;IND;1;PL
-kallistama	ei olnud kallistanudp	V;ACT;PST;PRF;NEG;IND
+kallistama	ei olnud kallistanud	V;ACT;PST;PRF;NEG;IND
 kallistama	oleksid kallistanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kallistama	olgu kallistanud	V;ACT;PRS;PRF;POS;IMP;PL
 kallistama	oli kallistanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -6125,9 +6125,9 @@ kallistama	ärgu kallistagu	V;ACT;PRS;NEG;IMP;3;PL
 kallistama	olgu kallistanud	V;ACT;PRS;PRF;POS;IMP;SG
 kallistama	kallistati	V;PASS;PST;POS;IND
 kallistama	ei kallistavat	V;ACT;PRS;NEG;QUOT
-kallistama	ei oleks kallistatudp	V;PASS;PRS;PRF;NEG;COND
+kallistama	ei oleks kallistatud	V;PASS;PRS;PRF;NEG;COND
 kallistama	ei kallistanud	V;ACT;PST;NEG;IND
-kallistama	ei olevat kallistatudp	V;PASS;PRS;PRF;NEG;QUOT
+kallistama	ei olevat kallistatud	V;PASS;PRS;PRF;NEG;QUOT
 kallistama	ei kallistaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kallistama	kallistatud	V.PTCP;PASS;PST
 kallistama	olid kallistanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -6146,7 +6146,7 @@ kallistama	olgu kallistatud	V;PASS;PRS;PRF;POS;IMP
 kallistama	kallistaks	V;ACT;PRS;POS;COND;3;SG
 kallistama	kallistagu	V;ACT;PRS;POS;IMP;3;PL
 kallistama	ärgu olgu kallistanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kallistama	ei ole kallistanudp	V;ACT;PST;NEG;IND
+kallistama	ei ole kallistanud	V;ACT;PST;NEG;IND
 kallistama	kallistad	V;ACT;PRS;POS;IND;2;SG
 kallistama	ära kallista	V;ACT;PRS;NEG;IMP;2;SG
 kallistama	ei kallista	V;ACT;PRS;NEG;IND
@@ -6174,17 +6174,17 @@ kallistama	ei kallistata	V;PASS;PRS;NEG;IND
 kallistama	kallistame	V;ACT;PRS;POS;IND;1;PL
 kallistama	kallistan	V;ACT;PRS;POS;IND;1;SG
 kallistama	ärgem kallistagem	V;ACT;PRS;NEG;IMP;1;PL
-kallistama	ei oleks kallistanudp	V;ACT;PRS;PRF;NEG;COND
+kallistama	ei oleks kallistanud	V;ACT;PRS;PRF;NEG;COND
 kallistama	oleksid kallistanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kallistama	kallistasite	V;ACT;PST;POS;IND;2;PL
 kallistama	oleks kallistanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kallistama	olin kallistanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kallistama	oled kallistanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kallistama	oli kallistanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kallistama	ei ole kallistatudp	V;PASS;PRS;PRF;NEG;IND
+kallistama	ei ole kallistatud	V;PASS;PRS;PRF;NEG;IND
 kallistama	kallistaksin	V;ACT;PRS;POS;COND;1;SG
 kallistama	olen kallistanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kallistama	ei olnud kallistatudp	V;PASS;PST;PRF;NEG;IND
+kallistama	ei olnud kallistatud	V;PASS;PST;PRF;NEG;IND
 kallistama	ärgu olgu kallistatud	V;PASS;PRS;PRF;NEG;IMP
 
 kaltsedon	kaltsedonini	N;TERM;SG
@@ -6498,7 +6498,7 @@ kanuu	kanuudesse	N;IN+ALL;PL
 kanuu	kanuudelt	N;AT+ABL;PL
 
 kaotama	olete kaotanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kaotama	ei olevat kaotanudp	V;ACT;PRS;PRF;NEG;QUOT
+kaotama	ei olevat kaotanud	V;ACT;PRS;PRF;NEG;QUOT
 kaotama	oleks kaotatud	V;PASS;PRS;PRF;POS;COND
 kaotama	kaotasin	V;ACT;PST;POS;IND;1;SG
 kaotama	kaotatakse	V;PASS;PRS;POS;IND
@@ -6507,7 +6507,7 @@ kaotama	kaotatagu	V;PASS;PRS;POS;IMP
 kaotama	ärgu kaotagu	V;ACT;PRS;NEG;IMP;3;SG
 kaotama	oli kaotatud	V;PASS;PST;PRF;POS;IND
 kaotama	kaotasime	V;ACT;PST;POS;IND;1;PL
-kaotama	ei olnud kaotanudp	V;ACT;PST;PRF;NEG;IND
+kaotama	ei olnud kaotanud	V;ACT;PST;PRF;NEG;IND
 kaotama	oleksid kaotanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kaotama	olgu kaotanud	V;ACT;PRS;PRF;POS;IMP;PL
 kaotama	oli kaotanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -6521,9 +6521,9 @@ kaotama	ärgu kaotagu	V;ACT;PRS;NEG;IMP;3;PL
 kaotama	olgu kaotanud	V;ACT;PRS;PRF;POS;IMP;SG
 kaotama	kaotati	V;PASS;PST;POS;IND
 kaotama	ei kaotavat	V;ACT;PRS;NEG;QUOT
-kaotama	ei oleks kaotatudp	V;PASS;PRS;PRF;NEG;COND
+kaotama	ei oleks kaotatud	V;PASS;PRS;PRF;NEG;COND
 kaotama	ei kaotanud	V;ACT;PST;NEG;IND
-kaotama	ei olevat kaotatudp	V;PASS;PRS;PRF;NEG;QUOT
+kaotama	ei olevat kaotatud	V;PASS;PRS;PRF;NEG;QUOT
 kaotama	ei kaotaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kaotama	kaotatud	V.PTCP;PASS;PST
 kaotama	olid kaotanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -6542,7 +6542,7 @@ kaotama	olgu kaotatud	V;PASS;PRS;PRF;POS;IMP
 kaotama	kaotaks	V;ACT;PRS;POS;COND;3;SG
 kaotama	kaotagu	V;ACT;PRS;POS;IMP;3;PL
 kaotama	ärgu olgu kaotanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kaotama	ei ole kaotanudp	V;ACT;PST;NEG;IND
+kaotama	ei ole kaotanud	V;ACT;PST;NEG;IND
 kaotama	kaotad	V;ACT;PRS;POS;IND;2;SG
 kaotama	ära kaota	V;ACT;PRS;NEG;IMP;2;SG
 kaotama	ei kaota	V;ACT;PRS;NEG;IND
@@ -6570,17 +6570,17 @@ kaotama	ei kaotata	V;PASS;PRS;NEG;IND
 kaotama	kaotame	V;ACT;PRS;POS;IND;1;PL
 kaotama	kaotan	V;ACT;PRS;POS;IND;1;SG
 kaotama	ärgem kaotagem	V;ACT;PRS;NEG;IMP;1;PL
-kaotama	ei oleks kaotanudp	V;ACT;PRS;PRF;NEG;COND
+kaotama	ei oleks kaotanud	V;ACT;PRS;PRF;NEG;COND
 kaotama	oleksid kaotanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kaotama	kaotasite	V;ACT;PST;POS;IND;2;PL
 kaotama	oleks kaotanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kaotama	olin kaotanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kaotama	oled kaotanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kaotama	oli kaotanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kaotama	ei ole kaotatudp	V;PASS;PRS;PRF;NEG;IND
+kaotama	ei ole kaotatud	V;PASS;PRS;PRF;NEG;IND
 kaotama	kaotaksin	V;ACT;PRS;POS;COND;1;SG
 kaotama	olen kaotanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kaotama	ei olnud kaotatudp	V;PASS;PST;PRF;NEG;IND
+kaotama	ei olnud kaotatud	V;PASS;PST;PRF;NEG;IND
 kaotama	ärgu olgu kaotatud	V;PASS;PRS;PRF;NEG;IMP
 
 kapital	kapitalini	N;TERM;SG
@@ -6863,7 +6863,7 @@ kasutaja	kasutajatesse	N;IN+ALL;PL
 kasutaja	kasutajatelt	N;AT+ABL;PL
 
 kasutama	olete kasutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kasutama	ei olevat kasutanudp	V;ACT;PRS;PRF;NEG;QUOT
+kasutama	ei olevat kasutanud	V;ACT;PRS;PRF;NEG;QUOT
 kasutama	oleks kasutatud	V;PASS;PRS;PRF;POS;COND
 kasutama	kasutasin	V;ACT;PST;POS;IND;1;SG
 kasutama	kasutatakse	V;PASS;PRS;POS;IND
@@ -6872,7 +6872,7 @@ kasutama	kasutatagu	V;PASS;PRS;POS;IMP
 kasutama	ärgu kasutagu	V;ACT;PRS;NEG;IMP;3;SG
 kasutama	oli kasutatud	V;PASS;PST;PRF;POS;IND
 kasutama	kasutasime	V;ACT;PST;POS;IND;1;PL
-kasutama	ei olnud kasutanudp	V;ACT;PST;PRF;NEG;IND
+kasutama	ei olnud kasutanud	V;ACT;PST;PRF;NEG;IND
 kasutama	oleksid kasutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kasutama	olgu kasutanud	V;ACT;PRS;PRF;POS;IMP;PL
 kasutama	oli kasutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -6886,9 +6886,9 @@ kasutama	ärgu kasutagu	V;ACT;PRS;NEG;IMP;3;PL
 kasutama	olgu kasutanud	V;ACT;PRS;PRF;POS;IMP;SG
 kasutama	kasutati	V;PASS;PST;POS;IND
 kasutama	ei kasutavat	V;ACT;PRS;NEG;QUOT
-kasutama	ei oleks kasutatudp	V;PASS;PRS;PRF;NEG;COND
+kasutama	ei oleks kasutatud	V;PASS;PRS;PRF;NEG;COND
 kasutama	ei kasutanud	V;ACT;PST;NEG;IND
-kasutama	ei olevat kasutatudp	V;PASS;PRS;PRF;NEG;QUOT
+kasutama	ei olevat kasutatud	V;PASS;PRS;PRF;NEG;QUOT
 kasutama	ei kasutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kasutama	kasutatud	V.PTCP;PASS;PST
 kasutama	olid kasutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -6907,7 +6907,7 @@ kasutama	olgu kasutatud	V;PASS;PRS;PRF;POS;IMP
 kasutama	kasutaks	V;ACT;PRS;POS;COND;3;SG
 kasutama	kasutagu	V;ACT;PRS;POS;IMP;3;PL
 kasutama	ärgu olgu kasutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kasutama	ei ole kasutanudp	V;ACT;PST;NEG;IND
+kasutama	ei ole kasutanud	V;ACT;PST;NEG;IND
 kasutama	kasutad	V;ACT;PRS;POS;IND;2;SG
 kasutama	ära kasuta	V;ACT;PRS;NEG;IMP;2;SG
 kasutama	ei kasuta	V;ACT;PRS;NEG;IND
@@ -6935,17 +6935,17 @@ kasutama	ei kasutata	V;PASS;PRS;NEG;IND
 kasutama	kasutame	V;ACT;PRS;POS;IND;1;PL
 kasutama	kasutan	V;ACT;PRS;POS;IND;1;SG
 kasutama	ärgem kasutagem	V;ACT;PRS;NEG;IMP;1;PL
-kasutama	ei oleks kasutanudp	V;ACT;PRS;PRF;NEG;COND
+kasutama	ei oleks kasutanud	V;ACT;PRS;PRF;NEG;COND
 kasutama	oleksid kasutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kasutama	kasutasite	V;ACT;PST;POS;IND;2;PL
 kasutama	oleks kasutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kasutama	olin kasutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kasutama	oled kasutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kasutama	oli kasutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kasutama	ei ole kasutatudp	V;PASS;PRS;PRF;NEG;IND
+kasutama	ei ole kasutatud	V;PASS;PRS;PRF;NEG;IND
 kasutama	kasutaksin	V;ACT;PRS;POS;COND;1;SG
 kasutama	olen kasutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kasutama	ei olnud kasutatudp	V;PASS;PST;PRF;NEG;IND
+kasutama	ei olnud kasutatud	V;PASS;PST;PRF;NEG;IND
 kasutama	ärgu olgu kasutatud	V;PASS;PRS;PRF;NEG;IMP
 
 kasvaja	kasvajani	N;TERM;SG
@@ -6980,7 +6980,7 @@ kasvaja	kasvajatesse	N;IN+ALL;PL
 kasvaja	kasvajatelt	N;AT+ABL;PL
 
 kasvama	olete kasvanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kasvama	ei olevat kasvanudp	V;ACT;PRS;PRF;NEG;QUOT
+kasvama	ei olevat kasvanud	V;ACT;PRS;PRF;NEG;QUOT
 kasvama	oleks kasvatud	V;PASS;PRS;PRF;POS;COND
 kasvama	kasvasin	V;ACT;PST;POS;IND;1;SG
 kasvama	kasvatakse	V;PASS;PRS;POS;IND
@@ -6989,7 +6989,7 @@ kasvama	kasvatagu	V;PASS;PRS;POS;IMP
 kasvama	ärgu kasvagu	V;ACT;PRS;NEG;IMP;3;SG
 kasvama	oli kasvatud	V;PASS;PST;PRF;POS;IND
 kasvama	kasvasime	V;ACT;PST;POS;IND;1;PL
-kasvama	ei olnud kasvanudp	V;ACT;PST;PRF;NEG;IND
+kasvama	ei olnud kasvanud	V;ACT;PST;PRF;NEG;IND
 kasvama	oleksid kasvanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kasvama	olgu kasvanud	V;ACT;PRS;PRF;POS;IMP;PL
 kasvama	oli kasvanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -7003,9 +7003,9 @@ kasvama	ärgu kasvagu	V;ACT;PRS;NEG;IMP;3;PL
 kasvama	olgu kasvanud	V;ACT;PRS;PRF;POS;IMP;SG
 kasvama	kasvati	V;PASS;PST;POS;IND
 kasvama	ei kasvavat	V;ACT;PRS;NEG;QUOT
-kasvama	ei oleks kasvatudp	V;PASS;PRS;PRF;NEG;COND
+kasvama	ei oleks kasvatud	V;PASS;PRS;PRF;NEG;COND
 kasvama	ei kasvanud	V;ACT;PST;NEG;IND
-kasvama	ei olevat kasvatudp	V;PASS;PRS;PRF;NEG;QUOT
+kasvama	ei olevat kasvatud	V;PASS;PRS;PRF;NEG;QUOT
 kasvama	ei kasvaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kasvama	kasvatud	V.PTCP;PASS;PST
 kasvama	olid kasvanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -7024,7 +7024,7 @@ kasvama	olgu kasvatud	V;PASS;PRS;PRF;POS;IMP
 kasvama	kasvaks	V;ACT;PRS;POS;COND;3;SG
 kasvama	kasvagu	V;ACT;PRS;POS;IMP;3;PL
 kasvama	ärgu olgu kasvanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kasvama	ei ole kasvanudp	V;ACT;PST;NEG;IND
+kasvama	ei ole kasvanud	V;ACT;PST;NEG;IND
 kasvama	kasvad	V;ACT;PRS;POS;IND;2;SG
 kasvama	ära kasva	V;ACT;PRS;NEG;IMP;2;SG
 kasvama	ei kasva	V;ACT;PRS;NEG;IND
@@ -7052,17 +7052,17 @@ kasvama	ei kasvata	V;PASS;PRS;NEG;IND
 kasvama	kasvame	V;ACT;PRS;POS;IND;1;PL
 kasvama	kasvan	V;ACT;PRS;POS;IND;1;SG
 kasvama	ärgem kasvagem	V;ACT;PRS;NEG;IMP;1;PL
-kasvama	ei oleks kasvanudp	V;ACT;PRS;PRF;NEG;COND
+kasvama	ei oleks kasvanud	V;ACT;PRS;PRF;NEG;COND
 kasvama	oleksid kasvanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kasvama	kasvasite	V;ACT;PST;POS;IND;2;PL
 kasvama	oleks kasvanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kasvama	olin kasvanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kasvama	oled kasvanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kasvama	oli kasvanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kasvama	ei ole kasvatudp	V;PASS;PRS;PRF;NEG;IND
+kasvama	ei ole kasvatud	V;PASS;PRS;PRF;NEG;IND
 kasvama	kasvaksin	V;ACT;PRS;POS;COND;1;SG
 kasvama	olen kasvanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kasvama	ei olnud kasvatudp	V;PASS;PST;PRF;NEG;IND
+kasvama	ei olnud kasvatud	V;PASS;PST;PRF;NEG;IND
 kasvama	ärgu olgu kasvatud	V;PASS;PRS;PRF;NEG;IMP
 
 katalüüsneutralisaator	katalüüsneutralisaatorini	N;TERM;SG
@@ -7097,7 +7097,7 @@ katalüüsneutralisaator	katalüüsneutralisaatoritesse	N;IN+ALL;PL
 katalüüsneutralisaator	katalüüsneutralisaatoritelt	N;AT+ABL;PL
 
 katkema	olete katkenud	V;ACT;PRS;PRF;POS;IND;2;PL
-katkema	ei olevat katkenudp	V;ACT;PRS;PRF;NEG;QUOT
+katkema	ei olevat katkenud	V;ACT;PRS;PRF;NEG;QUOT
 katkema	oleks katketud	V;PASS;PRS;PRF;POS;COND
 katkema	katkesin	V;ACT;PST;POS;IND;1;SG
 katkema	katketakse	V;PASS;PRS;POS;IND
@@ -7106,7 +7106,7 @@ katkema	katketagu	V;PASS;PRS;POS;IMP
 katkema	ärgu katkegu	V;ACT;PRS;NEG;IMP;3;SG
 katkema	oli katketud	V;PASS;PST;PRF;POS;IND
 katkema	katkesime	V;ACT;PST;POS;IND;1;PL
-katkema	ei olnud katkenudp	V;ACT;PST;PRF;NEG;IND
+katkema	ei olnud katkenud	V;ACT;PST;PRF;NEG;IND
 katkema	oleksid katkenud	V;ACT;PRS;PRF;POS;COND;2;SG
 katkema	olgu katkenud	V;ACT;PRS;PRF;POS;IMP;PL
 katkema	oli katkenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -7120,9 +7120,9 @@ katkema	ärgu katkegu	V;ACT;PRS;NEG;IMP;3;PL
 katkema	olgu katkenud	V;ACT;PRS;PRF;POS;IMP;SG
 katkema	katketi	V;PASS;PST;POS;IND
 katkema	ei katkevat	V;ACT;PRS;NEG;QUOT
-katkema	ei oleks katketudp	V;PASS;PRS;PRF;NEG;COND
+katkema	ei oleks katketud	V;PASS;PRS;PRF;NEG;COND
 katkema	ei katkenud	V;ACT;PST;NEG;IND
-katkema	ei olevat katketudp	V;PASS;PRS;PRF;NEG;QUOT
+katkema	ei olevat katketud	V;PASS;PRS;PRF;NEG;QUOT
 katkema	ei katkeks	V;ACT;PRS;PRF;POS;COND;1;SG
 katkema	katketud	V.PTCP;PASS;PST
 katkema	olid katkenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -7141,7 +7141,7 @@ katkema	olgu katketud	V;PASS;PRS;PRF;POS;IMP
 katkema	katkeks	V;ACT;PRS;POS;COND;3;SG
 katkema	katkegu	V;ACT;PRS;POS;IMP;3;PL
 katkema	ärgu olgu katkenud	V;ACT;PRS;PRF;NEG;IMP;SG
-katkema	ei ole katkenudp	V;ACT;PST;NEG;IND
+katkema	ei ole katkenud	V;ACT;PST;NEG;IND
 katkema	katked	V;ACT;PRS;POS;IND;2;SG
 katkema	ära katke	V;ACT;PRS;NEG;IMP;2;SG
 katkema	ei katke	V;ACT;PRS;NEG;IND
@@ -7169,21 +7169,21 @@ katkema	ei katketa	V;PASS;PRS;NEG;IND
 katkema	katkeme	V;ACT;PRS;POS;IND;1;PL
 katkema	katken	V;ACT;PRS;POS;IND;1;SG
 katkema	ärgem katkegem	V;ACT;PRS;NEG;IMP;1;PL
-katkema	ei oleks katkenudp	V;ACT;PRS;PRF;NEG;COND
+katkema	ei oleks katkenud	V;ACT;PRS;PRF;NEG;COND
 katkema	oleksid katkenud	V;ACT;PRS;PRF;POS;COND;3;PL
 katkema	katkesite	V;ACT;PST;POS;IND;2;PL
 katkema	oleks katkenud	V;ACT;PRS;PRF;POS;COND;3;SG
 katkema	olin katkenud	V;ACT;PRS;PRF;POS;COND;1;SG
 katkema	oled katkenud	V;ACT;PRS;PRF;POS;IND;2;SG
 katkema	oli katkenud	V;ACT;PRS;PRF;POS;COND;3;SG
-katkema	ei ole katketudp	V;PASS;PRS;PRF;NEG;IND
+katkema	ei ole katketud	V;PASS;PRS;PRF;NEG;IND
 katkema	katkeksin	V;ACT;PRS;POS;COND;1;SG
 katkema	olen katkenud	V;ACT;PRS;PRF;POS;IND;1;SG
-katkema	ei olnud katketudp	V;PASS;PST;PRF;NEG;IND
+katkema	ei olnud katketud	V;PASS;PST;PRF;NEG;IND
 katkema	ärgu olgu katketud	V;PASS;PRS;PRF;NEG;IMP
 
 katma	olete katnud	V;ACT;PRS;PRF;POS;IND;2;PL
-katma	ei olevat katnudp	V;ACT;PRS;PRF;NEG;QUOT
+katma	ei olevat katnud	V;ACT;PRS;PRF;NEG;QUOT
 katma	oleks katetud	V;PASS;PRS;PRF;POS;COND
 katma	katsin	V;ACT;PST;POS;IND;1;SG
 katma	katetakse	V;PASS;PRS;POS;IND
@@ -7192,7 +7192,7 @@ katma	katetagu	V;PASS;PRS;POS;IMP
 katma	ärgu katku	V;ACT;PRS;NEG;IMP;3;SG
 katma	oli katetud	V;PASS;PST;PRF;POS;IND
 katma	katsime	V;ACT;PST;POS;IND;1;PL
-katma	ei olnud katnudp	V;ACT;PST;PRF;NEG;IND
+katma	ei olnud katnud	V;ACT;PST;PRF;NEG;IND
 katma	oleksid katnud	V;ACT;PRS;PRF;POS;COND;2;SG
 katma	olgu katnud	V;ACT;PRS;PRF;POS;IMP;PL
 katma	oli katnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -7206,9 +7206,9 @@ katma	ärgu katku	V;ACT;PRS;NEG;IMP;3;PL
 katma	olgu katnud	V;ACT;PRS;PRF;POS;IMP;SG
 katma	kateti	V;PASS;PST;POS;IND
 katma	ei katvat	V;ACT;PRS;NEG;QUOT
-katma	ei oleks katetudp	V;PASS;PRS;PRF;NEG;COND
+katma	ei oleks katetud	V;PASS;PRS;PRF;NEG;COND
 katma	ei katnud	V;ACT;PST;NEG;IND
-katma	ei olevat katetudp	V;PASS;PRS;PRF;NEG;QUOT
+katma	ei olevat katetud	V;PASS;PRS;PRF;NEG;QUOT
 katma	ei kataks	V;ACT;PRS;PRF;POS;COND;1;SG
 katma	katetud	V.PTCP;PASS;PST
 katma	olid katnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -7227,7 +7227,7 @@ katma	olgu katetud	V;PASS;PRS;PRF;POS;IMP
 katma	kataks	V;ACT;PRS;POS;COND;3;SG
 katma	katku	V;ACT;PRS;POS;IMP;3;PL
 katma	ärgu olgu katnud	V;ACT;PRS;PRF;NEG;IMP;SG
-katma	ei ole katnudp	V;ACT;PST;NEG;IND
+katma	ei ole katnud	V;ACT;PST;NEG;IND
 katma	katad	V;ACT;PRS;POS;IND;2;SG
 katma	ära kata	V;ACT;PRS;NEG;IMP;2;SG
 katma	ei kata	V;ACT;PRS;NEG;IND
@@ -7255,17 +7255,17 @@ katma	ei kateta	V;PASS;PRS;NEG;IND
 katma	katame	V;ACT;PRS;POS;IND;1;PL
 katma	katan	V;ACT;PRS;POS;IND;1;SG
 katma	ärgem katkem	V;ACT;PRS;NEG;IMP;1;PL
-katma	ei oleks katnudp	V;ACT;PRS;PRF;NEG;COND
+katma	ei oleks katnud	V;ACT;PRS;PRF;NEG;COND
 katma	oleksid katnud	V;ACT;PRS;PRF;POS;COND;3;PL
 katma	katsite	V;ACT;PST;POS;IND;2;PL
 katma	oleks katnud	V;ACT;PRS;PRF;POS;COND;3;SG
 katma	olin katnud	V;ACT;PRS;PRF;POS;COND;1;SG
 katma	oled katnud	V;ACT;PRS;PRF;POS;IND;2;SG
 katma	oli katnud	V;ACT;PRS;PRF;POS;COND;3;SG
-katma	ei ole katetudp	V;PASS;PRS;PRF;NEG;IND
+katma	ei ole katetud	V;PASS;PRS;PRF;NEG;IND
 katma	kataksin	V;ACT;PRS;POS;COND;1;SG
 katma	olen katnud	V;ACT;PRS;PRF;POS;IND;1;SG
-katma	ei olnud katetudp	V;PASS;PST;PRF;NEG;IND
+katma	ei olnud katetud	V;PASS;PST;PRF;NEG;IND
 katma	ärgu olgu katetud	V;PASS;PRS;PRF;NEG;IMP
 
 katus	katuseni	N;TERM;SG
@@ -7548,7 +7548,7 @@ keeleteadus	keeleteadustesse	N;IN+ALL;PL
 keeleteadus	keeleteadustelt	N;AT+ABL;PL
 
 keema	olete keenud	V;ACT;PRS;PRF;POS;IND;2;PL
-keema	ei olevat keenudp	V;ACT;PRS;PRF;NEG;QUOT
+keema	ei olevat keenud	V;ACT;PRS;PRF;NEG;QUOT
 keema	oleks keedud	V;PASS;PRS;PRF;POS;COND
 keema	keesin	V;ACT;PST;POS;IND;1;SG
 keema	keedakse	V;PASS;PRS;POS;IND
@@ -7557,7 +7557,7 @@ keema	keedagu	V;PASS;PRS;POS;IMP
 keema	ärgu keegu	V;ACT;PRS;NEG;IMP;3;SG
 keema	oli keedud	V;PASS;PST;PRF;POS;IND
 keema	keesime	V;ACT;PST;POS;IND;1;PL
-keema	ei olnud keenudp	V;ACT;PST;PRF;NEG;IND
+keema	ei olnud keenud	V;ACT;PST;PRF;NEG;IND
 keema	oleksid keenud	V;ACT;PRS;PRF;POS;COND;2;SG
 keema	olgu keenud	V;ACT;PRS;PRF;POS;IMP;PL
 keema	oli keenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -7571,9 +7571,9 @@ keema	ärgu keegu	V;ACT;PRS;NEG;IMP;3;PL
 keema	olgu keenud	V;ACT;PRS;PRF;POS;IMP;SG
 keema	keedi	V;PASS;PST;POS;IND
 keema	ei keevat	V;ACT;PRS;NEG;QUOT
-keema	ei oleks keedudp	V;PASS;PRS;PRF;NEG;COND
+keema	ei oleks keedud	V;PASS;PRS;PRF;NEG;COND
 keema	ei keenud	V;ACT;PST;NEG;IND
-keema	ei olevat keedudp	V;PASS;PRS;PRF;NEG;QUOT
+keema	ei olevat keedud	V;PASS;PRS;PRF;NEG;QUOT
 keema	ei keeks	V;ACT;PRS;PRF;POS;COND;1;SG
 keema	keedud	V.PTCP;PASS;PST
 keema	olid keenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -7592,7 +7592,7 @@ keema	olgu keedud	V;PASS;PRS;PRF;POS;IMP
 keema	keeks	V;ACT;PRS;POS;COND;3;SG
 keema	keegu	V;ACT;PRS;POS;IMP;3;PL
 keema	ärgu olgu keenud	V;ACT;PRS;PRF;NEG;IMP;SG
-keema	ei ole keenudp	V;ACT;PST;NEG;IND
+keema	ei ole keenud	V;ACT;PST;NEG;IND
 keema	keed	V;ACT;PRS;POS;IND;2;SG
 keema	ära kee	V;ACT;PRS;NEG;IMP;2;SG
 keema	ei kee	V;ACT;PRS;NEG;IND
@@ -7620,17 +7620,17 @@ keema	ei keeda	V;PASS;PRS;NEG;IND
 keema	keeme	V;ACT;PRS;POS;IND;1;PL
 keema	keen	V;ACT;PRS;POS;IND;1;SG
 keema	ärgem keegem	V;ACT;PRS;NEG;IMP;1;PL
-keema	ei oleks keenudp	V;ACT;PRS;PRF;NEG;COND
+keema	ei oleks keenud	V;ACT;PRS;PRF;NEG;COND
 keema	oleksid keenud	V;ACT;PRS;PRF;POS;COND;3;PL
 keema	keesite	V;ACT;PST;POS;IND;2;PL
 keema	oleks keenud	V;ACT;PRS;PRF;POS;COND;3;SG
 keema	olin keenud	V;ACT;PRS;PRF;POS;COND;1;SG
 keema	oled keenud	V;ACT;PRS;PRF;POS;IND;2;SG
 keema	oli keenud	V;ACT;PRS;PRF;POS;COND;3;SG
-keema	ei ole keedudp	V;PASS;PRS;PRF;NEG;IND
+keema	ei ole keedud	V;PASS;PRS;PRF;NEG;IND
 keema	keeksin	V;ACT;PRS;POS;COND;1;SG
 keema	olen keenud	V;ACT;PRS;PRF;POS;IND;1;SG
-keema	ei olnud keedudp	V;PASS;PST;PRF;NEG;IND
+keema	ei olnud keedud	V;PASS;PST;PRF;NEG;IND
 keema	ärgu olgu keedud	V;PASS;PRS;PRF;NEG;IMP
 
 keemik	keemikuni	N;TERM;SG
@@ -7665,7 +7665,7 @@ keemik	keemikutesse	N;IN+ALL;PL
 keemik	keemikutelt	N;AT+ABL;PL
 
 keerama	olete keeranud	V;ACT;PRS;PRF;POS;IND;2;PL
-keerama	ei olevat keeranudp	V;ACT;PRS;PRF;NEG;QUOT
+keerama	ei olevat keeranud	V;ACT;PRS;PRF;NEG;QUOT
 keerama	oleks keeratud	V;PASS;PRS;PRF;POS;COND
 keerama	keerasin	V;ACT;PST;POS;IND;1;SG
 keerama	keeratakse	V;PASS;PRS;POS;IND
@@ -7674,7 +7674,7 @@ keerama	keeratagu	V;PASS;PRS;POS;IMP
 keerama	ärgu keeraku	V;ACT;PRS;NEG;IMP;3;SG
 keerama	oli keeratud	V;PASS;PST;PRF;POS;IND
 keerama	keerasime	V;ACT;PST;POS;IND;1;PL
-keerama	ei olnud keeranudp	V;ACT;PST;PRF;NEG;IND
+keerama	ei olnud keeranud	V;ACT;PST;PRF;NEG;IND
 keerama	oleksid keeranud	V;ACT;PRS;PRF;POS;COND;2;SG
 keerama	olgu keeranud	V;ACT;PRS;PRF;POS;IMP;PL
 keerama	oli keeranud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -7688,9 +7688,9 @@ keerama	ärgu keeraku	V;ACT;PRS;NEG;IMP;3;PL
 keerama	olgu keeranud	V;ACT;PRS;PRF;POS;IMP;SG
 keerama	keerati	V;PASS;PST;POS;IND
 keerama	ei keeravat	V;ACT;PRS;NEG;QUOT
-keerama	ei oleks keeratudp	V;PASS;PRS;PRF;NEG;COND
+keerama	ei oleks keeratud	V;PASS;PRS;PRF;NEG;COND
 keerama	ei keeranud	V;ACT;PST;NEG;IND
-keerama	ei olevat keeratudp	V;PASS;PRS;PRF;NEG;QUOT
+keerama	ei olevat keeratud	V;PASS;PRS;PRF;NEG;QUOT
 keerama	ei keeraks	V;ACT;PRS;PRF;POS;COND;1;SG
 keerama	keeratud	V.PTCP;PASS;PST
 keerama	olid keeranud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -7709,7 +7709,7 @@ keerama	olgu keeratud	V;PASS;PRS;PRF;POS;IMP
 keerama	keeraks	V;ACT;PRS;POS;COND;3;SG
 keerama	keeraku	V;ACT;PRS;POS;IMP;3;PL
 keerama	ärgu olgu keeranud	V;ACT;PRS;PRF;NEG;IMP;SG
-keerama	ei ole keeranudp	V;ACT;PST;NEG;IND
+keerama	ei ole keeranud	V;ACT;PST;NEG;IND
 keerama	keerad	V;ACT;PRS;POS;IND;2;SG
 keerama	ära keera	V;ACT;PRS;NEG;IMP;2;SG
 keerama	ei keera	V;ACT;PRS;NEG;IND
@@ -7737,17 +7737,17 @@ keerama	ei keerata	V;PASS;PRS;NEG;IND
 keerama	keerame	V;ACT;PRS;POS;IND;1;PL
 keerama	keeran	V;ACT;PRS;POS;IND;1;SG
 keerama	ärgem keerakem	V;ACT;PRS;NEG;IMP;1;PL
-keerama	ei oleks keeranudp	V;ACT;PRS;PRF;NEG;COND
+keerama	ei oleks keeranud	V;ACT;PRS;PRF;NEG;COND
 keerama	oleksid keeranud	V;ACT;PRS;PRF;POS;COND;3;PL
 keerama	keerasite	V;ACT;PST;POS;IND;2;PL
 keerama	oleks keeranud	V;ACT;PRS;PRF;POS;COND;3;SG
 keerama	olin keeranud	V;ACT;PRS;PRF;POS;COND;1;SG
 keerama	oled keeranud	V;ACT;PRS;PRF;POS;IND;2;SG
 keerama	oli keeranud	V;ACT;PRS;PRF;POS;COND;3;SG
-keerama	ei ole keeratudp	V;PASS;PRS;PRF;NEG;IND
+keerama	ei ole keeratud	V;PASS;PRS;PRF;NEG;IND
 keerama	keeraksin	V;ACT;PRS;POS;COND;1;SG
 keerama	olen keeranud	V;ACT;PRS;PRF;POS;IND;1;SG
-keerama	ei olnud keeratudp	V;PASS;PST;PRF;NEG;IND
+keerama	ei olnud keeratud	V;PASS;PST;PRF;NEG;IND
 keerama	ärgu olgu keeratud	V;PASS;PRS;PRF;NEG;IMP
 
 keha	kehani	N;TERM;SG
@@ -7813,7 +7813,7 @@ keiser	keisritesse	N;IN+ALL;PL
 keiser	keisritelt	N;AT+ABL;PL
 
 keppima	olete keppinud	V;ACT;PRS;PRF;POS;IND;2;PL
-keppima	ei olevat keppinudp	V;ACT;PRS;PRF;NEG;QUOT
+keppima	ei olevat keppinud	V;ACT;PRS;PRF;NEG;QUOT
 keppima	oleks kepitud	V;PASS;PRS;PRF;POS;COND
 keppima	keppisin	V;ACT;PST;POS;IND;1;SG
 keppima	kepitakse	V;PASS;PRS;POS;IND
@@ -7822,7 +7822,7 @@ keppima	kepitagu	V;PASS;PRS;POS;IMP
 keppima	ärgu keppigu	V;ACT;PRS;NEG;IMP;3;SG
 keppima	oli kepitud	V;PASS;PST;PRF;POS;IND
 keppima	keppisime	V;ACT;PST;POS;IND;1;PL
-keppima	ei olnud keppinudp	V;ACT;PST;PRF;NEG;IND
+keppima	ei olnud keppinud	V;ACT;PST;PRF;NEG;IND
 keppima	oleksid keppinud	V;ACT;PRS;PRF;POS;COND;2;SG
 keppima	olgu keppinud	V;ACT;PRS;PRF;POS;IMP;PL
 keppima	oli keppinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -7836,9 +7836,9 @@ keppima	ärgu keppigu	V;ACT;PRS;NEG;IMP;3;PL
 keppima	olgu keppinud	V;ACT;PRS;PRF;POS;IMP;SG
 keppima	kepiti	V;PASS;PST;POS;IND
 keppima	ei keppivat	V;ACT;PRS;NEG;QUOT
-keppima	ei oleks kepitudp	V;PASS;PRS;PRF;NEG;COND
+keppima	ei oleks kepitud	V;PASS;PRS;PRF;NEG;COND
 keppima	ei keppinud	V;ACT;PST;NEG;IND
-keppima	ei olevat kepitudp	V;PASS;PRS;PRF;NEG;QUOT
+keppima	ei olevat kepitud	V;PASS;PRS;PRF;NEG;QUOT
 keppima	ei kepiks	V;ACT;PRS;PRF;POS;COND;1;SG
 keppima	kepitud	V.PTCP;PASS;PST
 keppima	olid keppinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -7857,7 +7857,7 @@ keppima	olgu kepitud	V;PASS;PRS;PRF;POS;IMP
 keppima	kepiks	V;ACT;PRS;POS;COND;3;SG
 keppima	keppigu	V;ACT;PRS;POS;IMP;3;PL
 keppima	ärgu olgu keppinud	V;ACT;PRS;PRF;NEG;IMP;SG
-keppima	ei ole keppinudp	V;ACT;PST;NEG;IND
+keppima	ei ole keppinud	V;ACT;PST;NEG;IND
 keppima	kepid	V;ACT;PRS;POS;IND;2;SG
 keppima	ära kepi	V;ACT;PRS;NEG;IMP;2;SG
 keppima	ei kepi	V;ACT;PRS;NEG;IND
@@ -7885,17 +7885,17 @@ keppima	ei kepita	V;PASS;PRS;NEG;IND
 keppima	kepime	V;ACT;PRS;POS;IND;1;PL
 keppima	kepin	V;ACT;PRS;POS;IND;1;SG
 keppima	ärgem keppigem	V;ACT;PRS;NEG;IMP;1;PL
-keppima	ei oleks keppinudp	V;ACT;PRS;PRF;NEG;COND
+keppima	ei oleks keppinud	V;ACT;PRS;PRF;NEG;COND
 keppima	oleksid keppinud	V;ACT;PRS;PRF;POS;COND;3;PL
 keppima	keppisite	V;ACT;PST;POS;IND;2;PL
 keppima	oleks keppinud	V;ACT;PRS;PRF;POS;COND;3;SG
 keppima	olin keppinud	V;ACT;PRS;PRF;POS;COND;1;SG
 keppima	oled keppinud	V;ACT;PRS;PRF;POS;IND;2;SG
 keppima	oli keppinud	V;ACT;PRS;PRF;POS;COND;3;SG
-keppima	ei ole kepitudp	V;PASS;PRS;PRF;NEG;IND
+keppima	ei ole kepitud	V;PASS;PRS;PRF;NEG;IND
 keppima	kepiksin	V;ACT;PRS;POS;COND;1;SG
 keppima	olen keppinud	V;ACT;PRS;PRF;POS;IND;1;SG
-keppima	ei olnud kepitudp	V;PASS;PST;PRF;NEG;IND
+keppima	ei olnud kepitud	V;PASS;PST;PRF;NEG;IND
 keppima	ärgu olgu kepitud	V;PASS;PRS;PRF;NEG;IMP
 
 keraamik	keraamikuni	N;TERM;SG
@@ -7930,7 +7930,7 @@ keraamik	keraamikutesse	N;IN+ALL;PL
 keraamik	keraamikutelt	N;AT+ABL;PL
 
 kerjama	olete kerjanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kerjama	ei olevat kerjanudp	V;ACT;PRS;PRF;NEG;QUOT
+kerjama	ei olevat kerjanud	V;ACT;PRS;PRF;NEG;QUOT
 kerjama	oleks kerjatud	V;PASS;PRS;PRF;POS;COND
 kerjama	kerjasin	V;ACT;PST;POS;IND;1;SG
 kerjama	kerjatakse	V;PASS;PRS;POS;IND
@@ -7939,7 +7939,7 @@ kerjama	kerjatagu	V;PASS;PRS;POS;IMP
 kerjama	ärgu kerjaku	V;ACT;PRS;NEG;IMP;3;SG
 kerjama	oli kerjatud	V;PASS;PST;PRF;POS;IND
 kerjama	kerjasime	V;ACT;PST;POS;IND;1;PL
-kerjama	ei olnud kerjanudp	V;ACT;PST;PRF;NEG;IND
+kerjama	ei olnud kerjanud	V;ACT;PST;PRF;NEG;IND
 kerjama	oleksid kerjanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kerjama	olgu kerjanud	V;ACT;PRS;PRF;POS;IMP;PL
 kerjama	oli kerjanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -7953,9 +7953,9 @@ kerjama	ärgu kerjaku	V;ACT;PRS;NEG;IMP;3;PL
 kerjama	olgu kerjanud	V;ACT;PRS;PRF;POS;IMP;SG
 kerjama	kerjati	V;PASS;PST;POS;IND
 kerjama	ei kerjavat	V;ACT;PRS;NEG;QUOT
-kerjama	ei oleks kerjatudp	V;PASS;PRS;PRF;NEG;COND
+kerjama	ei oleks kerjatud	V;PASS;PRS;PRF;NEG;COND
 kerjama	ei kerjanud	V;ACT;PST;NEG;IND
-kerjama	ei olevat kerjatudp	V;PASS;PRS;PRF;NEG;QUOT
+kerjama	ei olevat kerjatud	V;PASS;PRS;PRF;NEG;QUOT
 kerjama	ei kerjaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kerjama	kerjatud	V.PTCP;PASS;PST
 kerjama	olid kerjanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -7974,7 +7974,7 @@ kerjama	olgu kerjatud	V;PASS;PRS;PRF;POS;IMP
 kerjama	kerjaks	V;ACT;PRS;POS;COND;3;SG
 kerjama	kerjaku	V;ACT;PRS;POS;IMP;3;PL
 kerjama	ärgu olgu kerjanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kerjama	ei ole kerjanudp	V;ACT;PST;NEG;IND
+kerjama	ei ole kerjanud	V;ACT;PST;NEG;IND
 kerjama	kerjad	V;ACT;PRS;POS;IND;2;SG
 kerjama	ära kerja	V;ACT;PRS;NEG;IMP;2;SG
 kerjama	ei kerja	V;ACT;PRS;NEG;IND
@@ -8002,17 +8002,17 @@ kerjama	ei kerjata	V;PASS;PRS;NEG;IND
 kerjama	kerjame	V;ACT;PRS;POS;IND;1;PL
 kerjama	kerjan	V;ACT;PRS;POS;IND;1;SG
 kerjama	ärgem kerjakem	V;ACT;PRS;NEG;IMP;1;PL
-kerjama	ei oleks kerjanudp	V;ACT;PRS;PRF;NEG;COND
+kerjama	ei oleks kerjanud	V;ACT;PRS;PRF;NEG;COND
 kerjama	oleksid kerjanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kerjama	kerjasite	V;ACT;PST;POS;IND;2;PL
 kerjama	oleks kerjanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kerjama	olin kerjanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kerjama	oled kerjanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kerjama	oli kerjanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kerjama	ei ole kerjatudp	V;PASS;PRS;PRF;NEG;IND
+kerjama	ei ole kerjatud	V;PASS;PRS;PRF;NEG;IND
 kerjama	kerjaksin	V;ACT;PRS;POS;COND;1;SG
 kerjama	olen kerjanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kerjama	ei olnud kerjatudp	V;PASS;PST;PRF;NEG;IND
+kerjama	ei olnud kerjatud	V;PASS;PST;PRF;NEG;IND
 kerjama	ärgu olgu kerjatud	V;PASS;PRS;PRF;NEG;IMP
 
 kesa	kesani	N;TERM;SG
@@ -8171,7 +8171,7 @@ kesköö	kesköödesse	N;IN+ALL;PL
 kesköö	kesköödelt	N;AT+ABL;PL
 
 kihutama	olete kihutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kihutama	ei olevat kihutanudp	V;ACT;PRS;PRF;NEG;QUOT
+kihutama	ei olevat kihutanud	V;ACT;PRS;PRF;NEG;QUOT
 kihutama	oleks kihutatud	V;PASS;PRS;PRF;POS;COND
 kihutama	kihutasin	V;ACT;PST;POS;IND;1;SG
 kihutama	kihutatakse	V;PASS;PRS;POS;IND
@@ -8180,7 +8180,7 @@ kihutama	kihutatagu	V;PASS;PRS;POS;IMP
 kihutama	ärgu kihutagu	V;ACT;PRS;NEG;IMP;3;SG
 kihutama	oli kihutatud	V;PASS;PST;PRF;POS;IND
 kihutama	kihutasime	V;ACT;PST;POS;IND;1;PL
-kihutama	ei olnud kihutanudp	V;ACT;PST;PRF;NEG;IND
+kihutama	ei olnud kihutanud	V;ACT;PST;PRF;NEG;IND
 kihutama	oleksid kihutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kihutama	olgu kihutanud	V;ACT;PRS;PRF;POS;IMP;PL
 kihutama	oli kihutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -8194,9 +8194,9 @@ kihutama	ärgu kihutagu	V;ACT;PRS;NEG;IMP;3;PL
 kihutama	olgu kihutanud	V;ACT;PRS;PRF;POS;IMP;SG
 kihutama	kihutati	V;PASS;PST;POS;IND
 kihutama	ei kihutavat	V;ACT;PRS;NEG;QUOT
-kihutama	ei oleks kihutatudp	V;PASS;PRS;PRF;NEG;COND
+kihutama	ei oleks kihutatud	V;PASS;PRS;PRF;NEG;COND
 kihutama	ei kihutanud	V;ACT;PST;NEG;IND
-kihutama	ei olevat kihutatudp	V;PASS;PRS;PRF;NEG;QUOT
+kihutama	ei olevat kihutatud	V;PASS;PRS;PRF;NEG;QUOT
 kihutama	ei kihutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kihutama	kihutatud	V.PTCP;PASS;PST
 kihutama	olid kihutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -8215,7 +8215,7 @@ kihutama	olgu kihutatud	V;PASS;PRS;PRF;POS;IMP
 kihutama	kihutaks	V;ACT;PRS;POS;COND;3;SG
 kihutama	kihutagu	V;ACT;PRS;POS;IMP;3;PL
 kihutama	ärgu olgu kihutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kihutama	ei ole kihutanudp	V;ACT;PST;NEG;IND
+kihutama	ei ole kihutanud	V;ACT;PST;NEG;IND
 kihutama	kihutad	V;ACT;PRS;POS;IND;2;SG
 kihutama	ära kihuta	V;ACT;PRS;NEG;IMP;2;SG
 kihutama	ei kihuta	V;ACT;PRS;NEG;IND
@@ -8243,17 +8243,17 @@ kihutama	ei kihutata	V;PASS;PRS;NEG;IND
 kihutama	kihutame	V;ACT;PRS;POS;IND;1;PL
 kihutama	kihutan	V;ACT;PRS;POS;IND;1;SG
 kihutama	ärgem kihutagem	V;ACT;PRS;NEG;IMP;1;PL
-kihutama	ei oleks kihutanudp	V;ACT;PRS;PRF;NEG;COND
+kihutama	ei oleks kihutanud	V;ACT;PRS;PRF;NEG;COND
 kihutama	oleksid kihutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kihutama	kihutasite	V;ACT;PST;POS;IND;2;PL
 kihutama	oleks kihutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kihutama	olin kihutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kihutama	oled kihutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kihutama	oli kihutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kihutama	ei ole kihutatudp	V;PASS;PRS;PRF;NEG;IND
+kihutama	ei ole kihutatud	V;PASS;PRS;PRF;NEG;IND
 kihutama	kihutaksin	V;ACT;PRS;POS;COND;1;SG
 kihutama	olen kihutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kihutama	ei olnud kihutatudp	V;PASS;PST;PRF;NEG;IND
+kihutama	ei olnud kihutatud	V;PASS;PST;PRF;NEG;IND
 kihutama	ärgu olgu kihutatud	V;PASS;PRS;PRF;NEG;IMP
 
 kiilluu	kiilluuni	N;TERM;SG
@@ -8288,7 +8288,7 @@ kiilluu	kiilluudesse	N;IN+ALL;PL
 kiilluu	kiilluudelt	N;AT+ABL;PL
 
 kiirendama	olete kiirendanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kiirendama	ei olevat kiirendanudp	V;ACT;PRS;PRF;NEG;QUOT
+kiirendama	ei olevat kiirendanud	V;ACT;PRS;PRF;NEG;QUOT
 kiirendama	oleks kiirendatud	V;PASS;PRS;PRF;POS;COND
 kiirendama	kiirendasin	V;ACT;PST;POS;IND;1;SG
 kiirendama	kiirendatakse	V;PASS;PRS;POS;IND
@@ -8297,7 +8297,7 @@ kiirendama	kiirendatagu	V;PASS;PRS;POS;IMP
 kiirendama	ärgu kiirendagu	V;ACT;PRS;NEG;IMP;3;SG
 kiirendama	oli kiirendatud	V;PASS;PST;PRF;POS;IND
 kiirendama	kiirendasime	V;ACT;PST;POS;IND;1;PL
-kiirendama	ei olnud kiirendanudp	V;ACT;PST;PRF;NEG;IND
+kiirendama	ei olnud kiirendanud	V;ACT;PST;PRF;NEG;IND
 kiirendama	oleksid kiirendanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kiirendama	olgu kiirendanud	V;ACT;PRS;PRF;POS;IMP;PL
 kiirendama	oli kiirendanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -8311,9 +8311,9 @@ kiirendama	ärgu kiirendagu	V;ACT;PRS;NEG;IMP;3;PL
 kiirendama	olgu kiirendanud	V;ACT;PRS;PRF;POS;IMP;SG
 kiirendama	kiirendati	V;PASS;PST;POS;IND
 kiirendama	ei kiirendavat	V;ACT;PRS;NEG;QUOT
-kiirendama	ei oleks kiirendatudp	V;PASS;PRS;PRF;NEG;COND
+kiirendama	ei oleks kiirendatud	V;PASS;PRS;PRF;NEG;COND
 kiirendama	ei kiirendanud	V;ACT;PST;NEG;IND
-kiirendama	ei olevat kiirendatudp	V;PASS;PRS;PRF;NEG;QUOT
+kiirendama	ei olevat kiirendatud	V;PASS;PRS;PRF;NEG;QUOT
 kiirendama	ei kiirendaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kiirendama	kiirendatud	V.PTCP;PASS;PST
 kiirendama	olid kiirendanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -8332,7 +8332,7 @@ kiirendama	olgu kiirendatud	V;PASS;PRS;PRF;POS;IMP
 kiirendama	kiirendaks	V;ACT;PRS;POS;COND;3;SG
 kiirendama	kiirendagu	V;ACT;PRS;POS;IMP;3;PL
 kiirendama	ärgu olgu kiirendanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kiirendama	ei ole kiirendanudp	V;ACT;PST;NEG;IND
+kiirendama	ei ole kiirendanud	V;ACT;PST;NEG;IND
 kiirendama	kiirendad	V;ACT;PRS;POS;IND;2;SG
 kiirendama	ära kiirenda	V;ACT;PRS;NEG;IMP;2;SG
 kiirendama	ei kiirenda	V;ACT;PRS;NEG;IND
@@ -8360,17 +8360,17 @@ kiirendama	ei kiirendata	V;PASS;PRS;NEG;IND
 kiirendama	kiirendame	V;ACT;PRS;POS;IND;1;PL
 kiirendama	kiirendan	V;ACT;PRS;POS;IND;1;SG
 kiirendama	ärgem kiirendagem	V;ACT;PRS;NEG;IMP;1;PL
-kiirendama	ei oleks kiirendanudp	V;ACT;PRS;PRF;NEG;COND
+kiirendama	ei oleks kiirendanud	V;ACT;PRS;PRF;NEG;COND
 kiirendama	oleksid kiirendanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kiirendama	kiirendasite	V;ACT;PST;POS;IND;2;PL
 kiirendama	oleks kiirendanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kiirendama	olin kiirendanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kiirendama	oled kiirendanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kiirendama	oli kiirendanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kiirendama	ei ole kiirendatudp	V;PASS;PRS;PRF;NEG;IND
+kiirendama	ei ole kiirendatud	V;PASS;PRS;PRF;NEG;IND
 kiirendama	kiirendaksin	V;ACT;PRS;POS;COND;1;SG
 kiirendama	olen kiirendanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kiirendama	ei olnud kiirendatudp	V;PASS;PST;PRF;NEG;IND
+kiirendama	ei olnud kiirendatud	V;PASS;PST;PRF;NEG;IND
 kiirendama	ärgu olgu kiirendatud	V;PASS;PRS;PRF;NEG;IMP
 
 kiirendus	kiirenduseni	N;TERM;SG
@@ -8498,7 +8498,7 @@ kiiruspiirik	kiiruspiirikutesse	N;IN+ALL;PL
 kiiruspiirik	kiiruspiirikutelt	N;AT+ABL;PL
 
 kiitma	olete kiitnud	V;ACT;PRS;PRF;POS;IND;2;PL
-kiitma	ei olevat kiitnudp	V;ACT;PRS;PRF;NEG;QUOT
+kiitma	ei olevat kiitnud	V;ACT;PRS;PRF;NEG;QUOT
 kiitma	oleks kiidetud	V;PASS;PRS;PRF;POS;COND
 kiitma	kiitsin	V;ACT;PST;POS;IND;1;SG
 kiitma	kiidetakse	V;PASS;PRS;POS;IND
@@ -8507,7 +8507,7 @@ kiitma	kiidetagu	V;PASS;PRS;POS;IMP
 kiitma	ärgu kiitku	V;ACT;PRS;NEG;IMP;3;SG
 kiitma	oli kiidetud	V;PASS;PST;PRF;POS;IND
 kiitma	kiitsime	V;ACT;PST;POS;IND;1;PL
-kiitma	ei olnud kiitnudp	V;ACT;PST;PRF;NEG;IND
+kiitma	ei olnud kiitnud	V;ACT;PST;PRF;NEG;IND
 kiitma	oleksid kiitnud	V;ACT;PRS;PRF;POS;COND;2;SG
 kiitma	olgu kiitnud	V;ACT;PRS;PRF;POS;IMP;PL
 kiitma	oli kiitnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -8521,9 +8521,9 @@ kiitma	ärgu kiitku	V;ACT;PRS;NEG;IMP;3;PL
 kiitma	olgu kiitnud	V;ACT;PRS;PRF;POS;IMP;SG
 kiitma	kiideti	V;PASS;PST;POS;IND
 kiitma	ei kiitvat	V;ACT;PRS;NEG;QUOT
-kiitma	ei oleks kiidetudp	V;PASS;PRS;PRF;NEG;COND
+kiitma	ei oleks kiidetud	V;PASS;PRS;PRF;NEG;COND
 kiitma	ei kiitnud	V;ACT;PST;NEG;IND
-kiitma	ei olevat kiidetudp	V;PASS;PRS;PRF;NEG;QUOT
+kiitma	ei olevat kiidetud	V;PASS;PRS;PRF;NEG;QUOT
 kiitma	ei kiidaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kiitma	kiidetud	V.PTCP;PASS;PST
 kiitma	olid kiitnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -8542,7 +8542,7 @@ kiitma	olgu kiidetud	V;PASS;PRS;PRF;POS;IMP
 kiitma	kiidaks	V;ACT;PRS;POS;COND;3;SG
 kiitma	kiitku	V;ACT;PRS;POS;IMP;3;PL
 kiitma	ärgu olgu kiitnud	V;ACT;PRS;PRF;NEG;IMP;SG
-kiitma	ei ole kiitnudp	V;ACT;PST;NEG;IND
+kiitma	ei ole kiitnud	V;ACT;PST;NEG;IND
 kiitma	kiidad	V;ACT;PRS;POS;IND;2;SG
 kiitma	ära kiida	V;ACT;PRS;NEG;IMP;2;SG
 kiitma	ei kiida	V;ACT;PRS;NEG;IND
@@ -8570,17 +8570,17 @@ kiitma	ei kiideta	V;PASS;PRS;NEG;IND
 kiitma	kiidame	V;ACT;PRS;POS;IND;1;PL
 kiitma	kiidan	V;ACT;PRS;POS;IND;1;SG
 kiitma	ärgem kiitkem	V;ACT;PRS;NEG;IMP;1;PL
-kiitma	ei oleks kiitnudp	V;ACT;PRS;PRF;NEG;COND
+kiitma	ei oleks kiitnud	V;ACT;PRS;PRF;NEG;COND
 kiitma	oleksid kiitnud	V;ACT;PRS;PRF;POS;COND;3;PL
 kiitma	kiitsite	V;ACT;PST;POS;IND;2;PL
 kiitma	oleks kiitnud	V;ACT;PRS;PRF;POS;COND;3;SG
 kiitma	olin kiitnud	V;ACT;PRS;PRF;POS;COND;1;SG
 kiitma	oled kiitnud	V;ACT;PRS;PRF;POS;IND;2;SG
 kiitma	oli kiitnud	V;ACT;PRS;PRF;POS;COND;3;SG
-kiitma	ei ole kiidetudp	V;PASS;PRS;PRF;NEG;IND
+kiitma	ei ole kiidetud	V;PASS;PRS;PRF;NEG;IND
 kiitma	kiidaksin	V;ACT;PRS;POS;COND;1;SG
 kiitma	olen kiitnud	V;ACT;PRS;PRF;POS;IND;1;SG
-kiitma	ei olnud kiidetudp	V;PASS;PST;PRF;NEG;IND
+kiitma	ei olnud kiidetud	V;PASS;PST;PRF;NEG;IND
 kiitma	ärgu olgu kiidetud	V;PASS;PRS;PRF;NEG;IMP
 
 kinaver	kinaverini	N;TERM;SG
@@ -8677,7 +8677,7 @@ kindralmajor	kindralmajoritesse	N;IN+ALL;PL
 kindralmajor	kindralmajoritelt	N;AT+ABL;PL
 
 kinkima	olete kinkinud	V;ACT;PRS;PRF;POS;IND;2;PL
-kinkima	ei olevat kinkinudp	V;ACT;PRS;PRF;NEG;QUOT
+kinkima	ei olevat kinkinud	V;ACT;PRS;PRF;NEG;QUOT
 kinkima	oleks kingitud	V;PASS;PRS;PRF;POS;COND
 kinkima	kinkisin	V;ACT;PST;POS;IND;1;SG
 kinkima	kingitakse	V;PASS;PRS;POS;IND
@@ -8686,7 +8686,7 @@ kinkima	kingitagu	V;PASS;PRS;POS;IMP
 kinkima	ärgu kinkigu	V;ACT;PRS;NEG;IMP;3;SG
 kinkima	oli kingitud	V;PASS;PST;PRF;POS;IND
 kinkima	kinkisime	V;ACT;PST;POS;IND;1;PL
-kinkima	ei olnud kinkinudp	V;ACT;PST;PRF;NEG;IND
+kinkima	ei olnud kinkinud	V;ACT;PST;PRF;NEG;IND
 kinkima	oleksid kinkinud	V;ACT;PRS;PRF;POS;COND;2;SG
 kinkima	olgu kinkinud	V;ACT;PRS;PRF;POS;IMP;PL
 kinkima	oli kinkinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -8700,9 +8700,9 @@ kinkima	ärgu kinkigu	V;ACT;PRS;NEG;IMP;3;PL
 kinkima	olgu kinkinud	V;ACT;PRS;PRF;POS;IMP;SG
 kinkima	kingiti	V;PASS;PST;POS;IND
 kinkima	ei kinkivat	V;ACT;PRS;NEG;QUOT
-kinkima	ei oleks kingitudp	V;PASS;PRS;PRF;NEG;COND
+kinkima	ei oleks kingitud	V;PASS;PRS;PRF;NEG;COND
 kinkima	ei kin	V;ACT;PST;NEG;IND
-kinkima	ei olevat kingitudp	V;PASS;PRS;PRF;NEG;QUOT
+kinkima	ei olevat kingitud	V;PASS;PRS;PRF;NEG;QUOT
 kinkima	ei kingiks	V;ACT;PRS;PRF;POS;COND;1;SG
 kinkima	kingitud	V.PTCP;PASS;PST
 kinkima	olid kinkinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -8721,7 +8721,7 @@ kinkima	olgu kingitud	V;PASS;PRS;PRF;POS;IMP
 kinkima	kingiks	V;ACT;PRS;POS;COND;3;SG
 kinkima	kinkigu	V;ACT;PRS;POS;IMP;3;PL
 kinkima	ärgu olgu kinkinud	V;ACT;PRS;PRF;NEG;IMP;SG
-kinkima	ei ole kinkinudp	V;ACT;PST;NEG;IND
+kinkima	ei ole kinkinud	V;ACT;PST;NEG;IND
 kinkima	kingid	V;ACT;PRS;POS;IND;2;SG
 kinkima	ära kingi	V;ACT;PRS;NEG;IMP;2;SG
 kinkima	ei kingi	V;ACT;PRS;NEG;IND
@@ -8749,21 +8749,21 @@ kinkima	ei kingita	V;PASS;PRS;NEG;IND
 kinkima	kingime	V;ACT;PRS;POS;IND;1;PL
 kinkima	kingin	V;ACT;PRS;POS;IND;1;SG
 kinkima	ärgem kinkigem	V;ACT;PRS;NEG;IMP;1;PL
-kinkima	ei oleks kinkinudp	V;ACT;PRS;PRF;NEG;COND
+kinkima	ei oleks kinkinud	V;ACT;PRS;PRF;NEG;COND
 kinkima	oleksid kinkinud	V;ACT;PRS;PRF;POS;COND;3;PL
 kinkima	kinkisite	V;ACT;PST;POS;IND;2;PL
 kinkima	oleks kinkinud	V;ACT;PRS;PRF;POS;COND;3;SG
 kinkima	olin kinkinud	V;ACT;PRS;PRF;POS;COND;1;SG
 kinkima	oled kinkinud	V;ACT;PRS;PRF;POS;IND;2;SG
 kinkima	oli kinkinud	V;ACT;PRS;PRF;POS;COND;3;SG
-kinkima	ei ole kingitudp	V;PASS;PRS;PRF;NEG;IND
+kinkima	ei ole kingitud	V;PASS;PRS;PRF;NEG;IND
 kinkima	kingiksin	V;ACT;PRS;POS;COND;1;SG
 kinkima	olen kinkinud	V;ACT;PRS;PRF;POS;IND;1;SG
-kinkima	ei olnud kingitudp	V;PASS;PST;PRF;NEG;IND
+kinkima	ei olnud kingitud	V;PASS;PST;PRF;NEG;IND
 kinkima	ärgu olgu kingitud	V;PASS;PRS;PRF;NEG;IMP
 
 kinnitama	olete kinnitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kinnitama	ei olevat kinnitanudp	V;ACT;PRS;PRF;NEG;QUOT
+kinnitama	ei olevat kinnitanud	V;ACT;PRS;PRF;NEG;QUOT
 kinnitama	oleks kinnitatud	V;PASS;PRS;PRF;POS;COND
 kinnitama	kinnitasin	V;ACT;PST;POS;IND;1;SG
 kinnitama	kinnitatakse	V;PASS;PRS;POS;IND
@@ -8772,7 +8772,7 @@ kinnitama	kinnitatagu	V;PASS;PRS;POS;IMP
 kinnitama	ärgu kinnitagu	V;ACT;PRS;NEG;IMP;3;SG
 kinnitama	oli kinnitatud	V;PASS;PST;PRF;POS;IND
 kinnitama	kinnitasime	V;ACT;PST;POS;IND;1;PL
-kinnitama	ei olnud kinnitanudp	V;ACT;PST;PRF;NEG;IND
+kinnitama	ei olnud kinnitanud	V;ACT;PST;PRF;NEG;IND
 kinnitama	oleksid kinnitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kinnitama	olgu kinnitanud	V;ACT;PRS;PRF;POS;IMP;PL
 kinnitama	oli kinnitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -8786,9 +8786,9 @@ kinnitama	ärgu kinnitagu	V;ACT;PRS;NEG;IMP;3;PL
 kinnitama	olgu kinnitanud	V;ACT;PRS;PRF;POS;IMP;SG
 kinnitama	kinnitati	V;PASS;PST;POS;IND
 kinnitama	ei kinnitavat	V;ACT;PRS;NEG;QUOT
-kinnitama	ei oleks kinnitatudp	V;PASS;PRS;PRF;NEG;COND
+kinnitama	ei oleks kinnitatud	V;PASS;PRS;PRF;NEG;COND
 kinnitama	ei kinnitanud	V;ACT;PST;NEG;IND
-kinnitama	ei olevat kinnitatudp	V;PASS;PRS;PRF;NEG;QUOT
+kinnitama	ei olevat kinnitatud	V;PASS;PRS;PRF;NEG;QUOT
 kinnitama	ei kinnitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kinnitama	kinnitatud	V.PTCP;PASS;PST
 kinnitama	olid kinnitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -8807,7 +8807,7 @@ kinnitama	olgu kinnitatud	V;PASS;PRS;PRF;POS;IMP
 kinnitama	kinnitaks	V;ACT;PRS;POS;COND;3;SG
 kinnitama	kinnitagu	V;ACT;PRS;POS;IMP;3;PL
 kinnitama	ärgu olgu kinnitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kinnitama	ei ole kinnitanudp	V;ACT;PST;NEG;IND
+kinnitama	ei ole kinnitanud	V;ACT;PST;NEG;IND
 kinnitama	kinnitad	V;ACT;PRS;POS;IND;2;SG
 kinnitama	ära kinnita	V;ACT;PRS;NEG;IMP;2;SG
 kinnitama	ei kinnita	V;ACT;PRS;NEG;IND
@@ -8835,21 +8835,21 @@ kinnitama	ei kinnitata	V;PASS;PRS;NEG;IND
 kinnitama	kinnitame	V;ACT;PRS;POS;IND;1;PL
 kinnitama	kinnitan	V;ACT;PRS;POS;IND;1;SG
 kinnitama	ärgem kinnitagem	V;ACT;PRS;NEG;IMP;1;PL
-kinnitama	ei oleks kinnitanudp	V;ACT;PRS;PRF;NEG;COND
+kinnitama	ei oleks kinnitanud	V;ACT;PRS;PRF;NEG;COND
 kinnitama	oleksid kinnitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kinnitama	kinnitasite	V;ACT;PST;POS;IND;2;PL
 kinnitama	oleks kinnitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kinnitama	olin kinnitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kinnitama	oled kinnitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kinnitama	oli kinnitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kinnitama	ei ole kinnitatudp	V;PASS;PRS;PRF;NEG;IND
+kinnitama	ei ole kinnitatud	V;PASS;PRS;PRF;NEG;IND
 kinnitama	kinnitaksin	V;ACT;PRS;POS;COND;1;SG
 kinnitama	olen kinnitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kinnitama	ei olnud kinnitatudp	V;PASS;PST;PRF;NEG;IND
+kinnitama	ei olnud kinnitatud	V;PASS;PST;PRF;NEG;IND
 kinnitama	ärgu olgu kinnitatud	V;PASS;PRS;PRF;NEG;IMP
 
 kippuma	olete kippunud	V;ACT;PRS;PRF;POS;IND;2;PL
-kippuma	ei olevat kippunudp	V;ACT;PRS;PRF;NEG;QUOT
+kippuma	ei olevat kippunud	V;ACT;PRS;PRF;NEG;QUOT
 kippuma	oleks kiputud	V;PASS;PRS;PRF;POS;COND
 kippuma	kippusin	V;ACT;PST;POS;IND;1;SG
 kippuma	kiputakse	V;PASS;PRS;POS;IND
@@ -8858,7 +8858,7 @@ kippuma	kiputagu	V;PASS;PRS;POS;IMP
 kippuma	ärgu kippugu	V;ACT;PRS;NEG;IMP;3;SG
 kippuma	oli kiputud	V;PASS;PST;PRF;POS;IND
 kippuma	kippusime	V;ACT;PST;POS;IND;1;PL
-kippuma	ei olnud kippunudp	V;ACT;PST;PRF;NEG;IND
+kippuma	ei olnud kippunud	V;ACT;PST;PRF;NEG;IND
 kippuma	oleksid kippunud	V;ACT;PRS;PRF;POS;COND;2;SG
 kippuma	olgu kippunud	V;ACT;PRS;PRF;POS;IMP;PL
 kippuma	oli kippunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -8872,9 +8872,9 @@ kippuma	ärgu kippugu	V;ACT;PRS;NEG;IMP;3;PL
 kippuma	olgu kippunud	V;ACT;PRS;PRF;POS;IMP;SG
 kippuma	kiputi	V;PASS;PST;POS;IND
 kippuma	ei kippuvat	V;ACT;PRS;NEG;QUOT
-kippuma	ei oleks kiputudp	V;PASS;PRS;PRF;NEG;COND
+kippuma	ei oleks kiputud	V;PASS;PRS;PRF;NEG;COND
 kippuma	ei kippunud	V;ACT;PST;NEG;IND
-kippuma	ei olevat kiputudp	V;PASS;PRS;PRF;NEG;QUOT
+kippuma	ei olevat kiputud	V;PASS;PRS;PRF;NEG;QUOT
 kippuma	ei kipuks	V;ACT;PRS;PRF;POS;COND;1;SG
 kippuma	kiputud	V.PTCP;PASS;PST
 kippuma	olid kippunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -8893,7 +8893,7 @@ kippuma	olgu kiputud	V;PASS;PRS;PRF;POS;IMP
 kippuma	kipuks	V;ACT;PRS;POS;COND;3;SG
 kippuma	kippugu	V;ACT;PRS;POS;IMP;3;PL
 kippuma	ärgu olgu kippunud	V;ACT;PRS;PRF;NEG;IMP;SG
-kippuma	ei ole kippunudp	V;ACT;PST;NEG;IND
+kippuma	ei ole kippunud	V;ACT;PST;NEG;IND
 kippuma	kipud	V;ACT;PRS;POS;IND;2;SG
 kippuma	ära kipu	V;ACT;PRS;NEG;IMP;2;SG
 kippuma	ei kipu	V;ACT;PRS;NEG;IND
@@ -8921,17 +8921,17 @@ kippuma	ei kiputa	V;PASS;PRS;NEG;IND
 kippuma	kipume	V;ACT;PRS;POS;IND;1;PL
 kippuma	kipun	V;ACT;PRS;POS;IND;1;SG
 kippuma	ärgem kippugem	V;ACT;PRS;NEG;IMP;1;PL
-kippuma	ei oleks kippunudp	V;ACT;PRS;PRF;NEG;COND
+kippuma	ei oleks kippunud	V;ACT;PRS;PRF;NEG;COND
 kippuma	oleksid kippunud	V;ACT;PRS;PRF;POS;COND;3;PL
 kippuma	kippusite	V;ACT;PST;POS;IND;2;PL
 kippuma	oleks kippunud	V;ACT;PRS;PRF;POS;COND;3;SG
 kippuma	olin kippunud	V;ACT;PRS;PRF;POS;COND;1;SG
 kippuma	oled kippunud	V;ACT;PRS;PRF;POS;IND;2;SG
 kippuma	oli kippunud	V;ACT;PRS;PRF;POS;COND;3;SG
-kippuma	ei ole kiputudp	V;PASS;PRS;PRF;NEG;IND
+kippuma	ei ole kiputud	V;PASS;PRS;PRF;NEG;IND
 kippuma	kipuksin	V;ACT;PRS;POS;COND;1;SG
 kippuma	olen kippunud	V;ACT;PRS;PRF;POS;IND;1;SG
-kippuma	ei olnud kiputudp	V;PASS;PST;PRF;NEG;IND
+kippuma	ei olnud kiputud	V;PASS;PST;PRF;NEG;IND
 kippuma	ärgu olgu kiputud	V;PASS;PRS;PRF;NEG;IMP
 
 kirik	kirikuni	N;TERM;SG
@@ -8966,7 +8966,7 @@ kirik	kirikutesse	N;IN+ALL;PL
 kirik	kirikutelt	N;AT+ABL;PL
 
 kirjutama	olete kirjutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kirjutama	ei olevat kirjutanudp	V;ACT;PRS;PRF;NEG;QUOT
+kirjutama	ei olevat kirjutanud	V;ACT;PRS;PRF;NEG;QUOT
 kirjutama	oleks kirjutatud	V;PASS;PRS;PRF;POS;COND
 kirjutama	kirjutasin	V;ACT;PST;POS;IND;1;SG
 kirjutama	kirjutatakse	V;PASS;PRS;POS;IND
@@ -8975,7 +8975,7 @@ kirjutama	kirjutatagu	V;PASS;PRS;POS;IMP
 kirjutama	ärgu kirjutagu	V;ACT;PRS;NEG;IMP;3;SG
 kirjutama	oli kirjutatud	V;PASS;PST;PRF;POS;IND
 kirjutama	kirjutasime	V;ACT;PST;POS;IND;1;PL
-kirjutama	ei olnud kirjutanudp	V;ACT;PST;PRF;NEG;IND
+kirjutama	ei olnud kirjutanud	V;ACT;PST;PRF;NEG;IND
 kirjutama	oleksid kirjutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kirjutama	olgu kirjutanud	V;ACT;PRS;PRF;POS;IMP;PL
 kirjutama	oli kirjutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -8989,9 +8989,9 @@ kirjutama	ärgu kirjutagu	V;ACT;PRS;NEG;IMP;3;PL
 kirjutama	olgu kirjutanud	V;ACT;PRS;PRF;POS;IMP;SG
 kirjutama	kirjutati	V;PASS;PST;POS;IND
 kirjutama	ei kirjutavat	V;ACT;PRS;NEG;QUOT
-kirjutama	ei oleks kirjutatudp	V;PASS;PRS;PRF;NEG;COND
+kirjutama	ei oleks kirjutatud	V;PASS;PRS;PRF;NEG;COND
 kirjutama	ei kirjutanud	V;ACT;PST;NEG;IND
-kirjutama	ei olevat kirjutatudp	V;PASS;PRS;PRF;NEG;QUOT
+kirjutama	ei olevat kirjutatud	V;PASS;PRS;PRF;NEG;QUOT
 kirjutama	ei kirjutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kirjutama	kirjutatud	V.PTCP;PASS;PST
 kirjutama	olid kirjutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -9010,7 +9010,7 @@ kirjutama	olgu kirjutatud	V;PASS;PRS;PRF;POS;IMP
 kirjutama	kirjutaks	V;ACT;PRS;POS;COND;3;SG
 kirjutama	kirjutagu	V;ACT;PRS;POS;IMP;3;PL
 kirjutama	ärgu olgu kirjutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kirjutama	ei ole kirjutanudp	V;ACT;PST;NEG;IND
+kirjutama	ei ole kirjutanud	V;ACT;PST;NEG;IND
 kirjutama	kirjutad	V;ACT;PRS;POS;IND;2;SG
 kirjutama	ära kirjuta	V;ACT;PRS;NEG;IMP;2;SG
 kirjutama	ei kirjuta	V;ACT;PRS;NEG;IND
@@ -9038,17 +9038,17 @@ kirjutama	ei kirjutata	V;PASS;PRS;NEG;IND
 kirjutama	kirjutame	V;ACT;PRS;POS;IND;1;PL
 kirjutama	kirjutan	V;ACT;PRS;POS;IND;1;SG
 kirjutama	ärgem kirjutagem	V;ACT;PRS;NEG;IMP;1;PL
-kirjutama	ei oleks kirjutanudp	V;ACT;PRS;PRF;NEG;COND
+kirjutama	ei oleks kirjutanud	V;ACT;PRS;PRF;NEG;COND
 kirjutama	oleksid kirjutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kirjutama	kirjutasite	V;ACT;PST;POS;IND;2;PL
 kirjutama	oleks kirjutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kirjutama	olin kirjutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kirjutama	oled kirjutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kirjutama	oli kirjutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kirjutama	ei ole kirjutatudp	V;PASS;PRS;PRF;NEG;IND
+kirjutama	ei ole kirjutatud	V;PASS;PRS;PRF;NEG;IND
 kirjutama	kirjutaksin	V;ACT;PRS;POS;COND;1;SG
 kirjutama	olen kirjutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kirjutama	ei olnud kirjutatudp	V;PASS;PST;PRF;NEG;IND
+kirjutama	ei olnud kirjutatud	V;PASS;PST;PRF;NEG;IND
 kirjutama	ärgu olgu kirjutatud	V;PASS;PRS;PRF;NEG;IMP
 
 kirjutusmasin	kirjutusmasinani	N;TERM;SG
@@ -9300,7 +9300,7 @@ kobedus	kobedustesse	N;IN+ALL;PL
 kobedus	kobedustelt	N;AT+ABL;PL
 
 kobisema	olete kobisenud	V;ACT;PRS;PRF;POS;IND;2;PL
-kobisema	ei olevat kobisenudp	V;ACT;PRS;PRF;NEG;QUOT
+kobisema	ei olevat kobisenud	V;ACT;PRS;PRF;NEG;QUOT
 kobisema	oleks kobisetud	V;PASS;PRS;PRF;POS;COND
 kobisema	kobisesin	V;ACT;PST;POS;IND;1;SG
 kobisema	kobisetakse	V;PASS;PRS;POS;IND
@@ -9309,7 +9309,7 @@ kobisema	kobisetagu	V;PASS;PRS;POS;IMP
 kobisema	ärgu kobisegu	V;ACT;PRS;NEG;IMP;3;SG
 kobisema	oli kobisetud	V;PASS;PST;PRF;POS;IND
 kobisema	kobisesime	V;ACT;PST;POS;IND;1;PL
-kobisema	ei olnud kobisenudp	V;ACT;PST;PRF;NEG;IND
+kobisema	ei olnud kobisenud	V;ACT;PST;PRF;NEG;IND
 kobisema	oleksid kobisenud	V;ACT;PRS;PRF;POS;COND;2;SG
 kobisema	olgu kobisenud	V;ACT;PRS;PRF;POS;IMP;PL
 kobisema	oli kobisenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -9323,9 +9323,9 @@ kobisema	ärgu kobisegu	V;ACT;PRS;NEG;IMP;3;PL
 kobisema	olgu kobisenud	V;ACT;PRS;PRF;POS;IMP;SG
 kobisema	kobiseti	V;PASS;PST;POS;IND
 kobisema	ei kobisevat	V;ACT;PRS;NEG;QUOT
-kobisema	ei oleks kobisetudp	V;PASS;PRS;PRF;NEG;COND
+kobisema	ei oleks kobisetud	V;PASS;PRS;PRF;NEG;COND
 kobisema	ei kobisenud	V;ACT;PST;NEG;IND
-kobisema	ei olevat kobisetudp	V;PASS;PRS;PRF;NEG;QUOT
+kobisema	ei olevat kobisetud	V;PASS;PRS;PRF;NEG;QUOT
 kobisema	ei kobiseks	V;ACT;PRS;PRF;POS;COND;1;SG
 kobisema	kobisetud	V.PTCP;PASS;PST
 kobisema	olid kobisenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -9344,7 +9344,7 @@ kobisema	olgu kobisetud	V;PASS;PRS;PRF;POS;IMP
 kobisema	kobiseks	V;ACT;PRS;POS;COND;3;SG
 kobisema	kobisegu	V;ACT;PRS;POS;IMP;3;PL
 kobisema	ärgu olgu kobisenud	V;ACT;PRS;PRF;NEG;IMP;SG
-kobisema	ei ole kobisenudp	V;ACT;PST;NEG;IND
+kobisema	ei ole kobisenud	V;ACT;PST;NEG;IND
 kobisema	kobised	V;ACT;PRS;POS;IND;2;SG
 kobisema	ära kobise	V;ACT;PRS;NEG;IMP;2;SG
 kobisema	ei kobise	V;ACT;PRS;NEG;IND
@@ -9372,21 +9372,21 @@ kobisema	ei kobiseta	V;PASS;PRS;NEG;IND
 kobisema	kobiseme	V;ACT;PRS;POS;IND;1;PL
 kobisema	kobisen	V;ACT;PRS;POS;IND;1;SG
 kobisema	ärgem kobisegem	V;ACT;PRS;NEG;IMP;1;PL
-kobisema	ei oleks kobisenudp	V;ACT;PRS;PRF;NEG;COND
+kobisema	ei oleks kobisenud	V;ACT;PRS;PRF;NEG;COND
 kobisema	oleksid kobisenud	V;ACT;PRS;PRF;POS;COND;3;PL
 kobisema	kobisesite	V;ACT;PST;POS;IND;2;PL
 kobisema	oleks kobisenud	V;ACT;PRS;PRF;POS;COND;3;SG
 kobisema	olin kobisenud	V;ACT;PRS;PRF;POS;COND;1;SG
 kobisema	oled kobisenud	V;ACT;PRS;PRF;POS;IND;2;SG
 kobisema	oli kobisenud	V;ACT;PRS;PRF;POS;COND;3;SG
-kobisema	ei ole kobisetudp	V;PASS;PRS;PRF;NEG;IND
+kobisema	ei ole kobisetud	V;PASS;PRS;PRF;NEG;IND
 kobisema	kobiseksin	V;ACT;PRS;POS;COND;1;SG
 kobisema	olen kobisenud	V;ACT;PRS;PRF;POS;IND;1;SG
-kobisema	ei olnud kobisetudp	V;PASS;PST;PRF;NEG;IND
+kobisema	ei olnud kobisetud	V;PASS;PST;PRF;NEG;IND
 kobisema	ärgu olgu kobisetud	V;PASS;PRS;PRF;NEG;IMP
 
 kobistama	olete kobistanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kobistama	ei olevat kobistanudp	V;ACT;PRS;PRF;NEG;QUOT
+kobistama	ei olevat kobistanud	V;ACT;PRS;PRF;NEG;QUOT
 kobistama	oleks kobistatud	V;PASS;PRS;PRF;POS;COND
 kobistama	kobistasin	V;ACT;PST;POS;IND;1;SG
 kobistama	kobistatakse	V;PASS;PRS;POS;IND
@@ -9395,7 +9395,7 @@ kobistama	kobistatagu	V;PASS;PRS;POS;IMP
 kobistama	ärgu kobistagu	V;ACT;PRS;NEG;IMP;3;SG
 kobistama	oli kobistatud	V;PASS;PST;PRF;POS;IND
 kobistama	kobistasime	V;ACT;PST;POS;IND;1;PL
-kobistama	ei olnud kobistanudp	V;ACT;PST;PRF;NEG;IND
+kobistama	ei olnud kobistanud	V;ACT;PST;PRF;NEG;IND
 kobistama	oleksid kobistanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kobistama	olgu kobistanud	V;ACT;PRS;PRF;POS;IMP;PL
 kobistama	oli kobistanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -9409,9 +9409,9 @@ kobistama	ärgu kobistagu	V;ACT;PRS;NEG;IMP;3;PL
 kobistama	olgu kobistanud	V;ACT;PRS;PRF;POS;IMP;SG
 kobistama	kobistati	V;PASS;PST;POS;IND
 kobistama	ei kobistavat	V;ACT;PRS;NEG;QUOT
-kobistama	ei oleks kobistatudp	V;PASS;PRS;PRF;NEG;COND
+kobistama	ei oleks kobistatud	V;PASS;PRS;PRF;NEG;COND
 kobistama	ei kobistanud	V;ACT;PST;NEG;IND
-kobistama	ei olevat kobistatudp	V;PASS;PRS;PRF;NEG;QUOT
+kobistama	ei olevat kobistatud	V;PASS;PRS;PRF;NEG;QUOT
 kobistama	ei kobistaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kobistama	kobistatud	V.PTCP;PASS;PST
 kobistama	olid kobistanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -9430,7 +9430,7 @@ kobistama	olgu kobistatud	V;PASS;PRS;PRF;POS;IMP
 kobistama	kobistaks	V;ACT;PRS;POS;COND;3;SG
 kobistama	kobistagu	V;ACT;PRS;POS;IMP;3;PL
 kobistama	ärgu olgu kobistanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kobistama	ei ole kobistanudp	V;ACT;PST;NEG;IND
+kobistama	ei ole kobistanud	V;ACT;PST;NEG;IND
 kobistama	kobistad	V;ACT;PRS;POS;IND;2;SG
 kobistama	ära kobista	V;ACT;PRS;NEG;IMP;2;SG
 kobistama	ei kobista	V;ACT;PRS;NEG;IND
@@ -9458,17 +9458,17 @@ kobistama	ei kobistata	V;PASS;PRS;NEG;IND
 kobistama	kobistame	V;ACT;PRS;POS;IND;1;PL
 kobistama	kobistan	V;ACT;PRS;POS;IND;1;SG
 kobistama	ärgem kobistagem	V;ACT;PRS;NEG;IMP;1;PL
-kobistama	ei oleks kobistanudp	V;ACT;PRS;PRF;NEG;COND
+kobistama	ei oleks kobistanud	V;ACT;PRS;PRF;NEG;COND
 kobistama	oleksid kobistanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kobistama	kobistasite	V;ACT;PST;POS;IND;2;PL
 kobistama	oleks kobistanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kobistama	olin kobistanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kobistama	oled kobistanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kobistama	oli kobistanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kobistama	ei ole kobistatudp	V;PASS;PRS;PRF;NEG;IND
+kobistama	ei ole kobistatud	V;PASS;PRS;PRF;NEG;IND
 kobistama	kobistaksin	V;ACT;PRS;POS;COND;1;SG
 kobistama	olen kobistanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kobistama	ei olnud kobistatudp	V;PASS;PST;PRF;NEG;IND
+kobistama	ei olnud kobistatud	V;PASS;PST;PRF;NEG;IND
 kobistama	ärgu olgu kobistatud	V;PASS;PRS;PRF;NEG;IMP
 
 kodanlane	kodanlaseni	N;TERM;SG
@@ -9565,7 +9565,7 @@ kohin	kohinatesse	N;IN+ALL;PL
 kohin	kohinatelt	N;AT+ABL;PL
 
 kohtama	olete kohanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kohtama	ei olevat kohanudp	V;ACT;PRS;PRF;NEG;QUOT
+kohtama	ei olevat kohanud	V;ACT;PRS;PRF;NEG;QUOT
 kohtama	oleks kohatud	V;PASS;PRS;PRF;POS;COND
 kohtama	kohtasin	V;ACT;PST;POS;IND;1;SG
 kohtama	kohatakse	V;PASS;PRS;POS;IND
@@ -9574,7 +9574,7 @@ kohtama	kohatagu	V;PASS;PRS;POS;IMP
 kohtama	ärgu kohaku	V;ACT;PRS;NEG;IMP;3;SG
 kohtama	oli kohatud	V;PASS;PST;PRF;POS;IND
 kohtama	kohtasime	V;ACT;PST;POS;IND;1;PL
-kohtama	ei olnud kohanudp	V;ACT;PST;PRF;NEG;IND
+kohtama	ei olnud kohanud	V;ACT;PST;PRF;NEG;IND
 kohtama	oleksid kohanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kohtama	olgu kohanud	V;ACT;PRS;PRF;POS;IMP;PL
 kohtama	oli kohanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -9588,9 +9588,9 @@ kohtama	ärgu kohaku	V;ACT;PRS;NEG;IMP;3;PL
 kohtama	olgu kohanud	V;ACT;PRS;PRF;POS;IMP;SG
 kohtama	kohati	V;PASS;PST;POS;IND
 kohtama	ei kohtavat	V;ACT;PRS;NEG;QUOT
-kohtama	ei oleks kohatudp	V;PASS;PRS;PRF;NEG;COND
+kohtama	ei oleks kohatud	V;PASS;PRS;PRF;NEG;COND
 kohtama	ei kohanud	V;ACT;PST;NEG;IND
-kohtama	ei olevat kohatudp	V;PASS;PRS;PRF;NEG;QUOT
+kohtama	ei olevat kohatud	V;PASS;PRS;PRF;NEG;QUOT
 kohtama	ei kohtaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kohtama	kohatud	V.PTCP;PASS;PST
 kohtama	olid kohanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -9609,7 +9609,7 @@ kohtama	olgu kohatud	V;PASS;PRS;PRF;POS;IMP
 kohtama	kohtaks	V;ACT;PRS;POS;COND;3;SG
 kohtama	kohaku	V;ACT;PRS;POS;IMP;3;PL
 kohtama	ärgu olgu kohanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kohtama	ei ole kohanudp	V;ACT;PST;NEG;IND
+kohtama	ei ole kohanud	V;ACT;PST;NEG;IND
 kohtama	kohtad	V;ACT;PRS;POS;IND;2;SG
 kohtama	ära kohta	V;ACT;PRS;NEG;IMP;2;SG
 kohtama	ei kohta	V;ACT;PRS;NEG;IND
@@ -9637,17 +9637,17 @@ kohtama	ei kohata	V;PASS;PRS;NEG;IND
 kohtama	kohtame	V;ACT;PRS;POS;IND;1;PL
 kohtama	kohtan	V;ACT;PRS;POS;IND;1;SG
 kohtama	ärgem kohakem	V;ACT;PRS;NEG;IMP;1;PL
-kohtama	ei oleks kohanudp	V;ACT;PRS;PRF;NEG;COND
+kohtama	ei oleks kohanud	V;ACT;PRS;PRF;NEG;COND
 kohtama	oleksid kohanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kohtama	kohtasite	V;ACT;PST;POS;IND;2;PL
 kohtama	oleks kohanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kohtama	olin kohanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kohtama	oled kohanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kohtama	oli kohanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kohtama	ei ole kohatudp	V;PASS;PRS;PRF;NEG;IND
+kohtama	ei ole kohatud	V;PASS;PRS;PRF;NEG;IND
 kohtama	kohtaksin	V;ACT;PRS;POS;COND;1;SG
 kohtama	olen kohanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kohtama	ei olnud kohatudp	V;PASS;PST;PRF;NEG;IND
+kohtama	ei olnud kohatud	V;PASS;PST;PRF;NEG;IND
 kohtama	ärgu olgu kohatud	V;PASS;PRS;PRF;NEG;IMP
 
 kohtupidamine	kohtupidamiseni	N;TERM;SG
@@ -9868,7 +9868,7 @@ kopikas	kopikatesse	N;IN+ALL;PL
 kopikas	kopikatelt	N;AT+ABL;PL
 
 koristama	olete koristanud	V;ACT;PRS;PRF;POS;IND;2;PL
-koristama	ei olevat koristanudp	V;ACT;PRS;PRF;NEG;QUOT
+koristama	ei olevat koristanud	V;ACT;PRS;PRF;NEG;QUOT
 koristama	oleks koristatud	V;PASS;PRS;PRF;POS;COND
 koristama	koristasin	V;ACT;PST;POS;IND;1;SG
 koristama	koristatakse	V;PASS;PRS;POS;IND
@@ -9877,7 +9877,7 @@ koristama	koristatagu	V;PASS;PRS;POS;IMP
 koristama	ärgu koristagu	V;ACT;PRS;NEG;IMP;3;SG
 koristama	oli koristatud	V;PASS;PST;PRF;POS;IND
 koristama	koristasime	V;ACT;PST;POS;IND;1;PL
-koristama	ei olnud koristanudp	V;ACT;PST;PRF;NEG;IND
+koristama	ei olnud koristanud	V;ACT;PST;PRF;NEG;IND
 koristama	oleksid koristanud	V;ACT;PRS;PRF;POS;COND;2;SG
 koristama	olgu koristanud	V;ACT;PRS;PRF;POS;IMP;PL
 koristama	oli koristanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -9891,9 +9891,9 @@ koristama	ärgu koristagu	V;ACT;PRS;NEG;IMP;3;PL
 koristama	olgu koristanud	V;ACT;PRS;PRF;POS;IMP;SG
 koristama	koristati	V;PASS;PST;POS;IND
 koristama	ei koristavat	V;ACT;PRS;NEG;QUOT
-koristama	ei oleks koristatudp	V;PASS;PRS;PRF;NEG;COND
+koristama	ei oleks koristatud	V;PASS;PRS;PRF;NEG;COND
 koristama	ei koristanud	V;ACT;PST;NEG;IND
-koristama	ei olevat koristatudp	V;PASS;PRS;PRF;NEG;QUOT
+koristama	ei olevat koristatud	V;PASS;PRS;PRF;NEG;QUOT
 koristama	ei koristaks	V;ACT;PRS;PRF;POS;COND;1;SG
 koristama	koristatud	V.PTCP;PASS;PST
 koristama	olid koristanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -9912,7 +9912,7 @@ koristama	olgu koristatud	V;PASS;PRS;PRF;POS;IMP
 koristama	koristaks	V;ACT;PRS;POS;COND;3;SG
 koristama	koristagu	V;ACT;PRS;POS;IMP;3;PL
 koristama	ärgu olgu koristanud	V;ACT;PRS;PRF;NEG;IMP;SG
-koristama	ei ole koristanudp	V;ACT;PST;NEG;IND
+koristama	ei ole koristanud	V;ACT;PST;NEG;IND
 koristama	koristad	V;ACT;PRS;POS;IND;2;SG
 koristama	ära korista	V;ACT;PRS;NEG;IMP;2;SG
 koristama	ei korista	V;ACT;PRS;NEG;IND
@@ -9940,21 +9940,21 @@ koristama	ei koristata	V;PASS;PRS;NEG;IND
 koristama	koristame	V;ACT;PRS;POS;IND;1;PL
 koristama	koristan	V;ACT;PRS;POS;IND;1;SG
 koristama	ärgem koristagem	V;ACT;PRS;NEG;IMP;1;PL
-koristama	ei oleks koristanudp	V;ACT;PRS;PRF;NEG;COND
+koristama	ei oleks koristanud	V;ACT;PRS;PRF;NEG;COND
 koristama	oleksid koristanud	V;ACT;PRS;PRF;POS;COND;3;PL
 koristama	koristasite	V;ACT;PST;POS;IND;2;PL
 koristama	oleks koristanud	V;ACT;PRS;PRF;POS;COND;3;SG
 koristama	olin koristanud	V;ACT;PRS;PRF;POS;COND;1;SG
 koristama	oled koristanud	V;ACT;PRS;PRF;POS;IND;2;SG
 koristama	oli koristanud	V;ACT;PRS;PRF;POS;COND;3;SG
-koristama	ei ole koristatudp	V;PASS;PRS;PRF;NEG;IND
+koristama	ei ole koristatud	V;PASS;PRS;PRF;NEG;IND
 koristama	koristaksin	V;ACT;PRS;POS;COND;1;SG
 koristama	olen koristanud	V;ACT;PRS;PRF;POS;IND;1;SG
-koristama	ei olnud koristatudp	V;PASS;PST;PRF;NEG;IND
+koristama	ei olnud koristatud	V;PASS;PST;PRF;NEG;IND
 koristama	ärgu olgu koristatud	V;PASS;PRS;PRF;NEG;IMP
 
 korjama	olete korjanud	V;ACT;PRS;PRF;POS;IND;2;PL
-korjama	ei olevat korjanudp	V;ACT;PRS;PRF;NEG;QUOT
+korjama	ei olevat korjanud	V;ACT;PRS;PRF;NEG;QUOT
 korjama	oleks korjatud	V;PASS;PRS;PRF;POS;COND
 korjama	korjasin	V;ACT;PST;POS;IND;1;SG
 korjama	korjatakse	V;PASS;PRS;POS;IND
@@ -9963,7 +9963,7 @@ korjama	korjatagu	V;PASS;PRS;POS;IMP
 korjama	ärgu korjaku	V;ACT;PRS;NEG;IMP;3;SG
 korjama	oli korjatud	V;PASS;PST;PRF;POS;IND
 korjama	korjasime	V;ACT;PST;POS;IND;1;PL
-korjama	ei olnud korjanudp	V;ACT;PST;PRF;NEG;IND
+korjama	ei olnud korjanud	V;ACT;PST;PRF;NEG;IND
 korjama	oleksid korjanud	V;ACT;PRS;PRF;POS;COND;2;SG
 korjama	olgu korjanud	V;ACT;PRS;PRF;POS;IMP;PL
 korjama	oli korjanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -9977,9 +9977,9 @@ korjama	ärgu korjaku	V;ACT;PRS;NEG;IMP;3;PL
 korjama	olgu korjanud	V;ACT;PRS;PRF;POS;IMP;SG
 korjama	korjati	V;PASS;PST;POS;IND
 korjama	ei korjavat	V;ACT;PRS;NEG;QUOT
-korjama	ei oleks korjatudp	V;PASS;PRS;PRF;NEG;COND
+korjama	ei oleks korjatud	V;PASS;PRS;PRF;NEG;COND
 korjama	ei korjanud	V;ACT;PST;NEG;IND
-korjama	ei olevat korjatudp	V;PASS;PRS;PRF;NEG;QUOT
+korjama	ei olevat korjatud	V;PASS;PRS;PRF;NEG;QUOT
 korjama	ei korjaks	V;ACT;PRS;PRF;POS;COND;1;SG
 korjama	korjatud	V.PTCP;PASS;PST
 korjama	olid korjanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -9998,7 +9998,7 @@ korjama	olgu korjatud	V;PASS;PRS;PRF;POS;IMP
 korjama	korjaks	V;ACT;PRS;POS;COND;3;SG
 korjama	korjaku	V;ACT;PRS;POS;IMP;3;PL
 korjama	ärgu olgu korjanud	V;ACT;PRS;PRF;NEG;IMP;SG
-korjama	ei ole korjanudp	V;ACT;PST;NEG;IND
+korjama	ei ole korjanud	V;ACT;PST;NEG;IND
 korjama	korjad	V;ACT;PRS;POS;IND;2;SG
 korjama	ära korja	V;ACT;PRS;NEG;IMP;2;SG
 korjama	ei korja	V;ACT;PRS;NEG;IND
@@ -10026,17 +10026,17 @@ korjama	ei korjata	V;PASS;PRS;NEG;IND
 korjama	korjame	V;ACT;PRS;POS;IND;1;PL
 korjama	korjan	V;ACT;PRS;POS;IND;1;SG
 korjama	ärgem korjakem	V;ACT;PRS;NEG;IMP;1;PL
-korjama	ei oleks korjanudp	V;ACT;PRS;PRF;NEG;COND
+korjama	ei oleks korjanud	V;ACT;PRS;PRF;NEG;COND
 korjama	oleksid korjanud	V;ACT;PRS;PRF;POS;COND;3;PL
 korjama	korjasite	V;ACT;PST;POS;IND;2;PL
 korjama	oleks korjanud	V;ACT;PRS;PRF;POS;COND;3;SG
 korjama	olin korjanud	V;ACT;PRS;PRF;POS;COND;1;SG
 korjama	oled korjanud	V;ACT;PRS;PRF;POS;IND;2;SG
 korjama	oli korjanud	V;ACT;PRS;PRF;POS;COND;3;SG
-korjama	ei ole korjatudp	V;PASS;PRS;PRF;NEG;IND
+korjama	ei ole korjatud	V;PASS;PRS;PRF;NEG;IND
 korjama	korjaksin	V;ACT;PRS;POS;COND;1;SG
 korjama	olen korjanud	V;ACT;PRS;PRF;POS;IND;1;SG
-korjama	ei olnud korjatudp	V;PASS;PST;PRF;NEG;IND
+korjama	ei olnud korjatud	V;PASS;PST;PRF;NEG;IND
 korjama	ärgu olgu korjatud	V;PASS;PRS;PRF;NEG;IMP
 
 korsten	korstnani	N;TERM;SG
@@ -10319,7 +10319,7 @@ kuritöö	kuritöödesse	N;IN+ALL;PL
 kuritöö	kuritöödelt	N;AT+ABL;PL
 
 kustutama	olete kustutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kustutama	ei olevat kustutanudp	V;ACT;PRS;PRF;NEG;QUOT
+kustutama	ei olevat kustutanud	V;ACT;PRS;PRF;NEG;QUOT
 kustutama	oleks kustutatud	V;PASS;PRS;PRF;POS;COND
 kustutama	kustutasin	V;ACT;PST;POS;IND;1;SG
 kustutama	kustutatakse	V;PASS;PRS;POS;IND
@@ -10328,7 +10328,7 @@ kustutama	kustutatagu	V;PASS;PRS;POS;IMP
 kustutama	ärgu kustutagu	V;ACT;PRS;NEG;IMP;3;SG
 kustutama	oli kustutatud	V;PASS;PST;PRF;POS;IND
 kustutama	kustutasime	V;ACT;PST;POS;IND;1;PL
-kustutama	ei olnud kustutanudp	V;ACT;PST;PRF;NEG;IND
+kustutama	ei olnud kustutanud	V;ACT;PST;PRF;NEG;IND
 kustutama	oleksid kustutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kustutama	olgu kustutanud	V;ACT;PRS;PRF;POS;IMP;PL
 kustutama	oli kustutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -10342,9 +10342,9 @@ kustutama	ärgu kustutagu	V;ACT;PRS;NEG;IMP;3;PL
 kustutama	olgu kustutanud	V;ACT;PRS;PRF;POS;IMP;SG
 kustutama	kustutati	V;PASS;PST;POS;IND
 kustutama	ei kustutavat	V;ACT;PRS;NEG;QUOT
-kustutama	ei oleks kustutatudp	V;PASS;PRS;PRF;NEG;COND
+kustutama	ei oleks kustutatud	V;PASS;PRS;PRF;NEG;COND
 kustutama	ei kustutanud	V;ACT;PST;NEG;IND
-kustutama	ei olevat kustutatudp	V;PASS;PRS;PRF;NEG;QUOT
+kustutama	ei olevat kustutatud	V;PASS;PRS;PRF;NEG;QUOT
 kustutama	ei kustutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kustutama	kustutatud	V.PTCP;PASS;PST
 kustutama	olid kustutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -10363,7 +10363,7 @@ kustutama	olgu kustutatud	V;PASS;PRS;PRF;POS;IMP
 kustutama	kustutaks	V;ACT;PRS;POS;COND;3;SG
 kustutama	kustutagu	V;ACT;PRS;POS;IMP;3;PL
 kustutama	ärgu olgu kustutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kustutama	ei ole kustutanudp	V;ACT;PST;NEG;IND
+kustutama	ei ole kustutanud	V;ACT;PST;NEG;IND
 kustutama	kustutad	V;ACT;PRS;POS;IND;2;SG
 kustutama	ära kustuta	V;ACT;PRS;NEG;IMP;2;SG
 kustutama	ei kustuta	V;ACT;PRS;NEG;IND
@@ -10391,21 +10391,21 @@ kustutama	ei kustutata	V;PASS;PRS;NEG;IND
 kustutama	kustutame	V;ACT;PRS;POS;IND;1;PL
 kustutama	kustutan	V;ACT;PRS;POS;IND;1;SG
 kustutama	ärgem kustutagem	V;ACT;PRS;NEG;IMP;1;PL
-kustutama	ei oleks kustutanudp	V;ACT;PRS;PRF;NEG;COND
+kustutama	ei oleks kustutanud	V;ACT;PRS;PRF;NEG;COND
 kustutama	oleksid kustutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kustutama	kustutasite	V;ACT;PST;POS;IND;2;PL
 kustutama	oleks kustutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kustutama	olin kustutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kustutama	oled kustutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kustutama	oli kustutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kustutama	ei ole kustutatudp	V;PASS;PRS;PRF;NEG;IND
+kustutama	ei ole kustutatud	V;PASS;PRS;PRF;NEG;IND
 kustutama	kustutaksin	V;ACT;PRS;POS;COND;1;SG
 kustutama	olen kustutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kustutama	ei olnud kustutatudp	V;PASS;PST;PRF;NEG;IND
+kustutama	ei olnud kustutatud	V;PASS;PST;PRF;NEG;IND
 kustutama	ärgu olgu kustutatud	V;PASS;PRS;PRF;NEG;IMP
 
 kuulma	olete kuulnud	V;ACT;PRS;PRF;POS;IND;2;PL
-kuulma	ei olevat kuulnudp	V;ACT;PRS;PRF;NEG;QUOT
+kuulma	ei olevat kuulnud	V;ACT;PRS;PRF;NEG;QUOT
 kuulma	oleks kuuldud	V;PASS;PRS;PRF;POS;COND
 kuulma	kuulsin	V;ACT;PST;POS;IND;1;SG
 kuulma	kuuldakse	V;PASS;PRS;POS;IND
@@ -10414,7 +10414,7 @@ kuulma	kuuldagu	V;PASS;PRS;POS;IMP
 kuulma	ärgu kuulgu	V;ACT;PRS;NEG;IMP;3;SG
 kuulma	oli kuuldud	V;PASS;PST;PRF;POS;IND
 kuulma	kuulsime	V;ACT;PST;POS;IND;1;PL
-kuulma	ei olnud kuulnudp	V;ACT;PST;PRF;NEG;IND
+kuulma	ei olnud kuulnud	V;ACT;PST;PRF;NEG;IND
 kuulma	oleksid kuulnud	V;ACT;PRS;PRF;POS;COND;2;SG
 kuulma	olgu kuulnud	V;ACT;PRS;PRF;POS;IMP;PL
 kuulma	oli kuulnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -10428,9 +10428,9 @@ kuulma	ärgu kuulgu	V;ACT;PRS;NEG;IMP;3;PL
 kuulma	olgu kuulnud	V;ACT;PRS;PRF;POS;IMP;SG
 kuulma	kuuldi	V;PASS;PST;POS;IND
 kuulma	ei kuulvat	V;ACT;PRS;NEG;QUOT
-kuulma	ei oleks kuuldudp	V;PASS;PRS;PRF;NEG;COND
+kuulma	ei oleks kuuldud	V;PASS;PRS;PRF;NEG;COND
 kuulma	ei kuulnud	V;ACT;PST;NEG;IND
-kuulma	ei olevat kuuldudp	V;PASS;PRS;PRF;NEG;QUOT
+kuulma	ei olevat kuuldud	V;PASS;PRS;PRF;NEG;QUOT
 kuulma	ei kuuleks	V;ACT;PRS;PRF;POS;COND;1;SG
 kuulma	kuuldud	V.PTCP;PASS;PST
 kuulma	olid kuulnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -10449,7 +10449,7 @@ kuulma	olgu kuuldud	V;PASS;PRS;PRF;POS;IMP
 kuulma	kuuleks	V;ACT;PRS;POS;COND;3;SG
 kuulma	kuulgu	V;ACT;PRS;POS;IMP;3;PL
 kuulma	ärgu olgu kuulnud	V;ACT;PRS;PRF;NEG;IMP;SG
-kuulma	ei ole kuulnudp	V;ACT;PST;NEG;IND
+kuulma	ei ole kuulnud	V;ACT;PST;NEG;IND
 kuulma	kuuled	V;ACT;PRS;POS;IND;2;SG
 kuulma	ära kuule	V;ACT;PRS;NEG;IMP;2;SG
 kuulma	ei kuule	V;ACT;PRS;NEG;IND
@@ -10477,21 +10477,21 @@ kuulma	ei kuulda	V;PASS;PRS;NEG;IND
 kuulma	kuuleme	V;ACT;PRS;POS;IND;1;PL
 kuulma	kuulen	V;ACT;PRS;POS;IND;1;SG
 kuulma	ärgem kuulgem	V;ACT;PRS;NEG;IMP;1;PL
-kuulma	ei oleks kuulnudp	V;ACT;PRS;PRF;NEG;COND
+kuulma	ei oleks kuulnud	V;ACT;PRS;PRF;NEG;COND
 kuulma	oleksid kuulnud	V;ACT;PRS;PRF;POS;COND;3;PL
 kuulma	kuulsite	V;ACT;PST;POS;IND;2;PL
 kuulma	oleks kuulnud	V;ACT;PRS;PRF;POS;COND;3;SG
 kuulma	olin kuulnud	V;ACT;PRS;PRF;POS;COND;1;SG
 kuulma	oled kuulnud	V;ACT;PRS;PRF;POS;IND;2;SG
 kuulma	oli kuulnud	V;ACT;PRS;PRF;POS;COND;3;SG
-kuulma	ei ole kuuldudp	V;PASS;PRS;PRF;NEG;IND
+kuulma	ei ole kuuldud	V;PASS;PRS;PRF;NEG;IND
 kuulma	kuuleksin	V;ACT;PRS;POS;COND;1;SG
 kuulma	olen kuulnud	V;ACT;PRS;PRF;POS;IND;1;SG
-kuulma	ei olnud kuuldudp	V;PASS;PST;PRF;NEG;IND
+kuulma	ei olnud kuuldud	V;PASS;PST;PRF;NEG;IND
 kuulma	ärgu olgu kuuldud	V;PASS;PRS;PRF;NEG;IMP
 
 kuulutama	olete kuulutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-kuulutama	ei olevat kuulutanudp	V;ACT;PRS;PRF;NEG;QUOT
+kuulutama	ei olevat kuulutanud	V;ACT;PRS;PRF;NEG;QUOT
 kuulutama	oleks kuulutatud	V;PASS;PRS;PRF;POS;COND
 kuulutama	kuulutasin	V;ACT;PST;POS;IND;1;SG
 kuulutama	kuulutatakse	V;PASS;PRS;POS;IND
@@ -10500,7 +10500,7 @@ kuulutama	kuulutatagu	V;PASS;PRS;POS;IMP
 kuulutama	ärgu kuulutagu	V;ACT;PRS;NEG;IMP;3;SG
 kuulutama	oli kuulutatud	V;PASS;PST;PRF;POS;IND
 kuulutama	kuulutasime	V;ACT;PST;POS;IND;1;PL
-kuulutama	ei olnud kuulutanudp	V;ACT;PST;PRF;NEG;IND
+kuulutama	ei olnud kuulutanud	V;ACT;PST;PRF;NEG;IND
 kuulutama	oleksid kuulutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 kuulutama	olgu kuulutanud	V;ACT;PRS;PRF;POS;IMP;PL
 kuulutama	oli kuulutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -10514,9 +10514,9 @@ kuulutama	ärgu kuulutagu	V;ACT;PRS;NEG;IMP;3;PL
 kuulutama	olgu kuulutanud	V;ACT;PRS;PRF;POS;IMP;SG
 kuulutama	kuulutati	V;PASS;PST;POS;IND
 kuulutama	ei kuulutavat	V;ACT;PRS;NEG;QUOT
-kuulutama	ei oleks kuulutatudp	V;PASS;PRS;PRF;NEG;COND
+kuulutama	ei oleks kuulutatud	V;PASS;PRS;PRF;NEG;COND
 kuulutama	ei kuulutanud	V;ACT;PST;NEG;IND
-kuulutama	ei olevat kuulutatudp	V;PASS;PRS;PRF;NEG;QUOT
+kuulutama	ei olevat kuulutatud	V;PASS;PRS;PRF;NEG;QUOT
 kuulutama	ei kuulutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kuulutama	kuulutatud	V.PTCP;PASS;PST
 kuulutama	olid kuulutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -10535,7 +10535,7 @@ kuulutama	olgu kuulutatud	V;PASS;PRS;PRF;POS;IMP
 kuulutama	kuulutaks	V;ACT;PRS;POS;COND;3;SG
 kuulutama	kuulutagu	V;ACT;PRS;POS;IMP;3;PL
 kuulutama	ärgu olgu kuulutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-kuulutama	ei ole kuulutanudp	V;ACT;PST;NEG;IND
+kuulutama	ei ole kuulutanud	V;ACT;PST;NEG;IND
 kuulutama	kuulutad	V;ACT;PRS;POS;IND;2;SG
 kuulutama	ära kuuluta	V;ACT;PRS;NEG;IMP;2;SG
 kuulutama	ei kuuluta	V;ACT;PRS;NEG;IND
@@ -10563,17 +10563,17 @@ kuulutama	ei kuulutata	V;PASS;PRS;NEG;IND
 kuulutama	kuulutame	V;ACT;PRS;POS;IND;1;PL
 kuulutama	kuulutan	V;ACT;PRS;POS;IND;1;SG
 kuulutama	ärgem kuulutagem	V;ACT;PRS;NEG;IMP;1;PL
-kuulutama	ei oleks kuulutanudp	V;ACT;PRS;PRF;NEG;COND
+kuulutama	ei oleks kuulutanud	V;ACT;PRS;PRF;NEG;COND
 kuulutama	oleksid kuulutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 kuulutama	kuulutasite	V;ACT;PST;POS;IND;2;PL
 kuulutama	oleks kuulutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 kuulutama	olin kuulutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 kuulutama	oled kuulutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 kuulutama	oli kuulutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-kuulutama	ei ole kuulutatudp	V;PASS;PRS;PRF;NEG;IND
+kuulutama	ei ole kuulutatud	V;PASS;PRS;PRF;NEG;IND
 kuulutama	kuulutaksin	V;ACT;PRS;POS;COND;1;SG
 kuulutama	olen kuulutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-kuulutama	ei olnud kuulutatudp	V;PASS;PST;PRF;NEG;IND
+kuulutama	ei olnud kuulutatud	V;PASS;PST;PRF;NEG;IND
 kuulutama	ärgu olgu kuulutatud	V;PASS;PRS;PRF;NEG;IMP
 
 kuurium	kuuriumini	N;TERM;SG
@@ -10608,7 +10608,7 @@ kuurium	kuuriumdesse	N;IN+ALL;PL
 kuurium	kuuriumdelt	N;AT+ABL;PL
 
 käima	olete käinud	V;ACT;PRS;PRF;POS;IND;2;PL
-käima	ei olevat käinudp	V;ACT;PRS;PRF;NEG;QUOT
+käima	ei olevat käinud	V;ACT;PRS;PRF;NEG;QUOT
 käima	oleks käidud	V;PASS;PRS;PRF;POS;COND
 käima	käisin	V;ACT;PST;POS;IND;1;SG
 käima	käiakse	V;PASS;PRS;POS;IND
@@ -10617,7 +10617,7 @@ käima	käidagu	V;PASS;PRS;POS;IMP
 käima	ärgu käigu	V;ACT;PRS;NEG;IMP;3;SG
 käima	oli käidud	V;PASS;PST;PRF;POS;IND
 käima	käisime	V;ACT;PST;POS;IND;1;PL
-käima	ei olnud käinudp	V;ACT;PST;PRF;NEG;IND
+käima	ei olnud käinud	V;ACT;PST;PRF;NEG;IND
 käima	oleksid käinud	V;ACT;PRS;PRF;POS;COND;2;SG
 käima	olgu käinud	V;ACT;PRS;PRF;POS;IMP;PL
 käima	oli käinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -10631,9 +10631,9 @@ käima	ärgu käigu	V;ACT;PRS;NEG;IMP;3;PL
 käima	olgu käinud	V;ACT;PRS;PRF;POS;IMP;SG
 käima	käidi	V;PASS;PST;POS;IND
 käima	ei käivat	V;ACT;PRS;NEG;QUOT
-käima	ei oleks käidudp	V;PASS;PRS;PRF;NEG;COND
+käima	ei oleks käidud	V;PASS;PRS;PRF;NEG;COND
 käima	ei käinud	V;ACT;PST;NEG;IND
-käima	ei olevat käidudp	V;PASS;PRS;PRF;NEG;QUOT
+käima	ei olevat käidud	V;PASS;PRS;PRF;NEG;QUOT
 käima	ei käiks	V;ACT;PRS;PRF;POS;COND;1;SG
 käima	käidud	V.PTCP;PASS;PST
 käima	olid käinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -10652,7 +10652,7 @@ käima	olgu käidud	V;PASS;PRS;PRF;POS;IMP
 käima	käiks	V;ACT;PRS;POS;COND;3;SG
 käima	käigu	V;ACT;PRS;POS;IMP;3;PL
 käima	ärgu olgu käinud	V;ACT;PRS;PRF;NEG;IMP;SG
-käima	ei ole käinudp	V;ACT;PST;NEG;IND
+käima	ei ole käinud	V;ACT;PST;NEG;IND
 käima	käid	V;ACT;PRS;POS;IND;2;SG
 käima	ära käi	V;ACT;PRS;NEG;IMP;2;SG
 käima	ei käi	V;ACT;PRS;NEG;IND
@@ -10680,21 +10680,21 @@ käima	ei käida	V;PASS;PRS;NEG;IND
 käima	käime	V;ACT;PRS;POS;IND;1;PL
 käima	käin	V;ACT;PRS;POS;IND;1;SG
 käima	ärgem käigem	V;ACT;PRS;NEG;IMP;1;PL
-käima	ei oleks käinudp	V;ACT;PRS;PRF;NEG;COND
+käima	ei oleks käinud	V;ACT;PRS;PRF;NEG;COND
 käima	oleksid käinud	V;ACT;PRS;PRF;POS;COND;3;PL
 käima	käisite	V;ACT;PST;POS;IND;2;PL
 käima	oleks käinud	V;ACT;PRS;PRF;POS;COND;3;SG
 käima	olin käinud	V;ACT;PRS;PRF;POS;COND;1;SG
 käima	oled käinud	V;ACT;PRS;PRF;POS;IND;2;SG
 käima	oli käinud	V;ACT;PRS;PRF;POS;COND;3;SG
-käima	ei ole käidudp	V;PASS;PRS;PRF;NEG;IND
+käima	ei ole käidud	V;PASS;PRS;PRF;NEG;IND
 käima	käiksin	V;ACT;PRS;POS;COND;1;SG
 käima	olen käinud	V;ACT;PRS;PRF;POS;IND;1;SG
-käima	ei olnud käidudp	V;PASS;PST;PRF;NEG;IND
+käima	ei olnud käidud	V;PASS;PST;PRF;NEG;IND
 käima	ärgu olgu käidud	V;PASS;PRS;PRF;NEG;IMP
 
 käituma	olete käitunud	V;ACT;PRS;PRF;POS;IND;2;PL
-käituma	ei olevat käitunudp	V;ACT;PRS;PRF;NEG;QUOT
+käituma	ei olevat käitunud	V;ACT;PRS;PRF;NEG;QUOT
 käituma	oleks käitutud	V;PASS;PRS;PRF;POS;COND
 käituma	käitusin	V;ACT;PST;POS;IND;1;SG
 käituma	käitutakse	V;PASS;PRS;POS;IND
@@ -10703,7 +10703,7 @@ käituma	käitutagu	V;PASS;PRS;POS;IMP
 käituma	ärgu käitugu	V;ACT;PRS;NEG;IMP;3;SG
 käituma	oli käitutud	V;PASS;PST;PRF;POS;IND
 käituma	käitusime	V;ACT;PST;POS;IND;1;PL
-käituma	ei olnud käitunudp	V;ACT;PST;PRF;NEG;IND
+käituma	ei olnud käitunud	V;ACT;PST;PRF;NEG;IND
 käituma	oleksid käitunud	V;ACT;PRS;PRF;POS;COND;2;SG
 käituma	olgu käitunud	V;ACT;PRS;PRF;POS;IMP;PL
 käituma	oli käitunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -10717,9 +10717,9 @@ käituma	ärgu käitugu	V;ACT;PRS;NEG;IMP;3;PL
 käituma	olgu käitunud	V;ACT;PRS;PRF;POS;IMP;SG
 käituma	käituti	V;PASS;PST;POS;IND
 käituma	ei käituvat	V;ACT;PRS;NEG;QUOT
-käituma	ei oleks käitutudp	V;PASS;PRS;PRF;NEG;COND
+käituma	ei oleks käitutud	V;PASS;PRS;PRF;NEG;COND
 käituma	ei käitunud	V;ACT;PST;NEG;IND
-käituma	ei olevat käitutudp	V;PASS;PRS;PRF;NEG;QUOT
+käituma	ei olevat käitutud	V;PASS;PRS;PRF;NEG;QUOT
 käituma	ei käituks	V;ACT;PRS;PRF;POS;COND;1;SG
 käituma	käitutud	V.PTCP;PASS;PST
 käituma	olid käitunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -10738,7 +10738,7 @@ käituma	olgu käitutud	V;PASS;PRS;PRF;POS;IMP
 käituma	käituks	V;ACT;PRS;POS;COND;3;SG
 käituma	käitugu	V;ACT;PRS;POS;IMP;3;PL
 käituma	ärgu olgu käitunud	V;ACT;PRS;PRF;NEG;IMP;SG
-käituma	ei ole käitunudp	V;ACT;PST;NEG;IND
+käituma	ei ole käitunud	V;ACT;PST;NEG;IND
 käituma	käitud	V;ACT;PRS;POS;IND;2;SG
 käituma	ära käitu	V;ACT;PRS;NEG;IMP;2;SG
 käituma	ei käitu	V;ACT;PRS;NEG;IND
@@ -10766,17 +10766,17 @@ käituma	ei käituta	V;PASS;PRS;NEG;IND
 käituma	käitume	V;ACT;PRS;POS;IND;1;PL
 käituma	käitun	V;ACT;PRS;POS;IND;1;SG
 käituma	ärgem käitugem	V;ACT;PRS;NEG;IMP;1;PL
-käituma	ei oleks käitunudp	V;ACT;PRS;PRF;NEG;COND
+käituma	ei oleks käitunud	V;ACT;PRS;PRF;NEG;COND
 käituma	oleksid käitunud	V;ACT;PRS;PRF;POS;COND;3;PL
 käituma	käitusite	V;ACT;PST;POS;IND;2;PL
 käituma	oleks käitunud	V;ACT;PRS;PRF;POS;COND;3;SG
 käituma	olin käitunud	V;ACT;PRS;PRF;POS;COND;1;SG
 käituma	oled käitunud	V;ACT;PRS;PRF;POS;IND;2;SG
 käituma	oli käitunud	V;ACT;PRS;PRF;POS;COND;3;SG
-käituma	ei ole käitutudp	V;PASS;PRS;PRF;NEG;IND
+käituma	ei ole käitutud	V;PASS;PRS;PRF;NEG;IND
 käituma	käituksin	V;ACT;PRS;POS;COND;1;SG
 käituma	olen käitunud	V;ACT;PRS;PRF;POS;IND;1;SG
-käituma	ei olnud käitutudp	V;PASS;PST;PRF;NEG;IND
+käituma	ei olnud käitutud	V;PASS;PST;PRF;NEG;IND
 käituma	ärgu olgu käitutud	V;PASS;PRS;PRF;NEG;IMP
 
 käitumine	käitumiseni	N;TERM;SG
@@ -10873,7 +10873,7 @@ käsipuu	käsipuudesse	N;IN+ALL;PL
 käsipuu	käsipuudelt	N;AT+ABL;PL
 
 käsitlema	olete käsitlenud	V;ACT;PRS;PRF;POS;IND;2;PL
-käsitlema	ei olevat käsitlenudp	V;ACT;PRS;PRF;NEG;QUOT
+käsitlema	ei olevat käsitlenud	V;ACT;PRS;PRF;NEG;QUOT
 käsitlema	oleks käsitletud	V;PASS;PRS;PRF;POS;COND
 käsitlema	käsitlesin	V;ACT;PST;POS;IND;1;SG
 käsitlema	käsitletakse	V;PASS;PRS;POS;IND
@@ -10882,7 +10882,7 @@ käsitlema	käsitletagu	V;PASS;PRS;POS;IMP
 käsitlema	ärgu käsitlegu	V;ACT;PRS;NEG;IMP;3;SG
 käsitlema	oli käsitletud	V;PASS;PST;PRF;POS;IND
 käsitlema	käsitlesime	V;ACT;PST;POS;IND;1;PL
-käsitlema	ei olnud käsitlenudp	V;ACT;PST;PRF;NEG;IND
+käsitlema	ei olnud käsitlenud	V;ACT;PST;PRF;NEG;IND
 käsitlema	oleksid käsitlenud	V;ACT;PRS;PRF;POS;COND;2;SG
 käsitlema	olgu käsitlenud	V;ACT;PRS;PRF;POS;IMP;PL
 käsitlema	oli käsitlenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -10896,9 +10896,9 @@ käsitlema	ärgu käsitlegu	V;ACT;PRS;NEG;IMP;3;PL
 käsitlema	olgu käsitlenud	V;ACT;PRS;PRF;POS;IMP;SG
 käsitlema	käsitleti	V;PASS;PST;POS;IND
 käsitlema	ei käsitlevat	V;ACT;PRS;NEG;QUOT
-käsitlema	ei oleks käsitletudp	V;PASS;PRS;PRF;NEG;COND
+käsitlema	ei oleks käsitletud	V;PASS;PRS;PRF;NEG;COND
 käsitlema	ei käsitlenud	V;ACT;PST;NEG;IND
-käsitlema	ei olevat käsitletudp	V;PASS;PRS;PRF;NEG;QUOT
+käsitlema	ei olevat käsitletud	V;PASS;PRS;PRF;NEG;QUOT
 käsitlema	ei käsitleks	V;ACT;PRS;PRF;POS;COND;1;SG
 käsitlema	käsitletud	V.PTCP;PASS;PST
 käsitlema	olid käsitlenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -10917,7 +10917,7 @@ käsitlema	olgu käsitletud	V;PASS;PRS;PRF;POS;IMP
 käsitlema	käsitleks	V;ACT;PRS;POS;COND;3;SG
 käsitlema	käsitlegu	V;ACT;PRS;POS;IMP;3;PL
 käsitlema	ärgu olgu käsitlenud	V;ACT;PRS;PRF;NEG;IMP;SG
-käsitlema	ei ole käsitlenudp	V;ACT;PST;NEG;IND
+käsitlema	ei ole käsitlenud	V;ACT;PST;NEG;IND
 käsitlema	käsitled	V;ACT;PRS;POS;IND;2;SG
 käsitlema	ära käsitle	V;ACT;PRS;NEG;IMP;2;SG
 käsitlema	ei käsitle	V;ACT;PRS;NEG;IND
@@ -10945,17 +10945,17 @@ käsitlema	ei käsitleta	V;PASS;PRS;NEG;IND
 käsitlema	käsitleme	V;ACT;PRS;POS;IND;1;PL
 käsitlema	käsitlen	V;ACT;PRS;POS;IND;1;SG
 käsitlema	ärgem käsitlegem	V;ACT;PRS;NEG;IMP;1;PL
-käsitlema	ei oleks käsitlenudp	V;ACT;PRS;PRF;NEG;COND
+käsitlema	ei oleks käsitlenud	V;ACT;PRS;PRF;NEG;COND
 käsitlema	oleksid käsitlenud	V;ACT;PRS;PRF;POS;COND;3;PL
 käsitlema	käsitlesite	V;ACT;PST;POS;IND;2;PL
 käsitlema	oleks käsitlenud	V;ACT;PRS;PRF;POS;COND;3;SG
 käsitlema	olin käsitlenud	V;ACT;PRS;PRF;POS;COND;1;SG
 käsitlema	oled käsitlenud	V;ACT;PRS;PRF;POS;IND;2;SG
 käsitlema	oli käsitlenud	V;ACT;PRS;PRF;POS;COND;3;SG
-käsitlema	ei ole käsitletudp	V;PASS;PRS;PRF;NEG;IND
+käsitlema	ei ole käsitletud	V;PASS;PRS;PRF;NEG;IND
 käsitlema	käsitleksin	V;ACT;PRS;POS;COND;1;SG
 käsitlema	olen käsitlenud	V;ACT;PRS;PRF;POS;IND;1;SG
-käsitlema	ei olnud käsitletudp	V;PASS;PST;PRF;NEG;IND
+käsitlema	ei olnud käsitletud	V;PASS;PST;PRF;NEG;IND
 käsitlema	ärgu olgu käsitletud	V;PASS;PRS;PRF;NEG;IMP
 
 käsitlus	käsitluseni	N;TERM;SG
@@ -10990,7 +10990,7 @@ käsitlus	käsitlustesse	N;IN+ALL;PL
 käsitlus	käsitlustelt	N;AT+ABL;PL
 
 käskima	olete käskinud	V;ACT;PRS;PRF;POS;IND;2;PL
-käskima	ei olevat käskinudp	V;ACT;PRS;PRF;NEG;QUOT
+käskima	ei olevat käskinud	V;ACT;PRS;PRF;NEG;QUOT
 käskima	oleks käsitud	V;PASS;PRS;PRF;POS;COND
 käskima	käskisin	V;ACT;PST;POS;IND;1;SG
 käskima	käsitakse	V;PASS;PRS;POS;IND
@@ -10999,7 +10999,7 @@ käskima	käsitagu	V;PASS;PRS;POS;IMP
 käskima	ärgu käskigu	V;ACT;PRS;NEG;IMP;3;SG
 käskima	oli käsitud	V;PASS;PST;PRF;POS;IND
 käskima	käskisime	V;ACT;PST;POS;IND;1;PL
-käskima	ei olnud käskinudp	V;ACT;PST;PRF;NEG;IND
+käskima	ei olnud käskinud	V;ACT;PST;PRF;NEG;IND
 käskima	oleksid käskinud	V;ACT;PRS;PRF;POS;COND;2;SG
 käskima	olgu käskinud	V;ACT;PRS;PRF;POS;IMP;PL
 käskima	oli käskinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -11013,9 +11013,9 @@ käskima	ärgu käskigu	V;ACT;PRS;NEG;IMP;3;PL
 käskima	olgu käskinud	V;ACT;PRS;PRF;POS;IMP;SG
 käskima	käsiti	V;PASS;PST;POS;IND
 käskima	ei käskivat	V;ACT;PRS;NEG;QUOT
-käskima	ei oleks käsitudp	V;PASS;PRS;PRF;NEG;COND
+käskima	ei oleks käsitud	V;PASS;PRS;PRF;NEG;COND
 käskima	ei käskinud	V;ACT;PST;NEG;IND
-käskima	ei olevat käsitudp	V;PASS;PRS;PRF;NEG;QUOT
+käskima	ei olevat käsitud	V;PASS;PRS;PRF;NEG;QUOT
 käskima	ei käsiks	V;ACT;PRS;PRF;POS;COND;1;SG
 käskima	käsitud	V.PTCP;PASS;PST
 käskima	olid käskinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -11034,7 +11034,7 @@ käskima	olgu käsitud	V;PASS;PRS;PRF;POS;IMP
 käskima	käsiks	V;ACT;PRS;POS;COND;3;SG
 käskima	käskigu	V;ACT;PRS;POS;IMP;3;PL
 käskima	ärgu olgu käskinud	V;ACT;PRS;PRF;NEG;IMP;SG
-käskima	ei ole käskinudp	V;ACT;PST;NEG;IND
+käskima	ei ole käskinud	V;ACT;PST;NEG;IND
 käskima	käsid	V;ACT;PRS;POS;IND;2;SG
 käskima	ära käsi	V;ACT;PRS;NEG;IMP;2;SG
 käskima	ei käsi	V;ACT;PRS;NEG;IND
@@ -11062,17 +11062,17 @@ käskima	ei käsita	V;PASS;PRS;NEG;IND
 käskima	käsime	V;ACT;PRS;POS;IND;1;PL
 käskima	käsin	V;ACT;PRS;POS;IND;1;SG
 käskima	ärgem käskigem	V;ACT;PRS;NEG;IMP;1;PL
-käskima	ei oleks käskinudp	V;ACT;PRS;PRF;NEG;COND
+käskima	ei oleks käskinud	V;ACT;PRS;PRF;NEG;COND
 käskima	oleksid käskinud	V;ACT;PRS;PRF;POS;COND;3;PL
 käskima	käskisite	V;ACT;PST;POS;IND;2;PL
 käskima	oleks käskinud	V;ACT;PRS;PRF;POS;COND;3;SG
 käskima	olin käskinud	V;ACT;PRS;PRF;POS;COND;1;SG
 käskima	oled käskinud	V;ACT;PRS;PRF;POS;IND;2;SG
 käskima	oli käskinud	V;ACT;PRS;PRF;POS;COND;3;SG
-käskima	ei ole käsitudp	V;PASS;PRS;PRF;NEG;IND
+käskima	ei ole käsitud	V;PASS;PRS;PRF;NEG;IND
 käskima	käsiksin	V;ACT;PRS;POS;COND;1;SG
 käskima	olen käskinud	V;ACT;PRS;PRF;POS;IND;1;SG
-käskima	ei olnud käsitudp	V;PASS;PST;PRF;NEG;IND
+käskima	ei olnud käsitud	V;PASS;PST;PRF;NEG;IND
 käskima	ärgu olgu käsitud	V;PASS;PRS;PRF;NEG;IMP
 
 käskiv	käskivani	N;TERM;SG
@@ -11169,7 +11169,7 @@ kääbus	kääbustesse	N;IN+ALL;PL
 kääbus	kääbustelt	N;AT+ABL;PL
 
 kõndima	olete kõndinud	V;ACT;PRS;PRF;POS;IND;2;PL
-kõndima	ei olevat kõndinudp	V;ACT;PRS;PRF;NEG;QUOT
+kõndima	ei olevat kõndinud	V;ACT;PRS;PRF;NEG;QUOT
 kõndima	oleks kõnnitud	V;PASS;PRS;PRF;POS;COND
 kõndima	kõndisin	V;ACT;PST;POS;IND;1;SG
 kõndima	kõnnitakse	V;PASS;PRS;POS;IND
@@ -11178,7 +11178,7 @@ kõndima	kõnnitagu	V;PASS;PRS;POS;IMP
 kõndima	ärgu kõndigu	V;ACT;PRS;NEG;IMP;3;SG
 kõndima	oli kõnnitud	V;PASS;PST;PRF;POS;IND
 kõndima	kõndisime	V;ACT;PST;POS;IND;1;PL
-kõndima	ei olnud kõndinudp	V;ACT;PST;PRF;NEG;IND
+kõndima	ei olnud kõndinud	V;ACT;PST;PRF;NEG;IND
 kõndima	oleksid kõndinud	V;ACT;PRS;PRF;POS;COND;2;SG
 kõndima	olgu kõndinud	V;ACT;PRS;PRF;POS;IMP;PL
 kõndima	oli kõndinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -11192,9 +11192,9 @@ kõndima	ärgu kõndigu	V;ACT;PRS;NEG;IMP;3;PL
 kõndima	olgu kõndinud	V;ACT;PRS;PRF;POS;IMP;SG
 kõndima	kõnniti	V;PASS;PST;POS;IND
 kõndima	ei kõndivat	V;ACT;PRS;NEG;QUOT
-kõndima	ei oleks kõnnitudp	V;PASS;PRS;PRF;NEG;COND
+kõndima	ei oleks kõnnitud	V;PASS;PRS;PRF;NEG;COND
 kõndima	ei kõndinud	V;ACT;PST;NEG;IND
-kõndima	ei olevat kõnnitudp	V;PASS;PRS;PRF;NEG;QUOT
+kõndima	ei olevat kõnnitud	V;PASS;PRS;PRF;NEG;QUOT
 kõndima	ei kõnniks	V;ACT;PRS;PRF;POS;COND;1;SG
 kõndima	kõnnitud	V.PTCP;PASS;PST
 kõndima	olid kõndinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -11213,7 +11213,7 @@ kõndima	olgu kõnnitud	V;PASS;PRS;PRF;POS;IMP
 kõndima	kõnniks	V;ACT;PRS;POS;COND;3;SG
 kõndima	kõndigu	V;ACT;PRS;POS;IMP;3;PL
 kõndima	ärgu olgu kõndinud	V;ACT;PRS;PRF;NEG;IMP;SG
-kõndima	ei ole kõndinudp	V;ACT;PST;NEG;IND
+kõndima	ei ole kõndinud	V;ACT;PST;NEG;IND
 kõndima	kõnnid	V;ACT;PRS;POS;IND;2;SG
 kõndima	ära kõnni	V;ACT;PRS;NEG;IMP;2;SG
 kõndima	ei kõnni	V;ACT;PRS;NEG;IND
@@ -11241,17 +11241,17 @@ kõndima	ei kõnnita	V;PASS;PRS;NEG;IND
 kõndima	kõnnime	V;ACT;PRS;POS;IND;1;PL
 kõndima	kõnnin	V;ACT;PRS;POS;IND;1;SG
 kõndima	ärgem kõndigem	V;ACT;PRS;NEG;IMP;1;PL
-kõndima	ei oleks kõndinudp	V;ACT;PRS;PRF;NEG;COND
+kõndima	ei oleks kõndinud	V;ACT;PRS;PRF;NEG;COND
 kõndima	oleksid kõndinud	V;ACT;PRS;PRF;POS;COND;3;PL
 kõndima	kõndisite	V;ACT;PST;POS;IND;2;PL
 kõndima	oleks kõndinud	V;ACT;PRS;PRF;POS;COND;3;SG
 kõndima	olin kõndinud	V;ACT;PRS;PRF;POS;COND;1;SG
 kõndima	oled kõndinud	V;ACT;PRS;PRF;POS;IND;2;SG
 kõndima	oli kõndinud	V;ACT;PRS;PRF;POS;COND;3;SG
-kõndima	ei ole kõnnitudp	V;PASS;PRS;PRF;NEG;IND
+kõndima	ei ole kõnnitud	V;PASS;PRS;PRF;NEG;IND
 kõndima	kõnniksin	V;ACT;PRS;POS;COND;1;SG
 kõndima	olen kõndinud	V;ACT;PRS;PRF;POS;IND;1;SG
-kõndima	ei olnud kõnnitudp	V;PASS;PST;PRF;NEG;IND
+kõndima	ei olnud kõnnitud	V;PASS;PST;PRF;NEG;IND
 kõndima	ärgu olgu kõnnitud	V;PASS;PRS;PRF;NEG;IMP
 
 kõri	kõrini	N;TERM;SG
@@ -11286,7 +11286,7 @@ kõri	kõridesse	N;IN+ALL;PL
 kõri	kõridelt	N;AT+ABL;PL
 
 külastama	olete külastanud	V;ACT;PRS;PRF;POS;IND;2;PL
-külastama	ei olevat külastanudp	V;ACT;PRS;PRF;NEG;QUOT
+külastama	ei olevat külastanud	V;ACT;PRS;PRF;NEG;QUOT
 külastama	oleks külastatud	V;PASS;PRS;PRF;POS;COND
 külastama	külastasin	V;ACT;PST;POS;IND;1;SG
 külastama	külastatakse	V;PASS;PRS;POS;IND
@@ -11295,7 +11295,7 @@ külastama	külastatagu	V;PASS;PRS;POS;IMP
 külastama	ärgu külastagu	V;ACT;PRS;NEG;IMP;3;SG
 külastama	oli külastatud	V;PASS;PST;PRF;POS;IND
 külastama	külastasime	V;ACT;PST;POS;IND;1;PL
-külastama	ei olnud külastanudp	V;ACT;PST;PRF;NEG;IND
+külastama	ei olnud külastanud	V;ACT;PST;PRF;NEG;IND
 külastama	oleksid külastanud	V;ACT;PRS;PRF;POS;COND;2;SG
 külastama	olgu külastanud	V;ACT;PRS;PRF;POS;IMP;PL
 külastama	oli külastanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -11309,9 +11309,9 @@ külastama	ärgu külastagu	V;ACT;PRS;NEG;IMP;3;PL
 külastama	olgu külastanud	V;ACT;PRS;PRF;POS;IMP;SG
 külastama	külastati	V;PASS;PST;POS;IND
 külastama	ei külastavat	V;ACT;PRS;NEG;QUOT
-külastama	ei oleks külastatudp	V;PASS;PRS;PRF;NEG;COND
+külastama	ei oleks külastatud	V;PASS;PRS;PRF;NEG;COND
 külastama	ei külastanud	V;ACT;PST;NEG;IND
-külastama	ei olevat külastatudp	V;PASS;PRS;PRF;NEG;QUOT
+külastama	ei olevat külastatud	V;PASS;PRS;PRF;NEG;QUOT
 külastama	ei külastaks	V;ACT;PRS;PRF;POS;COND;1;SG
 külastama	külastatud	V.PTCP;PASS;PST
 külastama	olid külastanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -11330,7 +11330,7 @@ külastama	olgu külastatud	V;PASS;PRS;PRF;POS;IMP
 külastama	külastaks	V;ACT;PRS;POS;COND;3;SG
 külastama	külastagu	V;ACT;PRS;POS;IMP;3;PL
 külastama	ärgu olgu külastanud	V;ACT;PRS;PRF;NEG;IMP;SG
-külastama	ei ole külastanudp	V;ACT;PST;NEG;IND
+külastama	ei ole külastanud	V;ACT;PST;NEG;IND
 külastama	külastad	V;ACT;PRS;POS;IND;2;SG
 külastama	ära külasta	V;ACT;PRS;NEG;IMP;2;SG
 külastama	ei külasta	V;ACT;PRS;NEG;IND
@@ -11358,17 +11358,17 @@ külastama	ei külastata	V;PASS;PRS;NEG;IND
 külastama	külastame	V;ACT;PRS;POS;IND;1;PL
 külastama	külastan	V;ACT;PRS;POS;IND;1;SG
 külastama	ärgem külastagem	V;ACT;PRS;NEG;IMP;1;PL
-külastama	ei oleks külastanudp	V;ACT;PRS;PRF;NEG;COND
+külastama	ei oleks külastanud	V;ACT;PRS;PRF;NEG;COND
 külastama	oleksid külastanud	V;ACT;PRS;PRF;POS;COND;3;PL
 külastama	külastasite	V;ACT;PST;POS;IND;2;PL
 külastama	oleks külastanud	V;ACT;PRS;PRF;POS;COND;3;SG
 külastama	olin külastanud	V;ACT;PRS;PRF;POS;COND;1;SG
 külastama	oled külastanud	V;ACT;PRS;PRF;POS;IND;2;SG
 külastama	oli külastanud	V;ACT;PRS;PRF;POS;COND;3;SG
-külastama	ei ole külastatudp	V;PASS;PRS;PRF;NEG;IND
+külastama	ei ole külastatud	V;PASS;PRS;PRF;NEG;IND
 külastama	külastaksin	V;ACT;PRS;POS;COND;1;SG
 külastama	olen külastanud	V;ACT;PRS;PRF;POS;IND;1;SG
-külastama	ei olnud külastatudp	V;PASS;PST;PRF;NEG;IND
+külastama	ei olnud külastatud	V;PASS;PST;PRF;NEG;IND
 külastama	ärgu olgu külastatud	V;PASS;PRS;PRF;NEG;IMP
 
 künnis	künniseni	N;TERM;SG
@@ -11403,7 +11403,7 @@ künnis	künnistesse	N;IN+ALL;PL
 künnis	künnistelt	N;AT+ABL;PL
 
 küsima	olete küsinud	V;ACT;PRS;PRF;POS;IND;2;PL
-küsima	ei olevat küsinudp	V;ACT;PRS;PRF;NEG;QUOT
+küsima	ei olevat küsinud	V;ACT;PRS;PRF;NEG;QUOT
 küsima	oleks küsitud	V;PASS;PRS;PRF;POS;COND
 küsima	küsisin	V;ACT;PST;POS;IND;1;SG
 küsima	küsitakse	V;PASS;PRS;POS;IND
@@ -11412,7 +11412,7 @@ küsima	küsitagu	V;PASS;PRS;POS;IMP
 küsima	ärgu küsigu	V;ACT;PRS;NEG;IMP;3;SG
 küsima	oli küsitud	V;PASS;PST;PRF;POS;IND
 küsima	küsisime	V;ACT;PST;POS;IND;1;PL
-küsima	ei olnud küsinudp	V;ACT;PST;PRF;NEG;IND
+küsima	ei olnud küsinud	V;ACT;PST;PRF;NEG;IND
 küsima	oleksid küsinud	V;ACT;PRS;PRF;POS;COND;2;SG
 küsima	olgu küsinud	V;ACT;PRS;PRF;POS;IMP;PL
 küsima	oli küsinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -11426,9 +11426,9 @@ küsima	ärgu küsigu	V;ACT;PRS;NEG;IMP;3;PL
 küsima	olgu küsinud	V;ACT;PRS;PRF;POS;IMP;SG
 küsima	küsiti	V;PASS;PST;POS;IND
 küsima	ei küsivat	V;ACT;PRS;NEG;QUOT
-küsima	ei oleks küsitudp	V;PASS;PRS;PRF;NEG;COND
+küsima	ei oleks küsitud	V;PASS;PRS;PRF;NEG;COND
 küsima	ei küsinud	V;ACT;PST;NEG;IND
-küsima	ei olevat küsitudp	V;PASS;PRS;PRF;NEG;QUOT
+küsima	ei olevat küsitud	V;PASS;PRS;PRF;NEG;QUOT
 küsima	ei küsiks	V;ACT;PRS;PRF;POS;COND;1;SG
 küsima	küsitud	V.PTCP;PASS;PST
 küsima	olid küsinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -11447,7 +11447,7 @@ küsima	olgu küsitud	V;PASS;PRS;PRF;POS;IMP
 küsima	küsiks	V;ACT;PRS;POS;COND;3;SG
 küsima	küsigu	V;ACT;PRS;POS;IMP;3;PL
 küsima	ärgu olgu küsinud	V;ACT;PRS;PRF;NEG;IMP;SG
-küsima	ei ole küsinudp	V;ACT;PST;NEG;IND
+küsima	ei ole küsinud	V;ACT;PST;NEG;IND
 küsima	küsid	V;ACT;PRS;POS;IND;2;SG
 küsima	ära küsi	V;ACT;PRS;NEG;IMP;2;SG
 küsima	ei küsi	V;ACT;PRS;NEG;IND
@@ -11475,17 +11475,17 @@ küsima	ei küsita	V;PASS;PRS;NEG;IND
 küsima	küsime	V;ACT;PRS;POS;IND;1;PL
 küsima	küsin	V;ACT;PRS;POS;IND;1;SG
 küsima	ärgem küsigem	V;ACT;PRS;NEG;IMP;1;PL
-küsima	ei oleks küsinudp	V;ACT;PRS;PRF;NEG;COND
+küsima	ei oleks küsinud	V;ACT;PRS;PRF;NEG;COND
 küsima	oleksid küsinud	V;ACT;PRS;PRF;POS;COND;3;PL
 küsima	küsisite	V;ACT;PST;POS;IND;2;PL
 küsima	oleks küsinud	V;ACT;PRS;PRF;POS;COND;3;SG
 küsima	olin küsinud	V;ACT;PRS;PRF;POS;COND;1;SG
 küsima	oled küsinud	V;ACT;PRS;PRF;POS;IND;2;SG
 küsima	oli küsinud	V;ACT;PRS;PRF;POS;COND;3;SG
-küsima	ei ole küsitudp	V;PASS;PRS;PRF;NEG;IND
+küsima	ei ole küsitud	V;PASS;PRS;PRF;NEG;IND
 küsima	küsiksin	V;ACT;PRS;POS;COND;1;SG
 küsima	olen küsinud	V;ACT;PRS;PRF;POS;IND;1;SG
-küsima	ei olnud küsitudp	V;PASS;PST;PRF;NEG;IND
+küsima	ei olnud küsitud	V;PASS;PST;PRF;NEG;IND
 küsima	ärgu olgu küsitud	V;PASS;PRS;PRF;NEG;IMP
 
 küsimus	küsimuseni	N;TERM;SG
@@ -11520,7 +11520,7 @@ küsimus	küsimustesse	N;IN+ALL;PL
 küsimus	küsimustelt	N;AT+ABL;PL
 
 kütma	olete kütnud	V;ACT;PRS;PRF;POS;IND;2;PL
-kütma	ei olevat kütnudp	V;ACT;PRS;PRF;NEG;QUOT
+kütma	ei olevat kütnud	V;ACT;PRS;PRF;NEG;QUOT
 kütma	oleks kütetud	V;PASS;PRS;PRF;POS;COND
 kütma	kütsin	V;ACT;PST;POS;IND;1;SG
 kütma	kütetakse	V;PASS;PRS;POS;IND
@@ -11529,7 +11529,7 @@ kütma	kütetagu	V;PASS;PRS;POS;IMP
 kütma	ärgu kütku	V;ACT;PRS;NEG;IMP;3;SG
 kütma	oli kütetud	V;PASS;PST;PRF;POS;IND
 kütma	kütsime	V;ACT;PST;POS;IND;1;PL
-kütma	ei olnud kütnudp	V;ACT;PST;PRF;NEG;IND
+kütma	ei olnud kütnud	V;ACT;PST;PRF;NEG;IND
 kütma	oleksid kütnud	V;ACT;PRS;PRF;POS;COND;2;SG
 kütma	olgu kütnud	V;ACT;PRS;PRF;POS;IMP;PL
 kütma	oli kütnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -11543,9 +11543,9 @@ kütma	ärgu kütku	V;ACT;PRS;NEG;IMP;3;PL
 kütma	olgu kütnud	V;ACT;PRS;PRF;POS;IMP;SG
 kütma	küteti	V;PASS;PST;POS;IND
 kütma	ei kütvat	V;ACT;PRS;NEG;QUOT
-kütma	ei oleks kütetudp	V;PASS;PRS;PRF;NEG;COND
+kütma	ei oleks kütetud	V;PASS;PRS;PRF;NEG;COND
 kütma	ei kütnud	V;ACT;PST;NEG;IND
-kütma	ei olevat kütetudp	V;PASS;PRS;PRF;NEG;QUOT
+kütma	ei olevat kütetud	V;PASS;PRS;PRF;NEG;QUOT
 kütma	ei kütaks	V;ACT;PRS;PRF;POS;COND;1;SG
 kütma	kütetud	V.PTCP;PASS;PST
 kütma	olid kütnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -11564,7 +11564,7 @@ kütma	olgu kütetud	V;PASS;PRS;PRF;POS;IMP
 kütma	kütaks	V;ACT;PRS;POS;COND;3;SG
 kütma	kütku	V;ACT;PRS;POS;IMP;3;PL
 kütma	ärgu olgu kütnud	V;ACT;PRS;PRF;NEG;IMP;SG
-kütma	ei ole kütnudp	V;ACT;PST;NEG;IND
+kütma	ei ole kütnud	V;ACT;PST;NEG;IND
 kütma	kütad	V;ACT;PRS;POS;IND;2;SG
 kütma	ära küta	V;ACT;PRS;NEG;IMP;2;SG
 kütma	ei küta	V;ACT;PRS;NEG;IND
@@ -11592,17 +11592,17 @@ kütma	ei küteta	V;PASS;PRS;NEG;IND
 kütma	kütame	V;ACT;PRS;POS;IND;1;PL
 kütma	kütan	V;ACT;PRS;POS;IND;1;SG
 kütma	ärgem kütkem	V;ACT;PRS;NEG;IMP;1;PL
-kütma	ei oleks kütnudp	V;ACT;PRS;PRF;NEG;COND
+kütma	ei oleks kütnud	V;ACT;PRS;PRF;NEG;COND
 kütma	oleksid kütnud	V;ACT;PRS;PRF;POS;COND;3;PL
 kütma	kütsite	V;ACT;PST;POS;IND;2;PL
 kütma	oleks kütnud	V;ACT;PRS;PRF;POS;COND;3;SG
 kütma	olin kütnud	V;ACT;PRS;PRF;POS;COND;1;SG
 kütma	oled kütnud	V;ACT;PRS;PRF;POS;IND;2;SG
 kütma	oli kütnud	V;ACT;PRS;PRF;POS;COND;3;SG
-kütma	ei ole kütetudp	V;PASS;PRS;PRF;NEG;IND
+kütma	ei ole kütetud	V;PASS;PRS;PRF;NEG;IND
 kütma	kütaksin	V;ACT;PRS;POS;COND;1;SG
 kütma	olen kütnud	V;ACT;PRS;PRF;POS;IND;1;SG
-kütma	ei olnud kütetudp	V;PASS;PST;PRF;NEG;IND
+kütma	ei olnud kütetud	V;PASS;PST;PRF;NEG;IND
 kütma	ärgu olgu kütetud	V;PASS;PRS;PRF;NEG;IMP
 
 küülik	küülikuni	N;TERM;SG
@@ -11792,7 +11792,7 @@ labidas	labidatesse	N;IN+ALL;PL
 labidas	labidatelt	N;AT+ABL;PL
 
 lahkuma	olete lahkunud	V;ACT;PRS;PRF;POS;IND;2;PL
-lahkuma	ei olevat lahkunudp	V;ACT;PRS;PRF;NEG;QUOT
+lahkuma	ei olevat lahkunud	V;ACT;PRS;PRF;NEG;QUOT
 lahkuma	oleks lahkutud	V;PASS;PRS;PRF;POS;COND
 lahkuma	lahkusin	V;ACT;PST;POS;IND;1;SG
 lahkuma	lahkutakse	V;PASS;PRS;POS;IND
@@ -11801,7 +11801,7 @@ lahkuma	lahkutagu	V;PASS;PRS;POS;IMP
 lahkuma	ärgu lahkugu	V;ACT;PRS;NEG;IMP;3;SG
 lahkuma	oli lahkutud	V;PASS;PST;PRF;POS;IND
 lahkuma	lahkusime	V;ACT;PST;POS;IND;1;PL
-lahkuma	ei olnud lahkunudp	V;ACT;PST;PRF;NEG;IND
+lahkuma	ei olnud lahkunud	V;ACT;PST;PRF;NEG;IND
 lahkuma	oleksid lahkunud	V;ACT;PRS;PRF;POS;COND;2;SG
 lahkuma	olgu lahkunud	V;ACT;PRS;PRF;POS;IMP;PL
 lahkuma	oli lahkunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -11815,9 +11815,9 @@ lahkuma	ärgu lahkugu	V;ACT;PRS;NEG;IMP;3;PL
 lahkuma	olgu lahkunud	V;ACT;PRS;PRF;POS;IMP;SG
 lahkuma	lahkuti	V;PASS;PST;POS;IND
 lahkuma	ei lahkuvat	V;ACT;PRS;NEG;QUOT
-lahkuma	ei oleks lahkutudp	V;PASS;PRS;PRF;NEG;COND
+lahkuma	ei oleks lahkutud	V;PASS;PRS;PRF;NEG;COND
 lahkuma	ei lahkunud	V;ACT;PST;NEG;IND
-lahkuma	ei olevat lahkutudp	V;PASS;PRS;PRF;NEG;QUOT
+lahkuma	ei olevat lahkutud	V;PASS;PRS;PRF;NEG;QUOT
 lahkuma	ei lahkuks	V;ACT;PRS;PRF;POS;COND;1;SG
 lahkuma	lahkutud	V.PTCP;PASS;PST
 lahkuma	olid lahkunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -11836,7 +11836,7 @@ lahkuma	olgu lahkutud	V;PASS;PRS;PRF;POS;IMP
 lahkuma	lahkuks	V;ACT;PRS;POS;COND;3;SG
 lahkuma	lahkugu	V;ACT;PRS;POS;IMP;3;PL
 lahkuma	ärgu olgu lahkunud	V;ACT;PRS;PRF;NEG;IMP;SG
-lahkuma	ei ole lahkunudp	V;ACT;PST;NEG;IND
+lahkuma	ei ole lahkunud	V;ACT;PST;NEG;IND
 lahkuma	lahkud	V;ACT;PRS;POS;IND;2;SG
 lahkuma	ära lahku	V;ACT;PRS;NEG;IMP;2;SG
 lahkuma	ei lahku	V;ACT;PRS;NEG;IND
@@ -11864,21 +11864,21 @@ lahkuma	ei lahkuta	V;PASS;PRS;NEG;IND
 lahkuma	lahkume	V;ACT;PRS;POS;IND;1;PL
 lahkuma	lahkun	V;ACT;PRS;POS;IND;1;SG
 lahkuma	ärgem lahkugem	V;ACT;PRS;NEG;IMP;1;PL
-lahkuma	ei oleks lahkunudp	V;ACT;PRS;PRF;NEG;COND
+lahkuma	ei oleks lahkunud	V;ACT;PRS;PRF;NEG;COND
 lahkuma	oleksid lahkunud	V;ACT;PRS;PRF;POS;COND;3;PL
 lahkuma	lahkusite	V;ACT;PST;POS;IND;2;PL
 lahkuma	oleks lahkunud	V;ACT;PRS;PRF;POS;COND;3;SG
 lahkuma	olin lahkunud	V;ACT;PRS;PRF;POS;COND;1;SG
 lahkuma	oled lahkunud	V;ACT;PRS;PRF;POS;IND;2;SG
 lahkuma	oli lahkunud	V;ACT;PRS;PRF;POS;COND;3;SG
-lahkuma	ei ole lahkutudp	V;PASS;PRS;PRF;NEG;IND
+lahkuma	ei ole lahkutud	V;PASS;PRS;PRF;NEG;IND
 lahkuma	lahkuksin	V;ACT;PRS;POS;COND;1;SG
 lahkuma	olen lahkunud	V;ACT;PRS;PRF;POS;IND;1;SG
-lahkuma	ei olnud lahkutudp	V;PASS;PST;PRF;NEG;IND
+lahkuma	ei olnud lahkutud	V;PASS;PST;PRF;NEG;IND
 lahkuma	ärgu olgu lahkutud	V;PASS;PRS;PRF;NEG;IMP
 
 langema	olete langenud	V;ACT;PRS;PRF;POS;IND;2;PL
-langema	ei olevat langenudp	V;ACT;PRS;PRF;NEG;QUOT
+langema	ei olevat langenud	V;ACT;PRS;PRF;NEG;QUOT
 langema	oleks langetud	V;PASS;PRS;PRF;POS;COND
 langema	langesin	V;ACT;PST;POS;IND;1;SG
 langema	langetakse	V;PASS;PRS;POS;IND
@@ -11887,7 +11887,7 @@ langema	langetagu	V;PASS;PRS;POS;IMP
 langema	ärgu langegu	V;ACT;PRS;NEG;IMP;3;SG
 langema	oli langetud	V;PASS;PST;PRF;POS;IND
 langema	langesime	V;ACT;PST;POS;IND;1;PL
-langema	ei olnud langenudp	V;ACT;PST;PRF;NEG;IND
+langema	ei olnud langenud	V;ACT;PST;PRF;NEG;IND
 langema	oleksid langenud	V;ACT;PRS;PRF;POS;COND;2;SG
 langema	olgu langenud	V;ACT;PRS;PRF;POS;IMP;PL
 langema	oli langenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -11901,9 +11901,9 @@ langema	ärgu langegu	V;ACT;PRS;NEG;IMP;3;PL
 langema	olgu langenud	V;ACT;PRS;PRF;POS;IMP;SG
 langema	langeti	V;PASS;PST;POS;IND
 langema	ei langevat	V;ACT;PRS;NEG;QUOT
-langema	ei oleks langetudp	V;PASS;PRS;PRF;NEG;COND
+langema	ei oleks langetud	V;PASS;PRS;PRF;NEG;COND
 langema	ei langenud	V;ACT;PST;NEG;IND
-langema	ei olevat langetudp	V;PASS;PRS;PRF;NEG;QUOT
+langema	ei olevat langetud	V;PASS;PRS;PRF;NEG;QUOT
 langema	ei langeks	V;ACT;PRS;PRF;POS;COND;1;SG
 langema	langetud	V.PTCP;PASS;PST
 langema	olid langenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -11922,7 +11922,7 @@ langema	olgu langetud	V;PASS;PRS;PRF;POS;IMP
 langema	langeks	V;ACT;PRS;POS;COND;3;SG
 langema	langegu	V;ACT;PRS;POS;IMP;3;PL
 langema	ärgu olgu langenud	V;ACT;PRS;PRF;NEG;IMP;SG
-langema	ei ole langenudp	V;ACT;PST;NEG;IND
+langema	ei ole langenud	V;ACT;PST;NEG;IND
 langema	langed	V;ACT;PRS;POS;IND;2;SG
 langema	ära lange	V;ACT;PRS;NEG;IMP;2;SG
 langema	ei lange	V;ACT;PRS;NEG;IND
@@ -11950,17 +11950,17 @@ langema	ei langeta	V;PASS;PRS;NEG;IND
 langema	langeme	V;ACT;PRS;POS;IND;1;PL
 langema	langen	V;ACT;PRS;POS;IND;1;SG
 langema	ärgem langegem	V;ACT;PRS;NEG;IMP;1;PL
-langema	ei oleks langenudp	V;ACT;PRS;PRF;NEG;COND
+langema	ei oleks langenud	V;ACT;PRS;PRF;NEG;COND
 langema	oleksid langenud	V;ACT;PRS;PRF;POS;COND;3;PL
 langema	langesite	V;ACT;PST;POS;IND;2;PL
 langema	oleks langenud	V;ACT;PRS;PRF;POS;COND;3;SG
 langema	olin langenud	V;ACT;PRS;PRF;POS;COND;1;SG
 langema	oled langenud	V;ACT;PRS;PRF;POS;IND;2;SG
 langema	oli langenud	V;ACT;PRS;PRF;POS;COND;3;SG
-langema	ei ole langetudp	V;PASS;PRS;PRF;NEG;IND
+langema	ei ole langetud	V;PASS;PRS;PRF;NEG;IND
 langema	langeksin	V;ACT;PRS;POS;COND;1;SG
 langema	olen langenud	V;ACT;PRS;PRF;POS;IND;1;SG
-langema	ei olnud langetudp	V;PASS;PST;PRF;NEG;IND
+langema	ei olnud langetud	V;PASS;PST;PRF;NEG;IND
 langema	ärgu olgu langetud	V;PASS;PRS;PRF;NEG;IMP
 
 langev	langevani	N;TERM;SG
@@ -12026,7 +12026,7 @@ laulja	lauljatesse	N;IN+ALL;PL
 laulja	lauljatelt	N;AT+ABL;PL
 
 laulma	olete laulnud	V;ACT;PRS;PRF;POS;IND;2;PL
-laulma	ei olevat laulnudp	V;ACT;PRS;PRF;NEG;QUOT
+laulma	ei olevat laulnud	V;ACT;PRS;PRF;NEG;QUOT
 laulma	oleks lauldud	V;PASS;PRS;PRF;POS;COND
 laulma	laulsin	V;ACT;PST;POS;IND;1;SG
 laulma	lauldakse	V;PASS;PRS;POS;IND
@@ -12035,7 +12035,7 @@ laulma	lauldagu	V;PASS;PRS;POS;IMP
 laulma	ärgu laulgu	V;ACT;PRS;NEG;IMP;3;SG
 laulma	oli lauldud	V;PASS;PST;PRF;POS;IND
 laulma	laulsime	V;ACT;PST;POS;IND;1;PL
-laulma	ei olnud laulnudp	V;ACT;PST;PRF;NEG;IND
+laulma	ei olnud laulnud	V;ACT;PST;PRF;NEG;IND
 laulma	oleksid laulnud	V;ACT;PRS;PRF;POS;COND;2;SG
 laulma	olgu laulnud	V;ACT;PRS;PRF;POS;IMP;PL
 laulma	oli laulnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -12049,9 +12049,9 @@ laulma	ärgu laulgu	V;ACT;PRS;NEG;IMP;3;PL
 laulma	olgu laulnud	V;ACT;PRS;PRF;POS;IMP;SG
 laulma	lauldi	V;PASS;PST;POS;IND
 laulma	ei laulvat	V;ACT;PRS;NEG;QUOT
-laulma	ei oleks lauldudp	V;PASS;PRS;PRF;NEG;COND
+laulma	ei oleks lauldud	V;PASS;PRS;PRF;NEG;COND
 laulma	ei laulnud	V;ACT;PST;NEG;IND
-laulma	ei olevat lauldudp	V;PASS;PRS;PRF;NEG;QUOT
+laulma	ei olevat lauldud	V;PASS;PRS;PRF;NEG;QUOT
 laulma	ei laulaks	V;ACT;PRS;PRF;POS;COND;1;SG
 laulma	lauldud	V.PTCP;PASS;PST
 laulma	olid laulnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -12070,7 +12070,7 @@ laulma	olgu lauldud	V;PASS;PRS;PRF;POS;IMP
 laulma	laulaks	V;ACT;PRS;POS;COND;3;SG
 laulma	laulgu	V;ACT;PRS;POS;IMP;3;PL
 laulma	ärgu olgu laulnud	V;ACT;PRS;PRF;NEG;IMP;SG
-laulma	ei ole laulnudp	V;ACT;PST;NEG;IND
+laulma	ei ole laulnud	V;ACT;PST;NEG;IND
 laulma	laulad	V;ACT;PRS;POS;IND;2;SG
 laulma	ära laula	V;ACT;PRS;NEG;IMP;2;SG
 laulma	ei laula	V;ACT;PRS;NEG;IND
@@ -12098,17 +12098,17 @@ laulma	ei laulda	V;PASS;PRS;NEG;IND
 laulma	laulame	V;ACT;PRS;POS;IND;1;PL
 laulma	laulan	V;ACT;PRS;POS;IND;1;SG
 laulma	ärgem laulgem	V;ACT;PRS;NEG;IMP;1;PL
-laulma	ei oleks laulnudp	V;ACT;PRS;PRF;NEG;COND
+laulma	ei oleks laulnud	V;ACT;PRS;PRF;NEG;COND
 laulma	oleksid laulnud	V;ACT;PRS;PRF;POS;COND;3;PL
 laulma	laulsite	V;ACT;PST;POS;IND;2;PL
 laulma	oleks laulnud	V;ACT;PRS;PRF;POS;COND;3;SG
 laulma	olin laulnud	V;ACT;PRS;PRF;POS;COND;1;SG
 laulma	oled laulnud	V;ACT;PRS;PRF;POS;IND;2;SG
 laulma	oli laulnud	V;ACT;PRS;PRF;POS;COND;3;SG
-laulma	ei ole lauldudp	V;PASS;PRS;PRF;NEG;IND
+laulma	ei ole lauldud	V;PASS;PRS;PRF;NEG;IND
 laulma	laulaksin	V;ACT;PRS;POS;COND;1;SG
 laulma	olen laulnud	V;ACT;PRS;PRF;POS;IND;1;SG
-laulma	ei olnud lauldudp	V;PASS;PST;PRF;NEG;IND
+laulma	ei olnud lauldud	V;PASS;PST;PRF;NEG;IND
 laulma	ärgu olgu lauldud	V;PASS;PRS;PRF;NEG;IMP
 
 lavastaja	lavastajani	N;TERM;SG
@@ -12143,7 +12143,7 @@ lavastaja	lavastajatesse	N;IN+ALL;PL
 lavastaja	lavastajatelt	N;AT+ABL;PL
 
 lavastama	olete lavastanud	V;ACT;PRS;PRF;POS;IND;2;PL
-lavastama	ei olevat lavastanudp	V;ACT;PRS;PRF;NEG;QUOT
+lavastama	ei olevat lavastanud	V;ACT;PRS;PRF;NEG;QUOT
 lavastama	oleks lavastatud	V;PASS;PRS;PRF;POS;COND
 lavastama	lavastasin	V;ACT;PST;POS;IND;1;SG
 lavastama	lavastatakse	V;PASS;PRS;POS;IND
@@ -12152,7 +12152,7 @@ lavastama	lavastatagu	V;PASS;PRS;POS;IMP
 lavastama	ärgu lavastagu	V;ACT;PRS;NEG;IMP;3;SG
 lavastama	oli lavastatud	V;PASS;PST;PRF;POS;IND
 lavastama	lavastasime	V;ACT;PST;POS;IND;1;PL
-lavastama	ei olnud lavastanudp	V;ACT;PST;PRF;NEG;IND
+lavastama	ei olnud lavastanud	V;ACT;PST;PRF;NEG;IND
 lavastama	oleksid lavastanud	V;ACT;PRS;PRF;POS;COND;2;SG
 lavastama	olgu lavastanud	V;ACT;PRS;PRF;POS;IMP;PL
 lavastama	oli lavastanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -12166,9 +12166,9 @@ lavastama	ärgu lavastagu	V;ACT;PRS;NEG;IMP;3;PL
 lavastama	olgu lavastanud	V;ACT;PRS;PRF;POS;IMP;SG
 lavastama	lavastati	V;PASS;PST;POS;IND
 lavastama	ei lavastavat	V;ACT;PRS;NEG;QUOT
-lavastama	ei oleks lavastatudp	V;PASS;PRS;PRF;NEG;COND
+lavastama	ei oleks lavastatud	V;PASS;PRS;PRF;NEG;COND
 lavastama	ei lavastanud	V;ACT;PST;NEG;IND
-lavastama	ei olevat lavastatudp	V;PASS;PRS;PRF;NEG;QUOT
+lavastama	ei olevat lavastatud	V;PASS;PRS;PRF;NEG;QUOT
 lavastama	ei lavastaks	V;ACT;PRS;PRF;POS;COND;1;SG
 lavastama	lavastatud	V.PTCP;PASS;PST
 lavastama	olid lavastanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -12187,7 +12187,7 @@ lavastama	olgu lavastatud	V;PASS;PRS;PRF;POS;IMP
 lavastama	lavastaks	V;ACT;PRS;POS;COND;3;SG
 lavastama	lavastagu	V;ACT;PRS;POS;IMP;3;PL
 lavastama	ärgu olgu lavastanud	V;ACT;PRS;PRF;NEG;IMP;SG
-lavastama	ei ole lavastanudp	V;ACT;PST;NEG;IND
+lavastama	ei ole lavastanud	V;ACT;PST;NEG;IND
 lavastama	lavastad	V;ACT;PRS;POS;IND;2;SG
 lavastama	ära lavasta	V;ACT;PRS;NEG;IMP;2;SG
 lavastama	ei lavasta	V;ACT;PRS;NEG;IND
@@ -12215,17 +12215,17 @@ lavastama	ei lavastata	V;PASS;PRS;NEG;IND
 lavastama	lavastame	V;ACT;PRS;POS;IND;1;PL
 lavastama	lavastan	V;ACT;PRS;POS;IND;1;SG
 lavastama	ärgem lavastagem	V;ACT;PRS;NEG;IMP;1;PL
-lavastama	ei oleks lavastanudp	V;ACT;PRS;PRF;NEG;COND
+lavastama	ei oleks lavastanud	V;ACT;PRS;PRF;NEG;COND
 lavastama	oleksid lavastanud	V;ACT;PRS;PRF;POS;COND;3;PL
 lavastama	lavastasite	V;ACT;PST;POS;IND;2;PL
 lavastama	oleks lavastanud	V;ACT;PRS;PRF;POS;COND;3;SG
 lavastama	olin lavastanud	V;ACT;PRS;PRF;POS;COND;1;SG
 lavastama	oled lavastanud	V;ACT;PRS;PRF;POS;IND;2;SG
 lavastama	oli lavastanud	V;ACT;PRS;PRF;POS;COND;3;SG
-lavastama	ei ole lavastatudp	V;PASS;PRS;PRF;NEG;IND
+lavastama	ei ole lavastatud	V;PASS;PRS;PRF;NEG;IND
 lavastama	lavastaksin	V;ACT;PRS;POS;COND;1;SG
 lavastama	olen lavastanud	V;ACT;PRS;PRF;POS;IND;1;SG
-lavastama	ei olnud lavastatudp	V;PASS;PST;PRF;NEG;IND
+lavastama	ei olnud lavastatud	V;PASS;PST;PRF;NEG;IND
 lavastama	ärgu olgu lavastatud	V;PASS;PRS;PRF;NEG;IMP
 
 lavrentsium	lavrentsiumini	N;TERM;SG
@@ -12260,7 +12260,7 @@ lavrentsium	lavrentsiumdesse	N;IN+ALL;PL
 lavrentsium	lavrentsiumdelt	N;AT+ABL;PL
 
 lebama	olete lebanud	V;ACT;PRS;PRF;POS;IND;2;PL
-lebama	ei olevat lebanudp	V;ACT;PRS;PRF;NEG;QUOT
+lebama	ei olevat lebanud	V;ACT;PRS;PRF;NEG;QUOT
 lebama	oleks lebatud	V;PASS;PRS;PRF;POS;COND
 lebama	lebasin	V;ACT;PST;POS;IND;1;SG
 lebama	lebatakse	V;PASS;PRS;POS;IND
@@ -12269,7 +12269,7 @@ lebama	lebatagu	V;PASS;PRS;POS;IMP
 lebama	ärgu lebagu	V;ACT;PRS;NEG;IMP;3;SG
 lebama	oli lebatud	V;PASS;PST;PRF;POS;IND
 lebama	lebasime	V;ACT;PST;POS;IND;1;PL
-lebama	ei olnud lebanudp	V;ACT;PST;PRF;NEG;IND
+lebama	ei olnud lebanud	V;ACT;PST;PRF;NEG;IND
 lebama	oleksid lebanud	V;ACT;PRS;PRF;POS;COND;2;SG
 lebama	olgu lebanud	V;ACT;PRS;PRF;POS;IMP;PL
 lebama	oli lebanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -12283,9 +12283,9 @@ lebama	ärgu lebagu	V;ACT;PRS;NEG;IMP;3;PL
 lebama	olgu lebanud	V;ACT;PRS;PRF;POS;IMP;SG
 lebama	lebati	V;PASS;PST;POS;IND
 lebama	ei lebavat	V;ACT;PRS;NEG;QUOT
-lebama	ei oleks lebatudp	V;PASS;PRS;PRF;NEG;COND
+lebama	ei oleks lebatud	V;PASS;PRS;PRF;NEG;COND
 lebama	ei lebanud	V;ACT;PST;NEG;IND
-lebama	ei olevat lebatudp	V;PASS;PRS;PRF;NEG;QUOT
+lebama	ei olevat lebatud	V;PASS;PRS;PRF;NEG;QUOT
 lebama	ei lebaks	V;ACT;PRS;PRF;POS;COND;1;SG
 lebama	lebatud	V.PTCP;PASS;PST
 lebama	olid lebanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -12304,7 +12304,7 @@ lebama	olgu lebatud	V;PASS;PRS;PRF;POS;IMP
 lebama	lebaks	V;ACT;PRS;POS;COND;3;SG
 lebama	lebagu	V;ACT;PRS;POS;IMP;3;PL
 lebama	ärgu olgu lebanud	V;ACT;PRS;PRF;NEG;IMP;SG
-lebama	ei ole lebanudp	V;ACT;PST;NEG;IND
+lebama	ei ole lebanud	V;ACT;PST;NEG;IND
 lebama	lebad	V;ACT;PRS;POS;IND;2;SG
 lebama	ära leba	V;ACT;PRS;NEG;IMP;2;SG
 lebama	ei leba	V;ACT;PRS;NEG;IND
@@ -12332,17 +12332,17 @@ lebama	ei lebata	V;PASS;PRS;NEG;IND
 lebama	lebame	V;ACT;PRS;POS;IND;1;PL
 lebama	leban	V;ACT;PRS;POS;IND;1;SG
 lebama	ärgem lebagem	V;ACT;PRS;NEG;IMP;1;PL
-lebama	ei oleks lebanudp	V;ACT;PRS;PRF;NEG;COND
+lebama	ei oleks lebanud	V;ACT;PRS;PRF;NEG;COND
 lebama	oleksid lebanud	V;ACT;PRS;PRF;POS;COND;3;PL
 lebama	lebasite	V;ACT;PST;POS;IND;2;PL
 lebama	oleks lebanud	V;ACT;PRS;PRF;POS;COND;3;SG
 lebama	olin lebanud	V;ACT;PRS;PRF;POS;COND;1;SG
 lebama	oled lebanud	V;ACT;PRS;PRF;POS;IND;2;SG
 lebama	oli lebanud	V;ACT;PRS;PRF;POS;COND;3;SG
-lebama	ei ole lebatudp	V;PASS;PRS;PRF;NEG;IND
+lebama	ei ole lebatud	V;PASS;PRS;PRF;NEG;IND
 lebama	lebaksin	V;ACT;PRS;POS;COND;1;SG
 lebama	olen lebanud	V;ACT;PRS;PRF;POS;IND;1;SG
-lebama	ei olnud lebatudp	V;PASS;PST;PRF;NEG;IND
+lebama	ei olnud lebatud	V;PASS;PST;PRF;NEG;IND
 lebama	ärgu olgu lebatud	V;PASS;PRS;PRF;NEG;IMP
 
 leedulane	leedulaseni	N;TERM;SG
@@ -12501,7 +12501,7 @@ lehtpuu	lehtpuudesse	N;IN+ALL;PL
 lehtpuu	lehtpuudelt	N;AT+ABL;PL
 
 leidma	olete leidnud	V;ACT;PRS;PRF;POS;IND;2;PL
-leidma	ei olevat leidnudp	V;ACT;PRS;PRF;NEG;QUOT
+leidma	ei olevat leidnud	V;ACT;PRS;PRF;NEG;QUOT
 leidma	oleks leietud	V;PASS;PRS;PRF;POS;COND
 leidma	leidsin	V;ACT;PST;POS;IND;1;SG
 leidma	leietakse	V;PASS;PRS;POS;IND
@@ -12510,7 +12510,7 @@ leidma	leietagu	V;PASS;PRS;POS;IMP
 leidma	ärgu leidku	V;ACT;PRS;NEG;IMP;3;SG
 leidma	oli leietud	V;PASS;PST;PRF;POS;IND
 leidma	leidsime	V;ACT;PST;POS;IND;1;PL
-leidma	ei olnud leidnudp	V;ACT;PST;PRF;NEG;IND
+leidma	ei olnud leidnud	V;ACT;PST;PRF;NEG;IND
 leidma	oleksid leidnud	V;ACT;PRS;PRF;POS;COND;2;SG
 leidma	olgu leidnud	V;ACT;PRS;PRF;POS;IMP;PL
 leidma	oli leidnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -12524,9 +12524,9 @@ leidma	ärgu leidku	V;ACT;PRS;NEG;IMP;3;PL
 leidma	olgu leidnud	V;ACT;PRS;PRF;POS;IMP;SG
 leidma	leieti	V;PASS;PST;POS;IND
 leidma	ei leidvat	V;ACT;PRS;NEG;QUOT
-leidma	ei oleks leietudp	V;PASS;PRS;PRF;NEG;COND
+leidma	ei oleks leietud	V;PASS;PRS;PRF;NEG;COND
 leidma	ei leidnud	V;ACT;PST;NEG;IND
-leidma	ei olevat leietudp	V;PASS;PRS;PRF;NEG;QUOT
+leidma	ei olevat leietud	V;PASS;PRS;PRF;NEG;QUOT
 leidma	ei leiaks	V;ACT;PRS;PRF;POS;COND;1;SG
 leidma	leietud	V.PTCP;PASS;PST
 leidma	olid leidnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -12545,7 +12545,7 @@ leidma	olgu leietud	V;PASS;PRS;PRF;POS;IMP
 leidma	leiaks	V;ACT;PRS;POS;COND;3;SG
 leidma	leidku	V;ACT;PRS;POS;IMP;3;PL
 leidma	ärgu olgu leidnud	V;ACT;PRS;PRF;NEG;IMP;SG
-leidma	ei ole leidnudp	V;ACT;PST;NEG;IND
+leidma	ei ole leidnud	V;ACT;PST;NEG;IND
 leidma	leiad	V;ACT;PRS;POS;IND;2;SG
 leidma	ära leia	V;ACT;PRS;NEG;IMP;2;SG
 leidma	ei leia	V;ACT;PRS;NEG;IND
@@ -12573,17 +12573,17 @@ leidma	ei leieta	V;PASS;PRS;NEG;IND
 leidma	leiame	V;ACT;PRS;POS;IND;1;PL
 leidma	leian	V;ACT;PRS;POS;IND;1;SG
 leidma	ärgem leidkem	V;ACT;PRS;NEG;IMP;1;PL
-leidma	ei oleks leidnudp	V;ACT;PRS;PRF;NEG;COND
+leidma	ei oleks leidnud	V;ACT;PRS;PRF;NEG;COND
 leidma	oleksid leidnud	V;ACT;PRS;PRF;POS;COND;3;PL
 leidma	leidsite	V;ACT;PST;POS;IND;2;PL
 leidma	oleks leidnud	V;ACT;PRS;PRF;POS;COND;3;SG
 leidma	olin leidnud	V;ACT;PRS;PRF;POS;COND;1;SG
 leidma	oled leidnud	V;ACT;PRS;PRF;POS;IND;2;SG
 leidma	oli leidnud	V;ACT;PRS;PRF;POS;COND;3;SG
-leidma	ei ole leietudp	V;PASS;PRS;PRF;NEG;IND
+leidma	ei ole leietud	V;PASS;PRS;PRF;NEG;IND
 leidma	leiaksin	V;ACT;PRS;POS;COND;1;SG
 leidma	olen leidnud	V;ACT;PRS;PRF;POS;IND;1;SG
-leidma	ei olnud leietudp	V;PASS;PST;PRF;NEG;IND
+leidma	ei olnud leietud	V;PASS;PST;PRF;NEG;IND
 leidma	ärgu olgu leietud	V;PASS;PRS;PRF;NEG;IMP
 
 leiutis	leiutiseni	N;TERM;SG
@@ -12649,7 +12649,7 @@ lemmik	lemmikutesse	N;IN+ALL;PL
 lemmik	lemmikutelt	N;AT+ABL;PL
 
 lendama	olete lennanud	V;ACT;PRS;PRF;POS;IND;2;PL
-lendama	ei olevat lennanudp	V;ACT;PRS;PRF;NEG;QUOT
+lendama	ei olevat lennanud	V;ACT;PRS;PRF;NEG;QUOT
 lendama	oleks lennatud	V;PASS;PRS;PRF;POS;COND
 lendama	lendasin	V;ACT;PST;POS;IND;1;SG
 lendama	lennatakse	V;PASS;PRS;POS;IND
@@ -12658,7 +12658,7 @@ lendama	lennatagu	V;PASS;PRS;POS;IMP
 lendama	ärgu lennaku	V;ACT;PRS;NEG;IMP;3;SG
 lendama	oli lennatud	V;PASS;PST;PRF;POS;IND
 lendama	lendasime	V;ACT;PST;POS;IND;1;PL
-lendama	ei olnud lennanudp	V;ACT;PST;PRF;NEG;IND
+lendama	ei olnud lennanud	V;ACT;PST;PRF;NEG;IND
 lendama	oleksid lennanud	V;ACT;PRS;PRF;POS;COND;2;SG
 lendama	olgu lennanud	V;ACT;PRS;PRF;POS;IMP;PL
 lendama	oli lennanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -12672,9 +12672,9 @@ lendama	ärgu lennaku	V;ACT;PRS;NEG;IMP;3;PL
 lendama	olgu lennanud	V;ACT;PRS;PRF;POS;IMP;SG
 lendama	lennati	V;PASS;PST;POS;IND
 lendama	ei lendavat	V;ACT;PRS;NEG;QUOT
-lendama	ei oleks lennatudp	V;PASS;PRS;PRF;NEG;COND
+lendama	ei oleks lennatud	V;PASS;PRS;PRF;NEG;COND
 lendama	ei lennanud	V;ACT;PST;NEG;IND
-lendama	ei olevat lennatudp	V;PASS;PRS;PRF;NEG;QUOT
+lendama	ei olevat lennatud	V;PASS;PRS;PRF;NEG;QUOT
 lendama	ei lendaks	V;ACT;PRS;PRF;POS;COND;1;SG
 lendama	lennatud	V.PTCP;PASS;PST
 lendama	olid lennanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -12693,7 +12693,7 @@ lendama	olgu lennatud	V;PASS;PRS;PRF;POS;IMP
 lendama	lendaks	V;ACT;PRS;POS;COND;3;SG
 lendama	lennaku	V;ACT;PRS;POS;IMP;3;PL
 lendama	ärgu olgu lennanud	V;ACT;PRS;PRF;NEG;IMP;SG
-lendama	ei ole lennanudp	V;ACT;PST;NEG;IND
+lendama	ei ole lennanud	V;ACT;PST;NEG;IND
 lendama	lendad	V;ACT;PRS;POS;IND;2;SG
 lendama	ära lenda	V;ACT;PRS;NEG;IMP;2;SG
 lendama	ei lenda	V;ACT;PRS;NEG;IND
@@ -12721,17 +12721,17 @@ lendama	ei lennata	V;PASS;PRS;NEG;IND
 lendama	lendame	V;ACT;PRS;POS;IND;1;PL
 lendama	lendan	V;ACT;PRS;POS;IND;1;SG
 lendama	ärgem lennakem	V;ACT;PRS;NEG;IMP;1;PL
-lendama	ei oleks lennanudp	V;ACT;PRS;PRF;NEG;COND
+lendama	ei oleks lennanud	V;ACT;PRS;PRF;NEG;COND
 lendama	oleksid lennanud	V;ACT;PRS;PRF;POS;COND;3;PL
 lendama	lendasite	V;ACT;PST;POS;IND;2;PL
 lendama	oleks lennanud	V;ACT;PRS;PRF;POS;COND;3;SG
 lendama	olin lennanud	V;ACT;PRS;PRF;POS;COND;1;SG
 lendama	oled lennanud	V;ACT;PRS;PRF;POS;IND;2;SG
 lendama	oli lennanud	V;ACT;PRS;PRF;POS;COND;3;SG
-lendama	ei ole lennatudp	V;PASS;PRS;PRF;NEG;IND
+lendama	ei ole lennatud	V;PASS;PRS;PRF;NEG;IND
 lendama	lendaksin	V;ACT;PRS;POS;COND;1;SG
 lendama	olen lennanud	V;ACT;PRS;PRF;POS;IND;1;SG
-lendama	ei olnud lennatudp	V;PASS;PST;PRF;NEG;IND
+lendama	ei olnud lennatud	V;PASS;PST;PRF;NEG;IND
 lendama	ärgu olgu lennatud	V;PASS;PRS;PRF;NEG;IMP
 
 lendav	lendavani	N;TERM;SG
@@ -12890,7 +12890,7 @@ lihas	lihastesse	N;IN+ALL;PL
 lihas	lihastelt	N;AT+ABL;PL
 
 liibuma	olete liibunud	V;ACT;PRS;PRF;POS;IND;2;PL
-liibuma	ei olevat liibunudp	V;ACT;PRS;PRF;NEG;QUOT
+liibuma	ei olevat liibunud	V;ACT;PRS;PRF;NEG;QUOT
 liibuma	oleks liibutud	V;PASS;PRS;PRF;POS;COND
 liibuma	liibusin	V;ACT;PST;POS;IND;1;SG
 liibuma	liibutakse	V;PASS;PRS;POS;IND
@@ -12899,7 +12899,7 @@ liibuma	liibutagu	V;PASS;PRS;POS;IMP
 liibuma	ärgu liibugu	V;ACT;PRS;NEG;IMP;3;SG
 liibuma	oli liibutud	V;PASS;PST;PRF;POS;IND
 liibuma	liibusime	V;ACT;PST;POS;IND;1;PL
-liibuma	ei olnud liibunudp	V;ACT;PST;PRF;NEG;IND
+liibuma	ei olnud liibunud	V;ACT;PST;PRF;NEG;IND
 liibuma	oleksid liibunud	V;ACT;PRS;PRF;POS;COND;2;SG
 liibuma	olgu liibunud	V;ACT;PRS;PRF;POS;IMP;PL
 liibuma	oli liibunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -12913,9 +12913,9 @@ liibuma	ärgu liibugu	V;ACT;PRS;NEG;IMP;3;PL
 liibuma	olgu liibunud	V;ACT;PRS;PRF;POS;IMP;SG
 liibuma	liibuti	V;PASS;PST;POS;IND
 liibuma	ei liibuvat	V;ACT;PRS;NEG;QUOT
-liibuma	ei oleks liibutudp	V;PASS;PRS;PRF;NEG;COND
+liibuma	ei oleks liibutud	V;PASS;PRS;PRF;NEG;COND
 liibuma	ei liibunud	V;ACT;PST;NEG;IND
-liibuma	ei olevat liibutudp	V;PASS;PRS;PRF;NEG;QUOT
+liibuma	ei olevat liibutud	V;PASS;PRS;PRF;NEG;QUOT
 liibuma	ei liibuks	V;ACT;PRS;PRF;POS;COND;1;SG
 liibuma	liibutud	V.PTCP;PASS;PST
 liibuma	olid liibunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -12934,7 +12934,7 @@ liibuma	olgu liibutud	V;PASS;PRS;PRF;POS;IMP
 liibuma	liibuks	V;ACT;PRS;POS;COND;3;SG
 liibuma	liibugu	V;ACT;PRS;POS;IMP;3;PL
 liibuma	ärgu olgu liibunud	V;ACT;PRS;PRF;NEG;IMP;SG
-liibuma	ei ole liibunudp	V;ACT;PST;NEG;IND
+liibuma	ei ole liibunud	V;ACT;PST;NEG;IND
 liibuma	liibud	V;ACT;PRS;POS;IND;2;SG
 liibuma	ära liibu	V;ACT;PRS;NEG;IMP;2;SG
 liibuma	ei liibu	V;ACT;PRS;NEG;IND
@@ -12962,17 +12962,17 @@ liibuma	ei liibuta	V;PASS;PRS;NEG;IND
 liibuma	liibume	V;ACT;PRS;POS;IND;1;PL
 liibuma	liibun	V;ACT;PRS;POS;IND;1;SG
 liibuma	ärgem liibugem	V;ACT;PRS;NEG;IMP;1;PL
-liibuma	ei oleks liibunudp	V;ACT;PRS;PRF;NEG;COND
+liibuma	ei oleks liibunud	V;ACT;PRS;PRF;NEG;COND
 liibuma	oleksid liibunud	V;ACT;PRS;PRF;POS;COND;3;PL
 liibuma	liibusite	V;ACT;PST;POS;IND;2;PL
 liibuma	oleks liibunud	V;ACT;PRS;PRF;POS;COND;3;SG
 liibuma	olin liibunud	V;ACT;PRS;PRF;POS;COND;1;SG
 liibuma	oled liibunud	V;ACT;PRS;PRF;POS;IND;2;SG
 liibuma	oli liibunud	V;ACT;PRS;PRF;POS;COND;3;SG
-liibuma	ei ole liibutudp	V;PASS;PRS;PRF;NEG;IND
+liibuma	ei ole liibutud	V;PASS;PRS;PRF;NEG;IND
 liibuma	liibuksin	V;ACT;PRS;POS;COND;1;SG
 liibuma	olen liibunud	V;ACT;PRS;PRF;POS;IND;1;SG
-liibuma	ei olnud liibutudp	V;PASS;PST;PRF;NEG;IND
+liibuma	ei olnud liibutud	V;PASS;PST;PRF;NEG;IND
 liibuma	ärgu olgu liibutud	V;PASS;PRS;PRF;NEG;IMP
 
 liige	liikmeni	N;TERM;SG
@@ -13069,7 +13069,7 @@ liivlane	liivlastesse	N;IN+ALL;PL
 liivlane	liivlastelt	N;AT+ABL;PL
 
 lintšima	olete lintšinud	V;ACT;PRS;PRF;POS;IND;2;PL
-lintšima	ei olevat lintšinudp	V;ACT;PRS;PRF;NEG;QUOT
+lintšima	ei olevat lintšinud	V;ACT;PRS;PRF;NEG;QUOT
 lintšima	oleks lintšitud	V;PASS;PRS;PRF;POS;COND
 lintšima	lintšisin	V;ACT;PST;POS;IND;1;SG
 lintšima	lintšitakse	V;PASS;PRS;POS;IND
@@ -13078,7 +13078,7 @@ lintšima	lintšitagu	V;PASS;PRS;POS;IMP
 lintšima	ärgu lintšigu	V;ACT;PRS;NEG;IMP;3;SG
 lintšima	oli lintšitud	V;PASS;PST;PRF;POS;IND
 lintšima	lintšisime	V;ACT;PST;POS;IND;1;PL
-lintšima	ei olnud lintšinudp	V;ACT;PST;PRF;NEG;IND
+lintšima	ei olnud lintšinud	V;ACT;PST;PRF;NEG;IND
 lintšima	oleksid lintšinud	V;ACT;PRS;PRF;POS;COND;2;SG
 lintšima	olgu lintšinud	V;ACT;PRS;PRF;POS;IMP;PL
 lintšima	oli lintšinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13092,9 +13092,9 @@ lintšima	ärgu lintšigu	V;ACT;PRS;NEG;IMP;3;PL
 lintšima	olgu lintšinud	V;ACT;PRS;PRF;POS;IMP;SG
 lintšima	lintšiti	V;PASS;PST;POS;IND
 lintšima	ei lintšivat	V;ACT;PRS;NEG;QUOT
-lintšima	ei oleks lintšitudp	V;PASS;PRS;PRF;NEG;COND
+lintšima	ei oleks lintšitud	V;PASS;PRS;PRF;NEG;COND
 lintšima	ei lintšinud	V;ACT;PST;NEG;IND
-lintšima	ei olevat lintšitudp	V;PASS;PRS;PRF;NEG;QUOT
+lintšima	ei olevat lintšitud	V;PASS;PRS;PRF;NEG;QUOT
 lintšima	ei lintšiks	V;ACT;PRS;PRF;POS;COND;1;SG
 lintšima	lintšitud	V.PTCP;PASS;PST
 lintšima	olid lintšinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13113,7 +13113,7 @@ lintšima	olgu lintšitud	V;PASS;PRS;PRF;POS;IMP
 lintšima	lintšiks	V;ACT;PRS;POS;COND;3;SG
 lintšima	lintšigu	V;ACT;PRS;POS;IMP;3;PL
 lintšima	ärgu olgu lintšinud	V;ACT;PRS;PRF;NEG;IMP;SG
-lintšima	ei ole lintšinudp	V;ACT;PST;NEG;IND
+lintšima	ei ole lintšinud	V;ACT;PST;NEG;IND
 lintšima	lintšid	V;ACT;PRS;POS;IND;2;SG
 lintšima	ära lintši	V;ACT;PRS;NEG;IMP;2;SG
 lintšima	ei lintši	V;ACT;PRS;NEG;IND
@@ -13141,21 +13141,21 @@ lintšima	ei lintšita	V;PASS;PRS;NEG;IND
 lintšima	lintšime	V;ACT;PRS;POS;IND;1;PL
 lintšima	lintšin	V;ACT;PRS;POS;IND;1;SG
 lintšima	ärgem lintšigem	V;ACT;PRS;NEG;IMP;1;PL
-lintšima	ei oleks lintšinudp	V;ACT;PRS;PRF;NEG;COND
+lintšima	ei oleks lintšinud	V;ACT;PRS;PRF;NEG;COND
 lintšima	oleksid lintšinud	V;ACT;PRS;PRF;POS;COND;3;PL
 lintšima	lintšisite	V;ACT;PST;POS;IND;2;PL
 lintšima	oleks lintšinud	V;ACT;PRS;PRF;POS;COND;3;SG
 lintšima	olin lintšinud	V;ACT;PRS;PRF;POS;COND;1;SG
 lintšima	oled lintšinud	V;ACT;PRS;PRF;POS;IND;2;SG
 lintšima	oli lintšinud	V;ACT;PRS;PRF;POS;COND;3;SG
-lintšima	ei ole lintšitudp	V;PASS;PRS;PRF;NEG;IND
+lintšima	ei ole lintšitud	V;PASS;PRS;PRF;NEG;IND
 lintšima	lintšiksin	V;ACT;PRS;POS;COND;1;SG
 lintšima	olen lintšinud	V;ACT;PRS;PRF;POS;IND;1;SG
-lintšima	ei olnud lintšitudp	V;PASS;PST;PRF;NEG;IND
+lintšima	ei olnud lintšitud	V;PASS;PST;PRF;NEG;IND
 lintšima	ärgu olgu lintšitud	V;PASS;PRS;PRF;NEG;IMP
 
 loendama	olete loendanud	V;ACT;PRS;PRF;POS;IND;2;PL
-loendama	ei olevat loendanudp	V;ACT;PRS;PRF;NEG;QUOT
+loendama	ei olevat loendanud	V;ACT;PRS;PRF;NEG;QUOT
 loendama	oleks loendatud	V;PASS;PRS;PRF;POS;COND
 loendama	loendasin	V;ACT;PST;POS;IND;1;SG
 loendama	loendatakse	V;PASS;PRS;POS;IND
@@ -13164,7 +13164,7 @@ loendama	loendatagu	V;PASS;PRS;POS;IMP
 loendama	ärgu loendagu	V;ACT;PRS;NEG;IMP;3;SG
 loendama	oli loendatud	V;PASS;PST;PRF;POS;IND
 loendama	loendasime	V;ACT;PST;POS;IND;1;PL
-loendama	ei olnud loendanudp	V;ACT;PST;PRF;NEG;IND
+loendama	ei olnud loendanud	V;ACT;PST;PRF;NEG;IND
 loendama	oleksid loendanud	V;ACT;PRS;PRF;POS;COND;2;SG
 loendama	olgu loendanud	V;ACT;PRS;PRF;POS;IMP;PL
 loendama	oli loendanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13178,9 +13178,9 @@ loendama	ärgu loendagu	V;ACT;PRS;NEG;IMP;3;PL
 loendama	olgu loendanud	V;ACT;PRS;PRF;POS;IMP;SG
 loendama	loendati	V;PASS;PST;POS;IND
 loendama	ei loendavat	V;ACT;PRS;NEG;QUOT
-loendama	ei oleks loendatudp	V;PASS;PRS;PRF;NEG;COND
+loendama	ei oleks loendatud	V;PASS;PRS;PRF;NEG;COND
 loendama	ei loendanud	V;ACT;PST;NEG;IND
-loendama	ei olevat loendatudp	V;PASS;PRS;PRF;NEG;QUOT
+loendama	ei olevat loendatud	V;PASS;PRS;PRF;NEG;QUOT
 loendama	ei loendaks	V;ACT;PRS;PRF;POS;COND;1;SG
 loendama	loendatud	V.PTCP;PASS;PST
 loendama	olid loendanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13199,7 +13199,7 @@ loendama	olgu loendatud	V;PASS;PRS;PRF;POS;IMP
 loendama	loendaks	V;ACT;PRS;POS;COND;3;SG
 loendama	loendagu	V;ACT;PRS;POS;IMP;3;PL
 loendama	ärgu olgu loendanud	V;ACT;PRS;PRF;NEG;IMP;SG
-loendama	ei ole loendanudp	V;ACT;PST;NEG;IND
+loendama	ei ole loendanud	V;ACT;PST;NEG;IND
 loendama	loendad	V;ACT;PRS;POS;IND;2;SG
 loendama	ära loenda	V;ACT;PRS;NEG;IMP;2;SG
 loendama	ei loenda	V;ACT;PRS;NEG;IND
@@ -13227,17 +13227,17 @@ loendama	ei loendata	V;PASS;PRS;NEG;IND
 loendama	loendame	V;ACT;PRS;POS;IND;1;PL
 loendama	loendan	V;ACT;PRS;POS;IND;1;SG
 loendama	ärgem loendagem	V;ACT;PRS;NEG;IMP;1;PL
-loendama	ei oleks loendanudp	V;ACT;PRS;PRF;NEG;COND
+loendama	ei oleks loendanud	V;ACT;PRS;PRF;NEG;COND
 loendama	oleksid loendanud	V;ACT;PRS;PRF;POS;COND;3;PL
 loendama	loendasite	V;ACT;PST;POS;IND;2;PL
 loendama	oleks loendanud	V;ACT;PRS;PRF;POS;COND;3;SG
 loendama	olin loendanud	V;ACT;PRS;PRF;POS;COND;1;SG
 loendama	oled loendanud	V;ACT;PRS;PRF;POS;IND;2;SG
 loendama	oli loendanud	V;ACT;PRS;PRF;POS;COND;3;SG
-loendama	ei ole loendatudp	V;PASS;PRS;PRF;NEG;IND
+loendama	ei ole loendatud	V;PASS;PRS;PRF;NEG;IND
 loendama	loendaksin	V;ACT;PRS;POS;COND;1;SG
 loendama	olen loendanud	V;ACT;PRS;PRF;POS;IND;1;SG
-loendama	ei olnud loendatudp	V;PASS;PST;PRF;NEG;IND
+loendama	ei olnud loendatud	V;PASS;PST;PRF;NEG;IND
 loendama	ärgu olgu loendatud	V;PASS;PRS;PRF;NEG;IMP
 
 loodus	looduseni	N;TERM;SG
@@ -13272,7 +13272,7 @@ loodus	loodustesse	N;IN+ALL;PL
 loodus	loodustelt	N;AT+ABL;PL
 
 looma	olete loonud	V;ACT;PRS;PRF;POS;IND;2;PL
-looma	ei olevat loonudp	V;ACT;PRS;PRF;NEG;QUOT
+looma	ei olevat loonud	V;ACT;PRS;PRF;NEG;QUOT
 looma	oleks loodud	V;PASS;PRS;PRF;POS;COND
 looma	lõin	V;ACT;PST;POS;IND;1;SG
 looma	luuakse	V;PASS;PRS;POS;IND
@@ -13281,7 +13281,7 @@ looma	loodagu	V;PASS;PRS;POS;IMP
 looma	ärgu loogu	V;ACT;PRS;NEG;IMP;3;SG
 looma	oli loodud	V;PASS;PST;PRF;POS;IND
 looma	lõime	V;ACT;PST;POS;IND;1;PL
-looma	ei olnud loonudp	V;ACT;PST;PRF;NEG;IND
+looma	ei olnud loonud	V;ACT;PST;PRF;NEG;IND
 looma	oleksid loonud	V;ACT;PRS;PRF;POS;COND;2;SG
 looma	olgu loonud	V;ACT;PRS;PRF;POS;IMP;PL
 looma	oli loonud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13295,9 +13295,9 @@ looma	ärgu loogu	V;ACT;PRS;NEG;IMP;3;PL
 looma	olgu loonud	V;ACT;PRS;PRF;POS;IMP;SG
 looma	loodi	V;PASS;PST;POS;IND
 looma	ei loovat	V;ACT;PRS;NEG;QUOT
-looma	ei oleks loodudp	V;PASS;PRS;PRF;NEG;COND
+looma	ei oleks loodud	V;PASS;PRS;PRF;NEG;COND
 looma	ei loonud	V;ACT;PST;NEG;IND
-looma	ei olevat loodudp	V;PASS;PRS;PRF;NEG;QUOT
+looma	ei olevat loodud	V;PASS;PRS;PRF;NEG;QUOT
 looma	ei looks	V;ACT;PRS;PRF;POS;COND;1;SG
 looma	loodud	V.PTCP;PASS;PST
 looma	olid loonud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13316,7 +13316,7 @@ looma	olgu loodud	V;PASS;PRS;PRF;POS;IMP
 looma	looks	V;ACT;PRS;POS;COND;3;SG
 looma	loogu	V;ACT;PRS;POS;IMP;3;PL
 looma	ärgu olgu loonud	V;ACT;PRS;PRF;NEG;IMP;SG
-looma	ei ole loonudp	V;ACT;PST;NEG;IND
+looma	ei ole loonud	V;ACT;PST;NEG;IND
 looma	lood	V;ACT;PRS;POS;IND;2;SG
 looma	ära loo	V;ACT;PRS;NEG;IMP;2;SG
 looma	ei loo	V;ACT;PRS;NEG;IND
@@ -13344,21 +13344,21 @@ looma	ei looda	V;PASS;PRS;NEG;IND
 looma	loome	V;ACT;PRS;POS;IND;1;PL
 looma	loon	V;ACT;PRS;POS;IND;1;SG
 looma	ärgem loogem	V;ACT;PRS;NEG;IMP;1;PL
-looma	ei oleks loonudp	V;ACT;PRS;PRF;NEG;COND
+looma	ei oleks loonud	V;ACT;PRS;PRF;NEG;COND
 looma	oleksid loonud	V;ACT;PRS;PRF;POS;COND;3;PL
 looma	lõite	V;ACT;PST;POS;IND;2;PL
 looma	oleks loonud	V;ACT;PRS;PRF;POS;COND;3;SG
 looma	olin loonud	V;ACT;PRS;PRF;POS;COND;1;SG
 looma	oled loonud	V;ACT;PRS;PRF;POS;IND;2;SG
 looma	oli loonud	V;ACT;PRS;PRF;POS;COND;3;SG
-looma	ei ole loodudp	V;PASS;PRS;PRF;NEG;IND
+looma	ei ole loodud	V;PASS;PRS;PRF;NEG;IND
 looma	looksin	V;ACT;PRS;POS;COND;1;SG
 looma	olen loonud	V;ACT;PRS;PRF;POS;IND;1;SG
-looma	ei olnud loodudp	V;PASS;PST;PRF;NEG;IND
+looma	ei olnud loodud	V;PASS;PST;PRF;NEG;IND
 looma	ärgu olgu loodud	V;PASS;PRS;PRF;NEG;IMP
 
 lootma	olete lootnud	V;ACT;PRS;PRF;POS;IND;2;PL
-lootma	ei olevat lootnudp	V;ACT;PRS;PRF;NEG;QUOT
+lootma	ei olevat lootnud	V;ACT;PRS;PRF;NEG;QUOT
 lootma	oleks loodetud	V;PASS;PRS;PRF;POS;COND
 lootma	lootsin	V;ACT;PST;POS;IND;1;SG
 lootma	loodetakse	V;PASS;PRS;POS;IND
@@ -13367,7 +13367,7 @@ lootma	loodetagu	V;PASS;PRS;POS;IMP
 lootma	ärgu lootku	V;ACT;PRS;NEG;IMP;3;SG
 lootma	oli loodetud	V;PASS;PST;PRF;POS;IND
 lootma	lootsime	V;ACT;PST;POS;IND;1;PL
-lootma	ei olnud lootnudp	V;ACT;PST;PRF;NEG;IND
+lootma	ei olnud lootnud	V;ACT;PST;PRF;NEG;IND
 lootma	oleksid lootnud	V;ACT;PRS;PRF;POS;COND;2;SG
 lootma	olgu lootnud	V;ACT;PRS;PRF;POS;IMP;PL
 lootma	oli lootnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13381,9 +13381,9 @@ lootma	ärgu lootku	V;ACT;PRS;NEG;IMP;3;PL
 lootma	olgu lootnud	V;ACT;PRS;PRF;POS;IMP;SG
 lootma	loodeti	V;PASS;PST;POS;IND
 lootma	ei lootvat	V;ACT;PRS;NEG;QUOT
-lootma	ei oleks loodetudp	V;PASS;PRS;PRF;NEG;COND
+lootma	ei oleks loodetud	V;PASS;PRS;PRF;NEG;COND
 lootma	ei lootnud	V;ACT;PST;NEG;IND
-lootma	ei olevat loodetudp	V;PASS;PRS;PRF;NEG;QUOT
+lootma	ei olevat loodetud	V;PASS;PRS;PRF;NEG;QUOT
 lootma	ei loodaks	V;ACT;PRS;PRF;POS;COND;1;SG
 lootma	loodetud	V.PTCP;PASS;PST
 lootma	olid lootnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13402,7 +13402,7 @@ lootma	olgu loodetud	V;PASS;PRS;PRF;POS;IMP
 lootma	loodaks	V;ACT;PRS;POS;COND;3;SG
 lootma	lootku	V;ACT;PRS;POS;IMP;3;PL
 lootma	ärgu olgu lootnud	V;ACT;PRS;PRF;NEG;IMP;SG
-lootma	ei ole lootnudp	V;ACT;PST;NEG;IND
+lootma	ei ole lootnud	V;ACT;PST;NEG;IND
 lootma	loodad	V;ACT;PRS;POS;IND;2;SG
 lootma	ära looda	V;ACT;PRS;NEG;IMP;2;SG
 lootma	ei looda	V;ACT;PRS;NEG;IND
@@ -13430,21 +13430,21 @@ lootma	ei loodeta	V;PASS;PRS;NEG;IND
 lootma	loodame	V;ACT;PRS;POS;IND;1;PL
 lootma	loodan	V;ACT;PRS;POS;IND;1;SG
 lootma	ärgem lootkem	V;ACT;PRS;NEG;IMP;1;PL
-lootma	ei oleks lootnudp	V;ACT;PRS;PRF;NEG;COND
+lootma	ei oleks lootnud	V;ACT;PRS;PRF;NEG;COND
 lootma	oleksid lootnud	V;ACT;PRS;PRF;POS;COND;3;PL
 lootma	lootsite	V;ACT;PST;POS;IND;2;PL
 lootma	oleks lootnud	V;ACT;PRS;PRF;POS;COND;3;SG
 lootma	olin lootnud	V;ACT;PRS;PRF;POS;COND;1;SG
 lootma	oled lootnud	V;ACT;PRS;PRF;POS;IND;2;SG
 lootma	oli lootnud	V;ACT;PRS;PRF;POS;COND;3;SG
-lootma	ei ole loodetudp	V;PASS;PRS;PRF;NEG;IND
+lootma	ei ole loodetud	V;PASS;PRS;PRF;NEG;IND
 lootma	loodaksin	V;ACT;PRS;POS;COND;1;SG
 lootma	olen lootnud	V;ACT;PRS;PRF;POS;IND;1;SG
-lootma	ei olnud loodetudp	V;PASS;PST;PRF;NEG;IND
+lootma	ei olnud loodetud	V;PASS;PST;PRF;NEG;IND
 lootma	ärgu olgu loodetud	V;PASS;PRS;PRF;NEG;IMP
 
 lugema	olete lugenud	V;ACT;PRS;PRF;POS;IND;2;PL
-lugema	ei olevat lugenudp	V;ACT;PRS;PRF;NEG;QUOT
+lugema	ei olevat lugenud	V;ACT;PRS;PRF;NEG;QUOT
 lugema	oleks loetud	V;PASS;PRS;PRF;POS;COND
 lugema	lugesin	V;ACT;PST;POS;IND;1;SG
 lugema	loetakse	V;PASS;PRS;POS;IND
@@ -13453,7 +13453,7 @@ lugema	loetagu	V;PASS;PRS;POS;IMP
 lugema	ärgu lugegu	V;ACT;PRS;NEG;IMP;3;SG
 lugema	oli loetud	V;PASS;PST;PRF;POS;IND
 lugema	lugesime	V;ACT;PST;POS;IND;1;PL
-lugema	ei olnud lugenudp	V;ACT;PST;PRF;NEG;IND
+lugema	ei olnud lugenud	V;ACT;PST;PRF;NEG;IND
 lugema	oleksid lugenud	V;ACT;PRS;PRF;POS;COND;2;SG
 lugema	olgu lugenud	V;ACT;PRS;PRF;POS;IMP;PL
 lugema	oli lugenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13467,9 +13467,9 @@ lugema	ärgu lugegu	V;ACT;PRS;NEG;IMP;3;PL
 lugema	olgu lugenud	V;ACT;PRS;PRF;POS;IMP;SG
 lugema	loeti	V;PASS;PST;POS;IND
 lugema	ei lugevat	V;ACT;PRS;NEG;QUOT
-lugema	ei oleks loetudp	V;PASS;PRS;PRF;NEG;COND
+lugema	ei oleks loetud	V;PASS;PRS;PRF;NEG;COND
 lugema	ei lugenud	V;ACT;PST;NEG;IND
-lugema	ei olevat loetudp	V;PASS;PRS;PRF;NEG;QUOT
+lugema	ei olevat loetud	V;PASS;PRS;PRF;NEG;QUOT
 lugema	ei loeks	V;ACT;PRS;PRF;POS;COND;1;SG
 lugema	loetud	V.PTCP;PASS;PST
 lugema	olid lugenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13488,7 +13488,7 @@ lugema	olgu loetud	V;PASS;PRS;PRF;POS;IMP
 lugema	loeks	V;ACT;PRS;POS;COND;3;SG
 lugema	lugegu	V;ACT;PRS;POS;IMP;3;PL
 lugema	ärgu olgu lugenud	V;ACT;PRS;PRF;NEG;IMP;SG
-lugema	ei ole lugenudp	V;ACT;PST;NEG;IND
+lugema	ei ole lugenud	V;ACT;PST;NEG;IND
 lugema	loed	V;ACT;PRS;POS;IND;2;SG
 lugema	ära loe	V;ACT;PRS;NEG;IMP;2;SG
 lugema	ei loe	V;ACT;PRS;NEG;IND
@@ -13516,17 +13516,17 @@ lugema	ei loeta	V;PASS;PRS;NEG;IND
 lugema	loeme	V;ACT;PRS;POS;IND;1;PL
 lugema	loen	V;ACT;PRS;POS;IND;1;SG
 lugema	ärgem lugegem	V;ACT;PRS;NEG;IMP;1;PL
-lugema	ei oleks lugenudp	V;ACT;PRS;PRF;NEG;COND
+lugema	ei oleks lugenud	V;ACT;PRS;PRF;NEG;COND
 lugema	oleksid lugenud	V;ACT;PRS;PRF;POS;COND;3;PL
 lugema	lugesite	V;ACT;PST;POS;IND;2;PL
 lugema	oleks lugenud	V;ACT;PRS;PRF;POS;COND;3;SG
 lugema	olin lugenud	V;ACT;PRS;PRF;POS;COND;1;SG
 lugema	oled lugenud	V;ACT;PRS;PRF;POS;IND;2;SG
 lugema	oli lugenud	V;ACT;PRS;PRF;POS;COND;3;SG
-lugema	ei ole loetudp	V;PASS;PRS;PRF;NEG;IND
+lugema	ei ole loetud	V;PASS;PRS;PRF;NEG;IND
 lugema	loeksin	V;ACT;PRS;POS;COND;1;SG
 lugema	olen lugenud	V;ACT;PRS;PRF;POS;IND;1;SG
-lugema	ei olnud loetudp	V;PASS;PST;PRF;NEG;IND
+lugema	ei olnud loetud	V;PASS;PST;PRF;NEG;IND
 lugema	ärgu olgu loetud	V;PASS;PRS;PRF;NEG;IMP
 
 lusikas	lusikani	N;TERM;SG
@@ -13623,7 +13623,7 @@ luterlane	luterlastesse	N;IN+ALL;PL
 luterlane	luterlastelt	N;AT+ABL;PL
 
 läbistama	olete läbistanud	V;ACT;PRS;PRF;POS;IND;2;PL
-läbistama	ei olevat läbistanudp	V;ACT;PRS;PRF;NEG;QUOT
+läbistama	ei olevat läbistanud	V;ACT;PRS;PRF;NEG;QUOT
 läbistama	oleks läbistatud	V;PASS;PRS;PRF;POS;COND
 läbistama	läbistasin	V;ACT;PST;POS;IND;1;SG
 läbistama	läbistatakse	V;PASS;PRS;POS;IND
@@ -13632,7 +13632,7 @@ läbistama	läbistatagu	V;PASS;PRS;POS;IMP
 läbistama	ärgu läbistagu	V;ACT;PRS;NEG;IMP;3;SG
 läbistama	oli läbistatud	V;PASS;PST;PRF;POS;IND
 läbistama	läbistasime	V;ACT;PST;POS;IND;1;PL
-läbistama	ei olnud läbistanudp	V;ACT;PST;PRF;NEG;IND
+läbistama	ei olnud läbistanud	V;ACT;PST;PRF;NEG;IND
 läbistama	oleksid läbistanud	V;ACT;PRS;PRF;POS;COND;2;SG
 läbistama	olgu läbistanud	V;ACT;PRS;PRF;POS;IMP;PL
 läbistama	oli läbistanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13646,9 +13646,9 @@ läbistama	ärgu läbistagu	V;ACT;PRS;NEG;IMP;3;PL
 läbistama	olgu läbistanud	V;ACT;PRS;PRF;POS;IMP;SG
 läbistama	läbistati	V;PASS;PST;POS;IND
 läbistama	ei läbistavat	V;ACT;PRS;NEG;QUOT
-läbistama	ei oleks läbistatudp	V;PASS;PRS;PRF;NEG;COND
+läbistama	ei oleks läbistatud	V;PASS;PRS;PRF;NEG;COND
 läbistama	ei läbistanud	V;ACT;PST;NEG;IND
-läbistama	ei olevat läbistatudp	V;PASS;PRS;PRF;NEG;QUOT
+läbistama	ei olevat läbistatud	V;PASS;PRS;PRF;NEG;QUOT
 läbistama	ei läbistaks	V;ACT;PRS;PRF;POS;COND;1;SG
 läbistama	läbistatud	V.PTCP;PASS;PST
 läbistama	olid läbistanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13667,7 +13667,7 @@ läbistama	olgu läbistatud	V;PASS;PRS;PRF;POS;IMP
 läbistama	läbistaks	V;ACT;PRS;POS;COND;3;SG
 läbistama	läbistagu	V;ACT;PRS;POS;IMP;3;PL
 läbistama	ärgu olgu läbistanud	V;ACT;PRS;PRF;NEG;IMP;SG
-läbistama	ei ole läbistanudp	V;ACT;PST;NEG;IND
+läbistama	ei ole läbistanud	V;ACT;PST;NEG;IND
 läbistama	läbistad	V;ACT;PRS;POS;IND;2;SG
 läbistama	ära läbista	V;ACT;PRS;NEG;IMP;2;SG
 läbistama	ei läbista	V;ACT;PRS;NEG;IND
@@ -13695,17 +13695,17 @@ läbistama	ei läbistata	V;PASS;PRS;NEG;IND
 läbistama	läbistame	V;ACT;PRS;POS;IND;1;PL
 läbistama	läbistan	V;ACT;PRS;POS;IND;1;SG
 läbistama	ärgem läbistagem	V;ACT;PRS;NEG;IMP;1;PL
-läbistama	ei oleks läbistanudp	V;ACT;PRS;PRF;NEG;COND
+läbistama	ei oleks läbistanud	V;ACT;PRS;PRF;NEG;COND
 läbistama	oleksid läbistanud	V;ACT;PRS;PRF;POS;COND;3;PL
 läbistama	läbistasite	V;ACT;PST;POS;IND;2;PL
 läbistama	oleks läbistanud	V;ACT;PRS;PRF;POS;COND;3;SG
 läbistama	olin läbistanud	V;ACT;PRS;PRF;POS;COND;1;SG
 läbistama	oled läbistanud	V;ACT;PRS;PRF;POS;IND;2;SG
 läbistama	oli läbistanud	V;ACT;PRS;PRF;POS;COND;3;SG
-läbistama	ei ole läbistatudp	V;PASS;PRS;PRF;NEG;IND
+läbistama	ei ole läbistatud	V;PASS;PRS;PRF;NEG;IND
 läbistama	läbistaksin	V;ACT;PRS;POS;COND;1;SG
 läbistama	olen läbistanud	V;ACT;PRS;PRF;POS;IND;1;SG
-läbistama	ei olnud läbistatudp	V;PASS;PST;PRF;NEG;IND
+läbistama	ei olnud läbistatud	V;PASS;PST;PRF;NEG;IND
 läbistama	ärgu olgu läbistatud	V;PASS;PRS;PRF;NEG;IMP
 
 lätlane	lätlaseni	N;TERM;SG
@@ -13802,7 +13802,7 @@ lõikuskuu	lõikuskuudesse	N;IN+ALL;PL
 lõikuskuu	lõikuskuudelt	N;AT+ABL;PL
 
 lõpetama	olete lõpetanud	V;ACT;PRS;PRF;POS;IND;2;PL
-lõpetama	ei olevat lõpetanudp	V;ACT;PRS;PRF;NEG;QUOT
+lõpetama	ei olevat lõpetanud	V;ACT;PRS;PRF;NEG;QUOT
 lõpetama	oleks lõpetatud	V;PASS;PRS;PRF;POS;COND
 lõpetama	lõpetasin	V;ACT;PST;POS;IND;1;SG
 lõpetama	lõpetatakse	V;PASS;PRS;POS;IND
@@ -13811,7 +13811,7 @@ lõpetama	lõpetatagu	V;PASS;PRS;POS;IMP
 lõpetama	ärgu lõpetagu	V;ACT;PRS;NEG;IMP;3;SG
 lõpetama	oli lõpetatud	V;PASS;PST;PRF;POS;IND
 lõpetama	lõpetasime	V;ACT;PST;POS;IND;1;PL
-lõpetama	ei olnud lõpetanudp	V;ACT;PST;PRF;NEG;IND
+lõpetama	ei olnud lõpetanud	V;ACT;PST;PRF;NEG;IND
 lõpetama	oleksid lõpetanud	V;ACT;PRS;PRF;POS;COND;2;SG
 lõpetama	olgu lõpetanud	V;ACT;PRS;PRF;POS;IMP;PL
 lõpetama	oli lõpetanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13825,9 +13825,9 @@ lõpetama	ärgu lõpetagu	V;ACT;PRS;NEG;IMP;3;PL
 lõpetama	olgu lõpetanud	V;ACT;PRS;PRF;POS;IMP;SG
 lõpetama	lõpetati	V;PASS;PST;POS;IND
 lõpetama	ei lõpetavat	V;ACT;PRS;NEG;QUOT
-lõpetama	ei oleks lõpetatudp	V;PASS;PRS;PRF;NEG;COND
+lõpetama	ei oleks lõpetatud	V;PASS;PRS;PRF;NEG;COND
 lõpetama	ei lõpetanud	V;ACT;PST;NEG;IND
-lõpetama	ei olevat lõpetatudp	V;PASS;PRS;PRF;NEG;QUOT
+lõpetama	ei olevat lõpetatud	V;PASS;PRS;PRF;NEG;QUOT
 lõpetama	ei lõpetaks	V;ACT;PRS;PRF;POS;COND;1;SG
 lõpetama	lõpetatud	V.PTCP;PASS;PST
 lõpetama	olid lõpetanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13846,7 +13846,7 @@ lõpetama	olgu lõpetatud	V;PASS;PRS;PRF;POS;IMP
 lõpetama	lõpetaks	V;ACT;PRS;POS;COND;3;SG
 lõpetama	lõpetagu	V;ACT;PRS;POS;IMP;3;PL
 lõpetama	ärgu olgu lõpetanud	V;ACT;PRS;PRF;NEG;IMP;SG
-lõpetama	ei ole lõpetanudp	V;ACT;PST;NEG;IND
+lõpetama	ei ole lõpetanud	V;ACT;PST;NEG;IND
 lõpetama	lõpetad	V;ACT;PRS;POS;IND;2;SG
 lõpetama	ära lõpeta	V;ACT;PRS;NEG;IMP;2;SG
 lõpetama	ei lõpeta	V;ACT;PRS;NEG;IND
@@ -13874,17 +13874,17 @@ lõpetama	ei lõpetata	V;PASS;PRS;NEG;IND
 lõpetama	lõpetame	V;ACT;PRS;POS;IND;1;PL
 lõpetama	lõpetan	V;ACT;PRS;POS;IND;1;SG
 lõpetama	ärgem lõpetagem	V;ACT;PRS;NEG;IMP;1;PL
-lõpetama	ei oleks lõpetanudp	V;ACT;PRS;PRF;NEG;COND
+lõpetama	ei oleks lõpetanud	V;ACT;PRS;PRF;NEG;COND
 lõpetama	oleksid lõpetanud	V;ACT;PRS;PRF;POS;COND;3;PL
 lõpetama	lõpetasite	V;ACT;PST;POS;IND;2;PL
 lõpetama	oleks lõpetanud	V;ACT;PRS;PRF;POS;COND;3;SG
 lõpetama	olin lõpetanud	V;ACT;PRS;PRF;POS;COND;1;SG
 lõpetama	oled lõpetanud	V;ACT;PRS;PRF;POS;IND;2;SG
 lõpetama	oli lõpetanud	V;ACT;PRS;PRF;POS;COND;3;SG
-lõpetama	ei ole lõpetatudp	V;PASS;PRS;PRF;NEG;IND
+lõpetama	ei ole lõpetatud	V;PASS;PRS;PRF;NEG;IND
 lõpetama	lõpetaksin	V;ACT;PRS;POS;COND;1;SG
 lõpetama	olen lõpetanud	V;ACT;PRS;PRF;POS;IND;1;SG
-lõpetama	ei olnud lõpetatudp	V;PASS;PST;PRF;NEG;IND
+lõpetama	ei olnud lõpetatud	V;PASS;PST;PRF;NEG;IND
 lõpetama	ärgu olgu lõpetatud	V;PASS;PRS;PRF;NEG;IMP
 
 lõvi	lõvini	N;TERM;SG
@@ -13919,7 +13919,7 @@ lõvi	lõvidesse	N;IN+ALL;PL
 lõvi	lõvidelt	N;AT+ABL;PL
 
 lööma	olete löönud	V;ACT;PRS;PRF;POS;IND;2;PL
-lööma	ei olevat löönudp	V;ACT;PRS;PRF;NEG;QUOT
+lööma	ei olevat löönud	V;ACT;PRS;PRF;NEG;QUOT
 lööma	oleks löödud	V;PASS;PRS;PRF;POS;COND
 lööma	lõin	V;ACT;PST;POS;IND;1;SG
 lööma	lüüakse	V;PASS;PRS;POS;IND
@@ -13928,7 +13928,7 @@ lööma	löödagu	V;PASS;PRS;POS;IMP
 lööma	ärgu löögu	V;ACT;PRS;NEG;IMP;3;SG
 lööma	oli löödud	V;PASS;PST;PRF;POS;IND
 lööma	lõime	V;ACT;PST;POS;IND;1;PL
-lööma	ei olnud löönudp	V;ACT;PST;PRF;NEG;IND
+lööma	ei olnud löönud	V;ACT;PST;PRF;NEG;IND
 lööma	oleksid löönud	V;ACT;PRS;PRF;POS;COND;2;SG
 lööma	olgu löönud	V;ACT;PRS;PRF;POS;IMP;PL
 lööma	oli löönud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -13942,9 +13942,9 @@ lööma	ärgu löögu	V;ACT;PRS;NEG;IMP;3;PL
 lööma	olgu löönud	V;ACT;PRS;PRF;POS;IMP;SG
 lööma	löödi	V;PASS;PST;POS;IND
 lööma	ei löövat	V;ACT;PRS;NEG;QUOT
-lööma	ei oleks löödudp	V;PASS;PRS;PRF;NEG;COND
+lööma	ei oleks löödud	V;PASS;PRS;PRF;NEG;COND
 lööma	ei löönud	V;ACT;PST;NEG;IND
-lööma	ei olevat löödudp	V;PASS;PRS;PRF;NEG;QUOT
+lööma	ei olevat löödud	V;PASS;PRS;PRF;NEG;QUOT
 lööma	ei lööks	V;ACT;PRS;PRF;POS;COND;1;SG
 lööma	löödud	V.PTCP;PASS;PST
 lööma	olid löönud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -13963,7 +13963,7 @@ lööma	olgu löödud	V;PASS;PRS;PRF;POS;IMP
 lööma	lööks	V;ACT;PRS;POS;COND;3;SG
 lööma	löögu	V;ACT;PRS;POS;IMP;3;PL
 lööma	ärgu olgu löönud	V;ACT;PRS;PRF;NEG;IMP;SG
-lööma	ei ole löönudp	V;ACT;PST;NEG;IND
+lööma	ei ole löönud	V;ACT;PST;NEG;IND
 lööma	lööd	V;ACT;PRS;POS;IND;2;SG
 lööma	ära löö	V;ACT;PRS;NEG;IMP;2;SG
 lööma	ei löö	V;ACT;PRS;NEG;IND
@@ -13991,21 +13991,21 @@ lööma	ei lööda	V;PASS;PRS;NEG;IND
 lööma	lööme	V;ACT;PRS;POS;IND;1;PL
 lööma	löön	V;ACT;PRS;POS;IND;1;SG
 lööma	ärgem löögem	V;ACT;PRS;NEG;IMP;1;PL
-lööma	ei oleks löönudp	V;ACT;PRS;PRF;NEG;COND
+lööma	ei oleks löönud	V;ACT;PRS;PRF;NEG;COND
 lööma	oleksid löönud	V;ACT;PRS;PRF;POS;COND;3;PL
 lööma	lõite	V;ACT;PST;POS;IND;2;PL
 lööma	oleks löönud	V;ACT;PRS;PRF;POS;COND;3;SG
 lööma	olin löönud	V;ACT;PRS;PRF;POS;COND;1;SG
 lööma	oled löönud	V;ACT;PRS;PRF;POS;IND;2;SG
 lööma	oli löönud	V;ACT;PRS;PRF;POS;COND;3;SG
-lööma	ei ole löödudp	V;PASS;PRS;PRF;NEG;IND
+lööma	ei ole löödud	V;PASS;PRS;PRF;NEG;IND
 lööma	lööksin	V;ACT;PRS;POS;COND;1;SG
 lööma	olen löönud	V;ACT;PRS;PRF;POS;IND;1;SG
-lööma	ei olnud löödudp	V;PASS;PST;PRF;NEG;IND
+lööma	ei olnud löödud	V;PASS;PST;PRF;NEG;IND
 lööma	ärgu olgu löödud	V;PASS;PRS;PRF;NEG;IMP
 
 lükkama	olete lükanud	V;ACT;PRS;PRF;POS;IND;2;PL
-lükkama	ei olevat lükanudp	V;ACT;PRS;PRF;NEG;QUOT
+lükkama	ei olevat lükanud	V;ACT;PRS;PRF;NEG;QUOT
 lükkama	oleks lükatud	V;PASS;PRS;PRF;POS;COND
 lükkama	lükkasin	V;ACT;PST;POS;IND;1;SG
 lükkama	lükatakse	V;PASS;PRS;POS;IND
@@ -14014,7 +14014,7 @@ lükkama	lükatagu	V;PASS;PRS;POS;IMP
 lükkama	ärgu lükaku	V;ACT;PRS;NEG;IMP;3;SG
 lükkama	oli lükatud	V;PASS;PST;PRF;POS;IND
 lükkama	lükkasime	V;ACT;PST;POS;IND;1;PL
-lükkama	ei olnud lükanudp	V;ACT;PST;PRF;NEG;IND
+lükkama	ei olnud lükanud	V;ACT;PST;PRF;NEG;IND
 lükkama	oleksid lükanud	V;ACT;PRS;PRF;POS;COND;2;SG
 lükkama	olgu lükanud	V;ACT;PRS;PRF;POS;IMP;PL
 lükkama	oli lükanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -14028,9 +14028,9 @@ lükkama	ärgu lükaku	V;ACT;PRS;NEG;IMP;3;PL
 lükkama	olgu lükanud	V;ACT;PRS;PRF;POS;IMP;SG
 lükkama	lükati	V;PASS;PST;POS;IND
 lükkama	ei lükkavat	V;ACT;PRS;NEG;QUOT
-lükkama	ei oleks lükatudp	V;PASS;PRS;PRF;NEG;COND
+lükkama	ei oleks lükatud	V;PASS;PRS;PRF;NEG;COND
 lükkama	ei lükanud	V;ACT;PST;NEG;IND
-lükkama	ei olevat lükatudp	V;PASS;PRS;PRF;NEG;QUOT
+lükkama	ei olevat lükatud	V;PASS;PRS;PRF;NEG;QUOT
 lükkama	ei lükkaks	V;ACT;PRS;PRF;POS;COND;1;SG
 lükkama	lükatud	V.PTCP;PASS;PST
 lükkama	olid lükanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -14049,7 +14049,7 @@ lükkama	olgu lükatud	V;PASS;PRS;PRF;POS;IMP
 lükkama	lükkaks	V;ACT;PRS;POS;COND;3;SG
 lükkama	lükaku	V;ACT;PRS;POS;IMP;3;PL
 lükkama	ärgu olgu lükanud	V;ACT;PRS;PRF;NEG;IMP;SG
-lükkama	ei ole lükanudp	V;ACT;PST;NEG;IND
+lükkama	ei ole lükanud	V;ACT;PST;NEG;IND
 lükkama	lükkad	V;ACT;PRS;POS;IND;2;SG
 lükkama	ära lükka	V;ACT;PRS;NEG;IMP;2;SG
 lükkama	ei lükka	V;ACT;PRS;NEG;IND
@@ -14077,17 +14077,17 @@ lükkama	ei lükata	V;PASS;PRS;NEG;IND
 lükkama	lükkame	V;ACT;PRS;POS;IND;1;PL
 lükkama	lükkan	V;ACT;PRS;POS;IND;1;SG
 lükkama	ärgem lükakem	V;ACT;PRS;NEG;IMP;1;PL
-lükkama	ei oleks lükanudp	V;ACT;PRS;PRF;NEG;COND
+lükkama	ei oleks lükanud	V;ACT;PRS;PRF;NEG;COND
 lükkama	oleksid lükanud	V;ACT;PRS;PRF;POS;COND;3;PL
 lükkama	lükkasite	V;ACT;PST;POS;IND;2;PL
 lükkama	oleks lükanud	V;ACT;PRS;PRF;POS;COND;3;SG
 lükkama	olin lükanud	V;ACT;PRS;PRF;POS;COND;1;SG
 lükkama	oled lükanud	V;ACT;PRS;PRF;POS;IND;2;SG
 lükkama	oli lükanud	V;ACT;PRS;PRF;POS;COND;3;SG
-lükkama	ei ole lükatudp	V;PASS;PRS;PRF;NEG;IND
+lükkama	ei ole lükatud	V;PASS;PRS;PRF;NEG;IND
 lükkama	lükkaksin	V;ACT;PRS;POS;COND;1;SG
 lükkama	olen lükanud	V;ACT;PRS;PRF;POS;IND;1;SG
-lükkama	ei olnud lükatudp	V;PASS;PST;PRF;NEG;IND
+lükkama	ei olnud lükatud	V;PASS;PST;PRF;NEG;IND
 lükkama	ärgu olgu lükatud	V;PASS;PRS;PRF;NEG;IMP
 
 maa	maani	N;TERM;SG
@@ -14215,7 +14215,7 @@ maasikas	maasikatesse	N;IN+ALL;PL
 maasikas	maasikatelt	N;AT+ABL;PL
 
 magama	olete maganud	V;ACT;PRS;PRF;POS;IND;2;PL
-magama	ei olevat maganudp	V;ACT;PRS;PRF;NEG;QUOT
+magama	ei olevat maganud	V;ACT;PRS;PRF;NEG;QUOT
 magama	oleks magatud	V;PASS;PRS;PRF;POS;COND
 magama	magasin	V;ACT;PST;POS;IND;1;SG
 magama	magatakse	V;PASS;PRS;POS;IND
@@ -14224,7 +14224,7 @@ magama	magatagu	V;PASS;PRS;POS;IMP
 magama	ärgu magagu	V;ACT;PRS;NEG;IMP;3;SG
 magama	oli magatud	V;PASS;PST;PRF;POS;IND
 magama	magasime	V;ACT;PST;POS;IND;1;PL
-magama	ei olnud maganudp	V;ACT;PST;PRF;NEG;IND
+magama	ei olnud maganud	V;ACT;PST;PRF;NEG;IND
 magama	oleksid maganud	V;ACT;PRS;PRF;POS;COND;2;SG
 magama	olgu maganud	V;ACT;PRS;PRF;POS;IMP;PL
 magama	oli maganud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -14238,9 +14238,9 @@ magama	ärgu magagu	V;ACT;PRS;NEG;IMP;3;PL
 magama	olgu maganud	V;ACT;PRS;PRF;POS;IMP;SG
 magama	magati	V;PASS;PST;POS;IND
 magama	ei magavat	V;ACT;PRS;NEG;QUOT
-magama	ei oleks magatudp	V;PASS;PRS;PRF;NEG;COND
+magama	ei oleks magatud	V;PASS;PRS;PRF;NEG;COND
 magama	ei maganud	V;ACT;PST;NEG;IND
-magama	ei olevat magatudp	V;PASS;PRS;PRF;NEG;QUOT
+magama	ei olevat magatud	V;PASS;PRS;PRF;NEG;QUOT
 magama	ei magaks	V;ACT;PRS;PRF;POS;COND;1;SG
 magama	magatud	V.PTCP;PASS;PST
 magama	olid maganud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -14259,7 +14259,7 @@ magama	olgu magatud	V;PASS;PRS;PRF;POS;IMP
 magama	magaks	V;ACT;PRS;POS;COND;3;SG
 magama	magagu	V;ACT;PRS;POS;IMP;3;PL
 magama	ärgu olgu maganud	V;ACT;PRS;PRF;NEG;IMP;SG
-magama	ei ole maganudp	V;ACT;PST;NEG;IND
+magama	ei ole maganud	V;ACT;PST;NEG;IND
 magama	magad	V;ACT;PRS;POS;IND;2;SG
 magama	ära maga	V;ACT;PRS;NEG;IMP;2;SG
 magama	ei maga	V;ACT;PRS;NEG;IND
@@ -14287,17 +14287,17 @@ magama	ei magata	V;PASS;PRS;NEG;IND
 magama	magame	V;ACT;PRS;POS;IND;1;PL
 magama	magan	V;ACT;PRS;POS;IND;1;SG
 magama	ärgem magagem	V;ACT;PRS;NEG;IMP;1;PL
-magama	ei oleks maganudp	V;ACT;PRS;PRF;NEG;COND
+magama	ei oleks maganud	V;ACT;PRS;PRF;NEG;COND
 magama	oleksid maganud	V;ACT;PRS;PRF;POS;COND;3;PL
 magama	magasite	V;ACT;PST;POS;IND;2;PL
 magama	oleks maganud	V;ACT;PRS;PRF;POS;COND;3;SG
 magama	olin maganud	V;ACT;PRS;PRF;POS;COND;1;SG
 magama	oled maganud	V;ACT;PRS;PRF;POS;IND;2;SG
 magama	oli maganud	V;ACT;PRS;PRF;POS;COND;3;SG
-magama	ei ole magatudp	V;PASS;PRS;PRF;NEG;IND
+magama	ei ole magatud	V;PASS;PRS;PRF;NEG;IND
 magama	magaksin	V;ACT;PRS;POS;COND;1;SG
 magama	olen maganud	V;ACT;PRS;PRF;POS;IND;1;SG
-magama	ei olnud magatudp	V;PASS;PST;PRF;NEG;IND
+magama	ei olnud magatud	V;PASS;PST;PRF;NEG;IND
 magama	ärgu olgu magatud	V;PASS;PRS;PRF;NEG;IMP
 
 magneesium	magneesiumini	N;TERM;SG
@@ -14332,7 +14332,7 @@ magneesium	magneesiumdesse	N;IN+ALL;PL
 magneesium	magneesiumdelt	N;AT+ABL;PL
 
 magustama	olete magustanud	V;ACT;PRS;PRF;POS;IND;2;PL
-magustama	ei olevat magustanudp	V;ACT;PRS;PRF;NEG;QUOT
+magustama	ei olevat magustanud	V;ACT;PRS;PRF;NEG;QUOT
 magustama	oleks magustatud	V;PASS;PRS;PRF;POS;COND
 magustama	magustasin	V;ACT;PST;POS;IND;1;SG
 magustama	magustatakse	V;PASS;PRS;POS;IND
@@ -14341,7 +14341,7 @@ magustama	magustatagu	V;PASS;PRS;POS;IMP
 magustama	ärgu magustagu	V;ACT;PRS;NEG;IMP;3;SG
 magustama	oli magustatud	V;PASS;PST;PRF;POS;IND
 magustama	magustasime	V;ACT;PST;POS;IND;1;PL
-magustama	ei olnud magustanudp	V;ACT;PST;PRF;NEG;IND
+magustama	ei olnud magustanud	V;ACT;PST;PRF;NEG;IND
 magustama	oleksid magustanud	V;ACT;PRS;PRF;POS;COND;2;SG
 magustama	olgu magustanud	V;ACT;PRS;PRF;POS;IMP;PL
 magustama	oli magustanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -14355,9 +14355,9 @@ magustama	ärgu magustagu	V;ACT;PRS;NEG;IMP;3;PL
 magustama	olgu magustanud	V;ACT;PRS;PRF;POS;IMP;SG
 magustama	magustati	V;PASS;PST;POS;IND
 magustama	ei magustavat	V;ACT;PRS;NEG;QUOT
-magustama	ei oleks magustatudp	V;PASS;PRS;PRF;NEG;COND
+magustama	ei oleks magustatud	V;PASS;PRS;PRF;NEG;COND
 magustama	ei magustanud	V;ACT;PST;NEG;IND
-magustama	ei olevat magustatudp	V;PASS;PRS;PRF;NEG;QUOT
+magustama	ei olevat magustatud	V;PASS;PRS;PRF;NEG;QUOT
 magustama	ei magustaks	V;ACT;PRS;PRF;POS;COND;1;SG
 magustama	magustatud	V.PTCP;PASS;PST
 magustama	olid magustanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -14376,7 +14376,7 @@ magustama	olgu magustatud	V;PASS;PRS;PRF;POS;IMP
 magustama	magustaks	V;ACT;PRS;POS;COND;3;SG
 magustama	magustagu	V;ACT;PRS;POS;IMP;3;PL
 magustama	ärgu olgu magustanud	V;ACT;PRS;PRF;NEG;IMP;SG
-magustama	ei ole magustanudp	V;ACT;PST;NEG;IND
+magustama	ei ole magustanud	V;ACT;PST;NEG;IND
 magustama	magustad	V;ACT;PRS;POS;IND;2;SG
 magustama	ära magusta	V;ACT;PRS;NEG;IMP;2;SG
 magustama	ei magusta	V;ACT;PRS;NEG;IND
@@ -14404,17 +14404,17 @@ magustama	ei magustata	V;PASS;PRS;NEG;IND
 magustama	magustame	V;ACT;PRS;POS;IND;1;PL
 magustama	magustan	V;ACT;PRS;POS;IND;1;SG
 magustama	ärgem magustagem	V;ACT;PRS;NEG;IMP;1;PL
-magustama	ei oleks magustanudp	V;ACT;PRS;PRF;NEG;COND
+magustama	ei oleks magustanud	V;ACT;PRS;PRF;NEG;COND
 magustama	oleksid magustanud	V;ACT;PRS;PRF;POS;COND;3;PL
 magustama	magustasite	V;ACT;PST;POS;IND;2;PL
 magustama	oleks magustanud	V;ACT;PRS;PRF;POS;COND;3;SG
 magustama	olin magustanud	V;ACT;PRS;PRF;POS;COND;1;SG
 magustama	oled magustanud	V;ACT;PRS;PRF;POS;IND;2;SG
 magustama	oli magustanud	V;ACT;PRS;PRF;POS;COND;3;SG
-magustama	ei ole magustatudp	V;PASS;PRS;PRF;NEG;IND
+magustama	ei ole magustatud	V;PASS;PRS;PRF;NEG;IND
 magustama	magustaksin	V;ACT;PRS;POS;COND;1;SG
 magustama	olen magustanud	V;ACT;PRS;PRF;POS;IND;1;SG
-magustama	ei olnud magustatudp	V;PASS;PST;PRF;NEG;IND
+magustama	ei olnud magustatud	V;PASS;PST;PRF;NEG;IND
 magustama	ärgu olgu magustatud	V;PASS;PRS;PRF;NEG;IMP
 
 mai	maini	N;TERM;SG
@@ -14821,7 +14821,7 @@ masin	masinatesse	N;IN+ALL;PL
 masin	masinatelt	N;AT+ABL;PL
 
 masturbeerima	olete masturbeerinud	V;ACT;PRS;PRF;POS;IND;2;PL
-masturbeerima	ei olevat masturbeerinudp	V;ACT;PRS;PRF;NEG;QUOT
+masturbeerima	ei olevat masturbeerinud	V;ACT;PRS;PRF;NEG;QUOT
 masturbeerima	oleks masturbeeritud	V;PASS;PRS;PRF;POS;COND
 masturbeerima	masturbeerisin	V;ACT;PST;POS;IND;1;SG
 masturbeerima	masturbeeritakse	V;PASS;PRS;POS;IND
@@ -14830,7 +14830,7 @@ masturbeerima	masturbeeritagu	V;PASS;PRS;POS;IMP
 masturbeerima	ärgu masturbeerigu	V;ACT;PRS;NEG;IMP;3;SG
 masturbeerima	oli masturbeeritud	V;PASS;PST;PRF;POS;IND
 masturbeerima	masturbeerisime	V;ACT;PST;POS;IND;1;PL
-masturbeerima	ei olnud masturbeerinudp	V;ACT;PST;PRF;NEG;IND
+masturbeerima	ei olnud masturbeerinud	V;ACT;PST;PRF;NEG;IND
 masturbeerima	oleksid masturbeerinud	V;ACT;PRS;PRF;POS;COND;2;SG
 masturbeerima	olgu masturbeerinud	V;ACT;PRS;PRF;POS;IMP;PL
 masturbeerima	oli masturbeerinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -14844,9 +14844,9 @@ masturbeerima	ärgu masturbeerigu	V;ACT;PRS;NEG;IMP;3;PL
 masturbeerima	olgu masturbeerinud	V;ACT;PRS;PRF;POS;IMP;SG
 masturbeerima	masturbeeriti	V;PASS;PST;POS;IND
 masturbeerima	ei masturbeerivat	V;ACT;PRS;NEG;QUOT
-masturbeerima	ei oleks masturbeeritudp	V;PASS;PRS;PRF;NEG;COND
+masturbeerima	ei oleks masturbeeritud	V;PASS;PRS;PRF;NEG;COND
 masturbeerima	ei masturbeerinud	V;ACT;PST;NEG;IND
-masturbeerima	ei olevat masturbeeritudp	V;PASS;PRS;PRF;NEG;QUOT
+masturbeerima	ei olevat masturbeeritud	V;PASS;PRS;PRF;NEG;QUOT
 masturbeerima	ei masturbeeriks	V;ACT;PRS;PRF;POS;COND;1;SG
 masturbeerima	masturbeeritud	V.PTCP;PASS;PST
 masturbeerima	olid masturbeerinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -14865,7 +14865,7 @@ masturbeerima	olgu masturbeeritud	V;PASS;PRS;PRF;POS;IMP
 masturbeerima	masturbeeriks	V;ACT;PRS;POS;COND;3;SG
 masturbeerima	masturbeerigu	V;ACT;PRS;POS;IMP;3;PL
 masturbeerima	ärgu olgu masturbeerinud	V;ACT;PRS;PRF;NEG;IMP;SG
-masturbeerima	ei ole masturbeerinudp	V;ACT;PST;NEG;IND
+masturbeerima	ei ole masturbeerinud	V;ACT;PST;NEG;IND
 masturbeerima	masturbeerid	V;ACT;PRS;POS;IND;2;SG
 masturbeerima	ära masturbeeri	V;ACT;PRS;NEG;IMP;2;SG
 masturbeerima	ei masturbeeri	V;ACT;PRS;NEG;IND
@@ -14893,17 +14893,17 @@ masturbeerima	ei masturbeerita	V;PASS;PRS;NEG;IND
 masturbeerima	masturbeerime	V;ACT;PRS;POS;IND;1;PL
 masturbeerima	masturbeerin	V;ACT;PRS;POS;IND;1;SG
 masturbeerima	ärgem masturbeerigem	V;ACT;PRS;NEG;IMP;1;PL
-masturbeerima	ei oleks masturbeerinudp	V;ACT;PRS;PRF;NEG;COND
+masturbeerima	ei oleks masturbeerinud	V;ACT;PRS;PRF;NEG;COND
 masturbeerima	oleksid masturbeerinud	V;ACT;PRS;PRF;POS;COND;3;PL
 masturbeerima	masturbeerisite	V;ACT;PST;POS;IND;2;PL
 masturbeerima	oleks masturbeerinud	V;ACT;PRS;PRF;POS;COND;3;SG
 masturbeerima	olin masturbeerinud	V;ACT;PRS;PRF;POS;COND;1;SG
 masturbeerima	oled masturbeerinud	V;ACT;PRS;PRF;POS;IND;2;SG
 masturbeerima	oli masturbeerinud	V;ACT;PRS;PRF;POS;COND;3;SG
-masturbeerima	ei ole masturbeeritudp	V;PASS;PRS;PRF;NEG;IND
+masturbeerima	ei ole masturbeeritud	V;PASS;PRS;PRF;NEG;IND
 masturbeerima	masturbeeriksin	V;ACT;PRS;POS;COND;1;SG
 masturbeerima	olen masturbeerinud	V;ACT;PRS;PRF;POS;IND;1;SG
-masturbeerima	ei olnud masturbeeritudp	V;PASS;PST;PRF;NEG;IND
+masturbeerima	ei olnud masturbeeritud	V;PASS;PST;PRF;NEG;IND
 masturbeerima	ärgu olgu masturbeeritud	V;PASS;PRS;PRF;NEG;IMP
 
 masturbeerimine	masturbeerimiseni	N;TERM;SG
@@ -14969,7 +14969,7 @@ aara	aaradesse	N;IN+ALL;PL
 aara	aaradelt	N;AT+ABL;PL
 
 meeldima	olete meeldinud	V;ACT;PRS;PRF;POS;IND;2;PL
-meeldima	ei olevat meeldinudp	V;ACT;PRS;PRF;NEG;QUOT
+meeldima	ei olevat meeldinud	V;ACT;PRS;PRF;NEG;QUOT
 meeldima	oleks meelditud	V;PASS;PRS;PRF;POS;COND
 meeldima	meeldisin	V;ACT;PST;POS;IND;1;SG
 meeldima	meelditakse	V;PASS;PRS;POS;IND
@@ -14978,7 +14978,7 @@ meeldima	meelditagu	V;PASS;PRS;POS;IMP
 meeldima	ärgu meeldigu	V;ACT;PRS;NEG;IMP;3;SG
 meeldima	oli meelditud	V;PASS;PST;PRF;POS;IND
 meeldima	meeldisime	V;ACT;PST;POS;IND;1;PL
-meeldima	ei olnud meeldinudp	V;ACT;PST;PRF;NEG;IND
+meeldima	ei olnud meeldinud	V;ACT;PST;PRF;NEG;IND
 meeldima	oleksid meeldinud	V;ACT;PRS;PRF;POS;COND;2;SG
 meeldima	olgu meeldinud	V;ACT;PRS;PRF;POS;IMP;PL
 meeldima	oli meeldinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -14992,9 +14992,9 @@ meeldima	ärgu meeldigu	V;ACT;PRS;NEG;IMP;3;PL
 meeldima	olgu meeldinud	V;ACT;PRS;PRF;POS;IMP;SG
 meeldima	meelditi	V;PASS;PST;POS;IND
 meeldima	ei meeldivat	V;ACT;PRS;NEG;QUOT
-meeldima	ei oleks meelditudp	V;PASS;PRS;PRF;NEG;COND
+meeldima	ei oleks meelditud	V;PASS;PRS;PRF;NEG;COND
 meeldima	ei meeldinud	V;ACT;PST;NEG;IND
-meeldima	ei olevat meelditudp	V;PASS;PRS;PRF;NEG;QUOT
+meeldima	ei olevat meelditud	V;PASS;PRS;PRF;NEG;QUOT
 meeldima	ei meeldiks	V;ACT;PRS;PRF;POS;COND;1;SG
 meeldima	meelditud	V.PTCP;PASS;PST
 meeldima	olid meeldinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -15013,7 +15013,7 @@ meeldima	olgu meelditud	V;PASS;PRS;PRF;POS;IMP
 meeldima	meeldiks	V;ACT;PRS;POS;COND;3;SG
 meeldima	meeldigu	V;ACT;PRS;POS;IMP;3;PL
 meeldima	ärgu olgu meeldinud	V;ACT;PRS;PRF;NEG;IMP;SG
-meeldima	ei ole meeldinudp	V;ACT;PST;NEG;IND
+meeldima	ei ole meeldinud	V;ACT;PST;NEG;IND
 meeldima	meeldid	V;ACT;PRS;POS;IND;2;SG
 meeldima	ära meeldi	V;ACT;PRS;NEG;IMP;2;SG
 meeldima	ei meeldi	V;ACT;PRS;NEG;IND
@@ -15041,17 +15041,17 @@ meeldima	ei meeldita	V;PASS;PRS;NEG;IND
 meeldima	meeldime	V;ACT;PRS;POS;IND;1;PL
 meeldima	meeldin	V;ACT;PRS;POS;IND;1;SG
 meeldima	ärgem meeldigem	V;ACT;PRS;NEG;IMP;1;PL
-meeldima	ei oleks meeldinudp	V;ACT;PRS;PRF;NEG;COND
+meeldima	ei oleks meeldinud	V;ACT;PRS;PRF;NEG;COND
 meeldima	oleksid meeldinud	V;ACT;PRS;PRF;POS;COND;3;PL
 meeldima	meeldisite	V;ACT;PST;POS;IND;2;PL
 meeldima	oleks meeldinud	V;ACT;PRS;PRF;POS;COND;3;SG
 meeldima	olin meeldinud	V;ACT;PRS;PRF;POS;COND;1;SG
 meeldima	oled meeldinud	V;ACT;PRS;PRF;POS;IND;2;SG
 meeldima	oli meeldinud	V;ACT;PRS;PRF;POS;COND;3;SG
-meeldima	ei ole meelditudp	V;PASS;PRS;PRF;NEG;IND
+meeldima	ei ole meelditud	V;PASS;PRS;PRF;NEG;IND
 meeldima	meeldiksin	V;ACT;PRS;POS;COND;1;SG
 meeldima	olen meeldinud	V;ACT;PRS;PRF;POS;IND;1;SG
-meeldima	ei olnud meelditudp	V;PASS;PST;PRF;NEG;IND
+meeldima	ei olnud meelditud	V;PASS;PST;PRF;NEG;IND
 meeldima	ärgu olgu meelditud	V;PASS;PRS;PRF;NEG;IMP
 
 aasialane	aasialaseni	N;TERM;SG
@@ -15334,7 +15334,7 @@ mihklikuu	mihklikuudesse	N;IN+ALL;PL
 mihklikuu	mihklikuudelt	N;AT+ABL;PL
 
 minema	olete läinud	V;ACT;PRS;PRF;POS;IND;2;PL
-minema	ei olevat läinudp	V;ACT;PRS;PRF;NEG;QUOT
+minema	ei olevat läinud	V;ACT;PRS;PRF;NEG;QUOT
 minema	oleks mindud	V;PASS;PRS;PRF;POS;COND
 minema	läksin	V;ACT;PST;POS;IND;1;SG
 minema	minnakse	V;PASS;PRS;POS;IND
@@ -15343,7 +15343,7 @@ minema	mindagu	V;PASS;PRS;POS;IMP
 minema	ärgu mingu	V;ACT;PRS;NEG;IMP;3;SG
 minema	oli mindud	V;PASS;PST;PRF;POS;IND
 minema	läksime	V;ACT;PST;POS;IND;1;PL
-minema	ei olnud läinudp	V;ACT;PST;PRF;NEG;IND
+minema	ei olnud läinud	V;ACT;PST;PRF;NEG;IND
 minema	oleksid läinud	V;ACT;PRS;PRF;POS;COND;2;SG
 minema	olgu läinud	V;ACT;PRS;PRF;POS;IMP;PL
 minema	oli läinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -15357,9 +15357,9 @@ minema	ärgu mingu	V;ACT;PRS;NEG;IMP;3;PL
 minema	olgu läinud	V;ACT;PRS;PRF;POS;IMP;SG
 minema	mindi	V;PASS;PST;POS;IND
 minema	ei minevat	V;ACT;PRS;NEG;QUOT
-minema	ei oleks mindudp	V;PASS;PRS;PRF;NEG;COND
+minema	ei oleks mindud	V;PASS;PRS;PRF;NEG;COND
 minema	ei läinud	V;ACT;PST;NEG;IND
-minema	ei olevat mindudp	V;PASS;PRS;PRF;NEG;QUOT
+minema	ei olevat mindud	V;PASS;PRS;PRF;NEG;QUOT
 minema	ei läheks	V;ACT;PRS;PRF;POS;COND;1;SG
 minema	mindud	V.PTCP;PASS;PST
 minema	olid läinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -15378,7 +15378,7 @@ minema	olgu mindud	V;PASS;PRS;PRF;POS;IMP
 minema	läheks	V;ACT;PRS;POS;COND;3;SG
 minema	mingu	V;ACT;PRS;POS;IMP;3;PL
 minema	ärgu olgu läinud	V;ACT;PRS;PRF;NEG;IMP;SG
-minema	ei ole läinudp	V;ACT;PST;NEG;IND
+minema	ei ole läinud	V;ACT;PST;NEG;IND
 minema	lähed	V;ACT;PRS;POS;IND;2;SG
 minema	ära mine	V;ACT;PRS;NEG;IMP;2;SG
 minema	ei lähe	V;ACT;PRS;NEG;IND
@@ -15406,17 +15406,17 @@ minema	ei minda	V;PASS;PRS;NEG;IND
 minema	läheme	V;ACT;PRS;POS;IND;1;PL
 minema	lähen	V;ACT;PRS;POS;IND;1;SG
 minema	ärgem mingem	V;ACT;PRS;NEG;IMP;1;PL
-minema	ei oleks läinudp	V;ACT;PRS;PRF;NEG;COND
+minema	ei oleks läinud	V;ACT;PRS;PRF;NEG;COND
 minema	oleksid läinud	V;ACT;PRS;PRF;POS;COND;3;PL
 minema	läksite	V;ACT;PST;POS;IND;2;PL
 minema	oleks läinud	V;ACT;PRS;PRF;POS;COND;3;SG
 minema	olin läinud	V;ACT;PRS;PRF;POS;COND;1;SG
 minema	oled läinud	V;ACT;PRS;PRF;POS;IND;2;SG
 minema	oli läinud	V;ACT;PRS;PRF;POS;COND;3;SG
-minema	ei ole mindudp	V;PASS;PRS;PRF;NEG;IND
+minema	ei ole mindud	V;PASS;PRS;PRF;NEG;IND
 minema	läheksin	V;ACT;PRS;POS;COND;1;SG
 minema	olen läinud	V;ACT;PRS;PRF;POS;IND;1;SG
-minema	ei olnud mindudp	V;PASS;PST;PRF;NEG;IND
+minema	ei olnud mindud	V;PASS;PST;PRF;NEG;IND
 minema	ärgu olgu mindud	V;PASS;PRS;PRF;NEG;IMP
 
 mitmus	mitmuseni	N;TERM;SG
@@ -15606,7 +15606,7 @@ muna	munadesse	N;IN+ALL;PL
 muna	munadelt	N;AT+ABL;PL
 
 murdma	olete murdnud	V;ACT;PRS;PRF;POS;IND;2;PL
-murdma	ei olevat murdnudp	V;ACT;PRS;PRF;NEG;QUOT
+murdma	ei olevat murdnud	V;ACT;PRS;PRF;NEG;QUOT
 murdma	oleks murretud	V;PASS;PRS;PRF;POS;COND
 murdma	murdsin	V;ACT;PST;POS;IND;1;SG
 murdma	murretakse	V;PASS;PRS;POS;IND
@@ -15615,7 +15615,7 @@ murdma	murretagu	V;PASS;PRS;POS;IMP
 murdma	ärgu murdku	V;ACT;PRS;NEG;IMP;3;SG
 murdma	oli murretud	V;PASS;PST;PRF;POS;IND
 murdma	murdsime	V;ACT;PST;POS;IND;1;PL
-murdma	ei olnud murdnudp	V;ACT;PST;PRF;NEG;IND
+murdma	ei olnud murdnud	V;ACT;PST;PRF;NEG;IND
 murdma	oleksid murdnud	V;ACT;PRS;PRF;POS;COND;2;SG
 murdma	olgu murdnud	V;ACT;PRS;PRF;POS;IMP;PL
 murdma	oli murdnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -15629,9 +15629,9 @@ murdma	ärgu murdku	V;ACT;PRS;NEG;IMP;3;PL
 murdma	olgu murdnud	V;ACT;PRS;PRF;POS;IMP;SG
 murdma	murreti	V;PASS;PST;POS;IND
 murdma	ei murdvat	V;ACT;PRS;NEG;QUOT
-murdma	ei oleks murretudp	V;PASS;PRS;PRF;NEG;COND
+murdma	ei oleks murretud	V;PASS;PRS;PRF;NEG;COND
 murdma	ei murdnud	V;ACT;PST;NEG;IND
-murdma	ei olevat murretudp	V;PASS;PRS;PRF;NEG;QUOT
+murdma	ei olevat murretud	V;PASS;PRS;PRF;NEG;QUOT
 murdma	ei murraks	V;ACT;PRS;PRF;POS;COND;1;SG
 murdma	murretud	V.PTCP;PASS;PST
 murdma	olid murdnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -15650,7 +15650,7 @@ murdma	olgu murretud	V;PASS;PRS;PRF;POS;IMP
 murdma	murraks	V;ACT;PRS;POS;COND;3;SG
 murdma	murdku	V;ACT;PRS;POS;IMP;3;PL
 murdma	ärgu olgu murdnud	V;ACT;PRS;PRF;NEG;IMP;SG
-murdma	ei ole murdnudp	V;ACT;PST;NEG;IND
+murdma	ei ole murdnud	V;ACT;PST;NEG;IND
 murdma	murrad	V;ACT;PRS;POS;IND;2;SG
 murdma	ära murra	V;ACT;PRS;NEG;IMP;2;SG
 murdma	ei murra	V;ACT;PRS;NEG;IND
@@ -15678,21 +15678,21 @@ murdma	ei murreta	V;PASS;PRS;NEG;IND
 murdma	murrame	V;ACT;PRS;POS;IND;1;PL
 murdma	murran	V;ACT;PRS;POS;IND;1;SG
 murdma	ärgem murdkem	V;ACT;PRS;NEG;IMP;1;PL
-murdma	ei oleks murdnudp	V;ACT;PRS;PRF;NEG;COND
+murdma	ei oleks murdnud	V;ACT;PRS;PRF;NEG;COND
 murdma	oleksid murdnud	V;ACT;PRS;PRF;POS;COND;3;PL
 murdma	murdsite	V;ACT;PST;POS;IND;2;PL
 murdma	oleks murdnud	V;ACT;PRS;PRF;POS;COND;3;SG
 murdma	olin murdnud	V;ACT;PRS;PRF;POS;COND;1;SG
 murdma	oled murdnud	V;ACT;PRS;PRF;POS;IND;2;SG
 murdma	oli murdnud	V;ACT;PRS;PRF;POS;COND;3;SG
-murdma	ei ole murretudp	V;PASS;PRS;PRF;NEG;IND
+murdma	ei ole murretud	V;PASS;PRS;PRF;NEG;IND
 murdma	murraksin	V;ACT;PRS;POS;COND;1;SG
 murdma	olen murdnud	V;ACT;PRS;PRF;POS;IND;1;SG
-murdma	ei olnud murretudp	V;PASS;PST;PRF;NEG;IND
+murdma	ei olnud murretud	V;PASS;PST;PRF;NEG;IND
 murdma	ärgu olgu murretud	V;PASS;PRS;PRF;NEG;IMP
 
 muretsema	olete muretsenud	V;ACT;PRS;PRF;POS;IND;2;PL
-muretsema	ei olevat muretsenudp	V;ACT;PRS;PRF;NEG;QUOT
+muretsema	ei olevat muretsenud	V;ACT;PRS;PRF;NEG;QUOT
 muretsema	oleks muretsetud	V;PASS;PRS;PRF;POS;COND
 muretsema	muretsesin	V;ACT;PST;POS;IND;1;SG
 muretsema	muretsetakse	V;PASS;PRS;POS;IND
@@ -15701,7 +15701,7 @@ muretsema	muretsetagu	V;PASS;PRS;POS;IMP
 muretsema	ärgu muretsegu	V;ACT;PRS;NEG;IMP;3;SG
 muretsema	oli muretsetud	V;PASS;PST;PRF;POS;IND
 muretsema	muretsesime	V;ACT;PST;POS;IND;1;PL
-muretsema	ei olnud muretsenudp	V;ACT;PST;PRF;NEG;IND
+muretsema	ei olnud muretsenud	V;ACT;PST;PRF;NEG;IND
 muretsema	oleksid muretsenud	V;ACT;PRS;PRF;POS;COND;2;SG
 muretsema	olgu muretsenud	V;ACT;PRS;PRF;POS;IMP;PL
 muretsema	oli muretsenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -15715,9 +15715,9 @@ muretsema	ärgu muretsegu	V;ACT;PRS;NEG;IMP;3;PL
 muretsema	olgu muretsenud	V;ACT;PRS;PRF;POS;IMP;SG
 muretsema	muretseti	V;PASS;PST;POS;IND
 muretsema	ei muretsevat	V;ACT;PRS;NEG;QUOT
-muretsema	ei oleks muretsetudp	V;PASS;PRS;PRF;NEG;COND
+muretsema	ei oleks muretsetud	V;PASS;PRS;PRF;NEG;COND
 muretsema	ei muretsenud	V;ACT;PST;NEG;IND
-muretsema	ei olevat muretsetudp	V;PASS;PRS;PRF;NEG;QUOT
+muretsema	ei olevat muretsetud	V;PASS;PRS;PRF;NEG;QUOT
 muretsema	ei muretseks	V;ACT;PRS;PRF;POS;COND;1;SG
 muretsema	muretsetud	V.PTCP;PASS;PST
 muretsema	olid muretsenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -15736,7 +15736,7 @@ muretsema	olgu muretsetud	V;PASS;PRS;PRF;POS;IMP
 muretsema	muretseks	V;ACT;PRS;POS;COND;3;SG
 muretsema	muretsegu	V;ACT;PRS;POS;IMP;3;PL
 muretsema	ärgu olgu muretsenud	V;ACT;PRS;PRF;NEG;IMP;SG
-muretsema	ei ole muretsenudp	V;ACT;PST;NEG;IND
+muretsema	ei ole muretsenud	V;ACT;PST;NEG;IND
 muretsema	muretsed	V;ACT;PRS;POS;IND;2;SG
 muretsema	ära muretse	V;ACT;PRS;NEG;IMP;2;SG
 muretsema	ei muretse	V;ACT;PRS;NEG;IND
@@ -15764,17 +15764,17 @@ muretsema	ei muretseta	V;PASS;PRS;NEG;IND
 muretsema	muretseme	V;ACT;PRS;POS;IND;1;PL
 muretsema	muretsen	V;ACT;PRS;POS;IND;1;SG
 muretsema	ärgem muretsegem	V;ACT;PRS;NEG;IMP;1;PL
-muretsema	ei oleks muretsenudp	V;ACT;PRS;PRF;NEG;COND
+muretsema	ei oleks muretsenud	V;ACT;PRS;PRF;NEG;COND
 muretsema	oleksid muretsenud	V;ACT;PRS;PRF;POS;COND;3;PL
 muretsema	muretsesite	V;ACT;PST;POS;IND;2;PL
 muretsema	oleks muretsenud	V;ACT;PRS;PRF;POS;COND;3;SG
 muretsema	olin muretsenud	V;ACT;PRS;PRF;POS;COND;1;SG
 muretsema	oled muretsenud	V;ACT;PRS;PRF;POS;IND;2;SG
 muretsema	oli muretsenud	V;ACT;PRS;PRF;POS;COND;3;SG
-muretsema	ei ole muretsetudp	V;PASS;PRS;PRF;NEG;IND
+muretsema	ei ole muretsetud	V;PASS;PRS;PRF;NEG;IND
 muretsema	muretseksin	V;ACT;PRS;POS;COND;1;SG
 muretsema	olen muretsenud	V;ACT;PRS;PRF;POS;IND;1;SG
-muretsema	ei olnud muretsetudp	V;PASS;PST;PRF;NEG;IND
+muretsema	ei olnud muretsetud	V;PASS;PST;PRF;NEG;IND
 muretsema	ärgu olgu muretsetud	V;PASS;PRS;PRF;NEG;IMP
 
 murjan	murjanini	N;TERM;SG
@@ -15964,7 +15964,7 @@ muusik	muusikutesse	N;IN+ALL;PL
 muusik	muusikutelt	N;AT+ABL;PL
 
 muutma	olete muutnud	V;ACT;PRS;PRF;POS;IND;2;PL
-muutma	ei olevat muutnudp	V;ACT;PRS;PRF;NEG;QUOT
+muutma	ei olevat muutnud	V;ACT;PRS;PRF;NEG;QUOT
 muutma	oleks muudetud	V;PASS;PRS;PRF;POS;COND
 muutma	muutsin	V;ACT;PST;POS;IND;1;SG
 muutma	muudetakse	V;PASS;PRS;POS;IND
@@ -15973,7 +15973,7 @@ muutma	muudetagu	V;PASS;PRS;POS;IMP
 muutma	ärgu muutku	V;ACT;PRS;NEG;IMP;3;SG
 muutma	oli muudetud	V;PASS;PST;PRF;POS;IND
 muutma	muutsime	V;ACT;PST;POS;IND;1;PL
-muutma	ei olnud muutnudp	V;ACT;PST;PRF;NEG;IND
+muutma	ei olnud muutnud	V;ACT;PST;PRF;NEG;IND
 muutma	oleksid muutnud	V;ACT;PRS;PRF;POS;COND;2;SG
 muutma	olgu muutnud	V;ACT;PRS;PRF;POS;IMP;PL
 muutma	oli muutnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -15987,9 +15987,9 @@ muutma	ärgu muutku	V;ACT;PRS;NEG;IMP;3;PL
 muutma	olgu muutnud	V;ACT;PRS;PRF;POS;IMP;SG
 muutma	muudeti	V;PASS;PST;POS;IND
 muutma	ei muutvat	V;ACT;PRS;NEG;QUOT
-muutma	ei oleks muudetudp	V;PASS;PRS;PRF;NEG;COND
+muutma	ei oleks muudetud	V;PASS;PRS;PRF;NEG;COND
 muutma	ei muutnud	V;ACT;PST;NEG;IND
-muutma	ei olevat muudetudp	V;PASS;PRS;PRF;NEG;QUOT
+muutma	ei olevat muudetud	V;PASS;PRS;PRF;NEG;QUOT
 muutma	ei muudaks	V;ACT;PRS;PRF;POS;COND;1;SG
 muutma	muudetud	V.PTCP;PASS;PST
 muutma	olid muutnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -16008,7 +16008,7 @@ muutma	olgu muudetud	V;PASS;PRS;PRF;POS;IMP
 muutma	muudaks	V;ACT;PRS;POS;COND;3;SG
 muutma	muutku	V;ACT;PRS;POS;IMP;3;PL
 muutma	ärgu olgu muutnud	V;ACT;PRS;PRF;NEG;IMP;SG
-muutma	ei ole muutnudp	V;ACT;PST;NEG;IND
+muutma	ei ole muutnud	V;ACT;PST;NEG;IND
 muutma	muudad	V;ACT;PRS;POS;IND;2;SG
 muutma	ära muuda	V;ACT;PRS;NEG;IMP;2;SG
 muutma	ei muuda	V;ACT;PRS;NEG;IND
@@ -16036,17 +16036,17 @@ muutma	ei muudeta	V;PASS;PRS;NEG;IND
 muutma	muudame	V;ACT;PRS;POS;IND;1;PL
 muutma	muudan	V;ACT;PRS;POS;IND;1;SG
 muutma	ärgem muutkem	V;ACT;PRS;NEG;IMP;1;PL
-muutma	ei oleks muutnudp	V;ACT;PRS;PRF;NEG;COND
+muutma	ei oleks muutnud	V;ACT;PRS;PRF;NEG;COND
 muutma	oleksid muutnud	V;ACT;PRS;PRF;POS;COND;3;PL
 muutma	muutsite	V;ACT;PST;POS;IND;2;PL
 muutma	oleks muutnud	V;ACT;PRS;PRF;POS;COND;3;SG
 muutma	olin muutnud	V;ACT;PRS;PRF;POS;COND;1;SG
 muutma	oled muutnud	V;ACT;PRS;PRF;POS;IND;2;SG
 muutma	oli muutnud	V;ACT;PRS;PRF;POS;COND;3;SG
-muutma	ei ole muudetudp	V;PASS;PRS;PRF;NEG;IND
+muutma	ei ole muudetud	V;PASS;PRS;PRF;NEG;IND
 muutma	muudaksin	V;ACT;PRS;POS;COND;1;SG
 muutma	olen muutnud	V;ACT;PRS;PRF;POS;IND;1;SG
-muutma	ei olnud muudetudp	V;PASS;PST;PRF;NEG;IND
+muutma	ei olnud muudetud	V;PASS;PST;PRF;NEG;IND
 muutma	ärgu olgu muudetud	V;PASS;PRS;PRF;NEG;IMP
 
 muutus	muutuseni	N;TERM;SG
@@ -16205,7 +16205,7 @@ mära	märadesse	N;IN+ALL;PL
 mära	märadelt	N;AT+ABL;PL
 
 märkima	olete märkinud	V;ACT;PRS;PRF;POS;IND;2;PL
-märkima	ei olevat märkinudp	V;ACT;PRS;PRF;NEG;QUOT
+märkima	ei olevat märkinud	V;ACT;PRS;PRF;NEG;QUOT
 märkima	oleks märgitud	V;PASS;PRS;PRF;POS;COND
 märkima	märkisin	V;ACT;PST;POS;IND;1;SG
 märkima	märgitakse	V;PASS;PRS;POS;IND
@@ -16214,7 +16214,7 @@ märkima	märgitagu	V;PASS;PRS;POS;IMP
 märkima	ärgu märkigu	V;ACT;PRS;NEG;IMP;3;SG
 märkima	oli märgitud	V;PASS;PST;PRF;POS;IND
 märkima	märkisime	V;ACT;PST;POS;IND;1;PL
-märkima	ei olnud märkinudp	V;ACT;PST;PRF;NEG;IND
+märkima	ei olnud märkinud	V;ACT;PST;PRF;NEG;IND
 märkima	oleksid märkinud	V;ACT;PRS;PRF;POS;COND;2;SG
 märkima	olgu märkinud	V;ACT;PRS;PRF;POS;IMP;PL
 märkima	oli märkinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -16228,9 +16228,9 @@ märkima	ärgu märkigu	V;ACT;PRS;NEG;IMP;3;PL
 märkima	olgu märkinud	V;ACT;PRS;PRF;POS;IMP;SG
 märkima	märgiti	V;PASS;PST;POS;IND
 märkima	ei märkivat	V;ACT;PRS;NEG;QUOT
-märkima	ei oleks märgitudp	V;PASS;PRS;PRF;NEG;COND
+märkima	ei oleks märgitud	V;PASS;PRS;PRF;NEG;COND
 märkima	ei märkinud	V;ACT;PST;NEG;IND
-märkima	ei olevat märgitudp	V;PASS;PRS;PRF;NEG;QUOT
+märkima	ei olevat märgitud	V;PASS;PRS;PRF;NEG;QUOT
 märkima	ei märgiks	V;ACT;PRS;PRF;POS;COND;1;SG
 märkima	märgitud	V.PTCP;PASS;PST
 märkima	olid märkinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -16249,7 +16249,7 @@ märkima	olgu märgitud	V;PASS;PRS;PRF;POS;IMP
 märkima	märgiks	V;ACT;PRS;POS;COND;3;SG
 märkima	märkigu	V;ACT;PRS;POS;IMP;3;PL
 märkima	ärgu olgu märkinud	V;ACT;PRS;PRF;NEG;IMP;SG
-märkima	ei ole märkinudp	V;ACT;PST;NEG;IND
+märkima	ei ole märkinud	V;ACT;PST;NEG;IND
 märkima	märgid	V;ACT;PRS;POS;IND;2;SG
 märkima	ära märgi	V;ACT;PRS;NEG;IMP;2;SG
 märkima	ei märgi	V;ACT;PRS;NEG;IND
@@ -16277,17 +16277,17 @@ märkima	ei märgita	V;PASS;PRS;NEG;IND
 märkima	märgime	V;ACT;PRS;POS;IND;1;PL
 märkima	märgin	V;ACT;PRS;POS;IND;1;SG
 märkima	ärgem märkigem	V;ACT;PRS;NEG;IMP;1;PL
-märkima	ei oleks märkinudp	V;ACT;PRS;PRF;NEG;COND
+märkima	ei oleks märkinud	V;ACT;PRS;PRF;NEG;COND
 märkima	oleksid märkinud	V;ACT;PRS;PRF;POS;COND;3;PL
 märkima	märkisite	V;ACT;PST;POS;IND;2;PL
 märkima	oleks märkinud	V;ACT;PRS;PRF;POS;COND;3;SG
 märkima	olin märkinud	V;ACT;PRS;PRF;POS;COND;1;SG
 märkima	oled märkinud	V;ACT;PRS;PRF;POS;IND;2;SG
 märkima	oli märkinud	V;ACT;PRS;PRF;POS;COND;3;SG
-märkima	ei ole märgitudp	V;PASS;PRS;PRF;NEG;IND
+märkima	ei ole märgitud	V;PASS;PRS;PRF;NEG;IND
 märkima	märgiksin	V;ACT;PRS;POS;COND;1;SG
 märkima	olen märkinud	V;ACT;PRS;PRF;POS;IND;1;SG
-märkima	ei olnud märgitudp	V;PASS;PST;PRF;NEG;IND
+märkima	ei olnud märgitud	V;PASS;PST;PRF;NEG;IND
 märkima	ärgu olgu märgitud	V;PASS;PRS;PRF;NEG;IMP
 
 mõis	mõisani	N;TERM;SG
@@ -16322,7 +16322,7 @@ mõis	mõisatesse	N;IN+ALL;PL
 mõis	mõisatelt	N;AT+ABL;PL
 
 mõistma	olete mõistnud	V;ACT;PRS;PRF;POS;IND;2;PL
-mõistma	ei olevat mõistnudp	V;ACT;PRS;PRF;NEG;QUOT
+mõistma	ei olevat mõistnud	V;ACT;PRS;PRF;NEG;QUOT
 mõistma	oleks mõistetud	V;PASS;PRS;PRF;POS;COND
 mõistma	mõistsin	V;ACT;PST;POS;IND;1;SG
 mõistma	mõistetakse	V;PASS;PRS;POS;IND
@@ -16331,7 +16331,7 @@ mõistma	mõistetagu	V;PASS;PRS;POS;IMP
 mõistma	ärgu mõistku	V;ACT;PRS;NEG;IMP;3;SG
 mõistma	oli mõistetud	V;PASS;PST;PRF;POS;IND
 mõistma	mõistsime	V;ACT;PST;POS;IND;1;PL
-mõistma	ei olnud mõistnudp	V;ACT;PST;PRF;NEG;IND
+mõistma	ei olnud mõistnud	V;ACT;PST;PRF;NEG;IND
 mõistma	oleksid mõistnud	V;ACT;PRS;PRF;POS;COND;2;SG
 mõistma	olgu mõistnud	V;ACT;PRS;PRF;POS;IMP;PL
 mõistma	oli mõistnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -16345,9 +16345,9 @@ mõistma	ärgu mõistku	V;ACT;PRS;NEG;IMP;3;PL
 mõistma	olgu mõistnud	V;ACT;PRS;PRF;POS;IMP;SG
 mõistma	mõisteti	V;PASS;PST;POS;IND
 mõistma	ei mõistvat	V;ACT;PRS;NEG;QUOT
-mõistma	ei oleks mõistetudp	V;PASS;PRS;PRF;NEG;COND
+mõistma	ei oleks mõistetud	V;PASS;PRS;PRF;NEG;COND
 mõistma	ei mõistnud	V;ACT;PST;NEG;IND
-mõistma	ei olevat mõistetudp	V;PASS;PRS;PRF;NEG;QUOT
+mõistma	ei olevat mõistetud	V;PASS;PRS;PRF;NEG;QUOT
 mõistma	ei mõistaks	V;ACT;PRS;PRF;POS;COND;1;SG
 mõistma	mõistetud	V.PTCP;PASS;PST
 mõistma	olid mõistnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -16366,7 +16366,7 @@ mõistma	olgu mõistetud	V;PASS;PRS;PRF;POS;IMP
 mõistma	mõistaks	V;ACT;PRS;POS;COND;3;SG
 mõistma	mõistku	V;ACT;PRS;POS;IMP;3;PL
 mõistma	ärgu olgu mõistnud	V;ACT;PRS;PRF;NEG;IMP;SG
-mõistma	ei ole mõistnudp	V;ACT;PST;NEG;IND
+mõistma	ei ole mõistnud	V;ACT;PST;NEG;IND
 mõistma	mõistad	V;ACT;PRS;POS;IND;2;SG
 mõistma	ära mõista	V;ACT;PRS;NEG;IMP;2;SG
 mõistma	ei mõista	V;ACT;PRS;NEG;IND
@@ -16394,17 +16394,17 @@ mõistma	ei mõisteta	V;PASS;PRS;NEG;IND
 mõistma	mõistame	V;ACT;PRS;POS;IND;1;PL
 mõistma	mõistan	V;ACT;PRS;POS;IND;1;SG
 mõistma	ärgem mõistkem	V;ACT;PRS;NEG;IMP;1;PL
-mõistma	ei oleks mõistnudp	V;ACT;PRS;PRF;NEG;COND
+mõistma	ei oleks mõistnud	V;ACT;PRS;PRF;NEG;COND
 mõistma	oleksid mõistnud	V;ACT;PRS;PRF;POS;COND;3;PL
 mõistma	mõistsite	V;ACT;PST;POS;IND;2;PL
 mõistma	oleks mõistnud	V;ACT;PRS;PRF;POS;COND;3;SG
 mõistma	olin mõistnud	V;ACT;PRS;PRF;POS;COND;1;SG
 mõistma	oled mõistnud	V;ACT;PRS;PRF;POS;IND;2;SG
 mõistma	oli mõistnud	V;ACT;PRS;PRF;POS;COND;3;SG
-mõistma	ei ole mõistetudp	V;PASS;PRS;PRF;NEG;IND
+mõistma	ei ole mõistetud	V;PASS;PRS;PRF;NEG;IND
 mõistma	mõistaksin	V;ACT;PRS;POS;COND;1;SG
 mõistma	olen mõistnud	V;ACT;PRS;PRF;POS;IND;1;SG
-mõistma	ei olnud mõistetudp	V;PASS;PST;PRF;NEG;IND
+mõistma	ei olnud mõistetud	V;PASS;PST;PRF;NEG;IND
 mõistma	ärgu olgu mõistetud	V;PASS;PRS;PRF;NEG;IMP
 
 mõla	mõlani	N;TERM;SG
@@ -16625,7 +16625,7 @@ naaber	naabritesse	N;IN+ALL;PL
 naaber	naabritelt	N;AT+ABL;PL
 
 naasma	olete naasnud	V;ACT;PRS;PRF;POS;IND;2;PL
-naasma	ei olevat naasnudp	V;ACT;PRS;PRF;NEG;QUOT
+naasma	ei olevat naasnud	V;ACT;PRS;PRF;NEG;QUOT
 naasma	oleks naastud	V;PASS;PRS;PRF;POS;COND
 naasma	naasin	V;ACT;PST;POS;IND;1;SG
 naasma	naastakse	V;PASS;PRS;POS;IND
@@ -16634,7 +16634,7 @@ naasma	naastagu	V;PASS;PRS;POS;IMP
 naasma	ärgu naasku	V;ACT;PRS;NEG;IMP;3;SG
 naasma	oli naastud	V;PASS;PST;PRF;POS;IND
 naasma	naasime	V;ACT;PST;POS;IND;1;PL
-naasma	ei olnud naasnudp	V;ACT;PST;PRF;NEG;IND
+naasma	ei olnud naasnud	V;ACT;PST;PRF;NEG;IND
 naasma	oleksid naasnud	V;ACT;PRS;PRF;POS;COND;2;SG
 naasma	olgu naasnud	V;ACT;PRS;PRF;POS;IMP;PL
 naasma	oli naasnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -16648,9 +16648,9 @@ naasma	ärgu naasku	V;ACT;PRS;NEG;IMP;3;PL
 naasma	olgu naasnud	V;ACT;PRS;PRF;POS;IMP;SG
 naasma	naasti	V;PASS;PST;POS;IND
 naasma	ei naasvat	V;ACT;PRS;NEG;QUOT
-naasma	ei oleks naastudp	V;PASS;PRS;PRF;NEG;COND
+naasma	ei oleks naastud	V;PASS;PRS;PRF;NEG;COND
 naasma	ei naasnud	V;ACT;PST;NEG;IND
-naasma	ei olevat naastudp	V;PASS;PRS;PRF;NEG;QUOT
+naasma	ei olevat naastud	V;PASS;PRS;PRF;NEG;QUOT
 naasma	ei naaseks	V;ACT;PRS;PRF;POS;COND;1;SG
 naasma	naastud	V.PTCP;PASS;PST
 naasma	olid naasnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -16669,7 +16669,7 @@ naasma	olgu naastud	V;PASS;PRS;PRF;POS;IMP
 naasma	naaseks	V;ACT;PRS;POS;COND;3;SG
 naasma	naasku	V;ACT;PRS;POS;IMP;3;PL
 naasma	ärgu olgu naasnud	V;ACT;PRS;PRF;NEG;IMP;SG
-naasma	ei ole naasnudp	V;ACT;PST;NEG;IND
+naasma	ei ole naasnud	V;ACT;PST;NEG;IND
 naasma	naased	V;ACT;PRS;POS;IND;2;SG
 naasma	ära naase	V;ACT;PRS;NEG;IMP;2;SG
 naasma	ei naase	V;ACT;PRS;NEG;IND
@@ -16697,17 +16697,17 @@ naasma	ei naasta	V;PASS;PRS;NEG;IND
 naasma	naaseme	V;ACT;PRS;POS;IND;1;PL
 naasma	naasen	V;ACT;PRS;POS;IND;1;SG
 naasma	ärgem naaskem	V;ACT;PRS;NEG;IMP;1;PL
-naasma	ei oleks naasnudp	V;ACT;PRS;PRF;NEG;COND
+naasma	ei oleks naasnud	V;ACT;PRS;PRF;NEG;COND
 naasma	oleksid naasnud	V;ACT;PRS;PRF;POS;COND;3;PL
 naasma	naasite	V;ACT;PST;POS;IND;2;PL
 naasma	oleks naasnud	V;ACT;PRS;PRF;POS;COND;3;SG
 naasma	olin naasnud	V;ACT;PRS;PRF;POS;COND;1;SG
 naasma	oled naasnud	V;ACT;PRS;PRF;POS;IND;2;SG
 naasma	oli naasnud	V;ACT;PRS;PRF;POS;COND;3;SG
-naasma	ei ole naastudp	V;PASS;PRS;PRF;NEG;IND
+naasma	ei ole naastud	V;PASS;PRS;PRF;NEG;IND
 naasma	naaseksin	V;ACT;PRS;POS;COND;1;SG
 naasma	olen naasnud	V;ACT;PRS;PRF;POS;IND;1;SG
-naasma	ei olnud naastudp	V;PASS;PST;PRF;NEG;IND
+naasma	ei olnud naastud	V;PASS;PST;PRF;NEG;IND
 naasma	ärgu olgu naastud	V;PASS;PRS;PRF;NEG;IMP
 
 naatrium	naatriumini	N;TERM;SG
@@ -16742,7 +16742,7 @@ naatrium	naatriumdesse	N;IN+ALL;PL
 naatrium	naatriumdelt	N;AT+ABL;PL
 
 naerma	olete naernud	V;ACT;PRS;PRF;POS;IND;2;PL
-naerma	ei olevat naernudp	V;ACT;PRS;PRF;NEG;QUOT
+naerma	ei olevat naernud	V;ACT;PRS;PRF;NEG;QUOT
 naerma	oleks naerdud	V;PASS;PRS;PRF;POS;COND
 naerma	naersin	V;ACT;PST;POS;IND;1;SG
 naerma	naerdakse	V;PASS;PRS;POS;IND
@@ -16751,7 +16751,7 @@ naerma	naerdagu	V;PASS;PRS;POS;IMP
 naerma	ärgu naergu	V;ACT;PRS;NEG;IMP;3;SG
 naerma	oli naerdud	V;PASS;PST;PRF;POS;IND
 naerma	naersime	V;ACT;PST;POS;IND;1;PL
-naerma	ei olnud naernudp	V;ACT;PST;PRF;NEG;IND
+naerma	ei olnud naernud	V;ACT;PST;PRF;NEG;IND
 naerma	oleksid naernud	V;ACT;PRS;PRF;POS;COND;2;SG
 naerma	olgu naernud	V;ACT;PRS;PRF;POS;IMP;PL
 naerma	oli naernud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -16765,9 +16765,9 @@ naerma	ärgu naergu	V;ACT;PRS;NEG;IMP;3;PL
 naerma	olgu naernud	V;ACT;PRS;PRF;POS;IMP;SG
 naerma	naerdi	V;PASS;PST;POS;IND
 naerma	ei naervat	V;ACT;PRS;NEG;QUOT
-naerma	ei oleks naerdudp	V;PASS;PRS;PRF;NEG;COND
+naerma	ei oleks naerdud	V;PASS;PRS;PRF;NEG;COND
 naerma	ei naernud	V;ACT;PST;NEG;IND
-naerma	ei olevat naerdudp	V;PASS;PRS;PRF;NEG;QUOT
+naerma	ei olevat naerdud	V;PASS;PRS;PRF;NEG;QUOT
 naerma	ei naeraks	V;ACT;PRS;PRF;POS;COND;1;SG
 naerma	naerdud	V.PTCP;PASS;PST
 naerma	olid naernud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -16786,7 +16786,7 @@ naerma	olgu naerdud	V;PASS;PRS;PRF;POS;IMP
 naerma	naeraks	V;ACT;PRS;POS;COND;3;SG
 naerma	naergu	V;ACT;PRS;POS;IMP;3;PL
 naerma	ärgu olgu naernud	V;ACT;PRS;PRF;NEG;IMP;SG
-naerma	ei ole naernudp	V;ACT;PST;NEG;IND
+naerma	ei ole naernud	V;ACT;PST;NEG;IND
 naerma	naerad	V;ACT;PRS;POS;IND;2;SG
 naerma	ära naera	V;ACT;PRS;NEG;IMP;2;SG
 naerma	ei naera	V;ACT;PRS;NEG;IND
@@ -16814,17 +16814,17 @@ naerma	ei naerda	V;PASS;PRS;NEG;IND
 naerma	naerame	V;ACT;PRS;POS;IND;1;PL
 naerma	naeran	V;ACT;PRS;POS;IND;1;SG
 naerma	ärgem naergem	V;ACT;PRS;NEG;IMP;1;PL
-naerma	ei oleks naernudp	V;ACT;PRS;PRF;NEG;COND
+naerma	ei oleks naernud	V;ACT;PRS;PRF;NEG;COND
 naerma	oleksid naernud	V;ACT;PRS;PRF;POS;COND;3;PL
 naerma	naersite	V;ACT;PST;POS;IND;2;PL
 naerma	oleks naernud	V;ACT;PRS;PRF;POS;COND;3;SG
 naerma	olin naernud	V;ACT;PRS;PRF;POS;COND;1;SG
 naerma	oled naernud	V;ACT;PRS;PRF;POS;IND;2;SG
 naerma	oli naernud	V;ACT;PRS;PRF;POS;COND;3;SG
-naerma	ei ole naerdudp	V;PASS;PRS;PRF;NEG;IND
+naerma	ei ole naerdud	V;PASS;PRS;PRF;NEG;IND
 naerma	naeraksin	V;ACT;PRS;POS;COND;1;SG
 naerma	olen naernud	V;ACT;PRS;PRF;POS;IND;1;SG
-naerma	ei olnud naerdudp	V;PASS;PST;PRF;NEG;IND
+naerma	ei olnud naerdud	V;PASS;PST;PRF;NEG;IND
 naerma	ärgu olgu naerdud	V;PASS;PRS;PRF;NEG;IMP
 
 nahkhiir	nahkhiireni	N;TERM;SG
@@ -16983,7 +16983,7 @@ neptuunium	neptuuniumdesse	N;IN+ALL;PL
 neptuunium	neptuuniumdelt	N;AT+ABL;PL
 
 niisutama	olete niisutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-niisutama	ei olevat niisutanudp	V;ACT;PRS;PRF;NEG;QUOT
+niisutama	ei olevat niisutanud	V;ACT;PRS;PRF;NEG;QUOT
 niisutama	oleks niisutatud	V;PASS;PRS;PRF;POS;COND
 niisutama	niisutasin	V;ACT;PST;POS;IND;1;SG
 niisutama	niisutatakse	V;PASS;PRS;POS;IND
@@ -16992,7 +16992,7 @@ niisutama	niisutatagu	V;PASS;PRS;POS;IMP
 niisutama	ärgu niisutagu	V;ACT;PRS;NEG;IMP;3;SG
 niisutama	oli niisutatud	V;PASS;PST;PRF;POS;IND
 niisutama	niisutasime	V;ACT;PST;POS;IND;1;PL
-niisutama	ei olnud niisutanudp	V;ACT;PST;PRF;NEG;IND
+niisutama	ei olnud niisutanud	V;ACT;PST;PRF;NEG;IND
 niisutama	oleksid niisutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 niisutama	olgu niisutanud	V;ACT;PRS;PRF;POS;IMP;PL
 niisutama	oli niisutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -17006,9 +17006,9 @@ niisutama	ärgu niisutagu	V;ACT;PRS;NEG;IMP;3;PL
 niisutama	olgu niisutanud	V;ACT;PRS;PRF;POS;IMP;SG
 niisutama	niisutati	V;PASS;PST;POS;IND
 niisutama	ei niisutavat	V;ACT;PRS;NEG;QUOT
-niisutama	ei oleks niisutatudp	V;PASS;PRS;PRF;NEG;COND
+niisutama	ei oleks niisutatud	V;PASS;PRS;PRF;NEG;COND
 niisutama	ei niisutanud	V;ACT;PST;NEG;IND
-niisutama	ei olevat niisutatudp	V;PASS;PRS;PRF;NEG;QUOT
+niisutama	ei olevat niisutatud	V;PASS;PRS;PRF;NEG;QUOT
 niisutama	ei niisutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 niisutama	niisutatud	V.PTCP;PASS;PST
 niisutama	olid niisutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -17027,7 +17027,7 @@ niisutama	olgu niisutatud	V;PASS;PRS;PRF;POS;IMP
 niisutama	niisutaks	V;ACT;PRS;POS;COND;3;SG
 niisutama	niisutagu	V;ACT;PRS;POS;IMP;3;PL
 niisutama	ärgu olgu niisutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-niisutama	ei ole niisutanudp	V;ACT;PST;NEG;IND
+niisutama	ei ole niisutanud	V;ACT;PST;NEG;IND
 niisutama	niisutad	V;ACT;PRS;POS;IND;2;SG
 niisutama	ära niisuta	V;ACT;PRS;NEG;IMP;2;SG
 niisutama	ei niisuta	V;ACT;PRS;NEG;IND
@@ -17055,17 +17055,17 @@ niisutama	ei niisutata	V;PASS;PRS;NEG;IND
 niisutama	niisutame	V;ACT;PRS;POS;IND;1;PL
 niisutama	niisutan	V;ACT;PRS;POS;IND;1;SG
 niisutama	ärgem niisutagem	V;ACT;PRS;NEG;IMP;1;PL
-niisutama	ei oleks niisutanudp	V;ACT;PRS;PRF;NEG;COND
+niisutama	ei oleks niisutanud	V;ACT;PRS;PRF;NEG;COND
 niisutama	oleksid niisutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 niisutama	niisutasite	V;ACT;PST;POS;IND;2;PL
 niisutama	oleks niisutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 niisutama	olin niisutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 niisutama	oled niisutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 niisutama	oli niisutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-niisutama	ei ole niisutatudp	V;PASS;PRS;PRF;NEG;IND
+niisutama	ei ole niisutatud	V;PASS;PRS;PRF;NEG;IND
 niisutama	niisutaksin	V;ACT;PRS;POS;COND;1;SG
 niisutama	olen niisutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-niisutama	ei olnud niisutatudp	V;PASS;PST;PRF;NEG;IND
+niisutama	ei olnud niisutatud	V;PASS;PST;PRF;NEG;IND
 niisutama	ärgu olgu niisutatud	V;PASS;PRS;PRF;NEG;IMP
 
 nikkel	niklini	N;TERM;SG
@@ -17100,7 +17100,7 @@ nikkel	niklitesse	N;IN+ALL;PL
 nikkel	niklitelt	N;AT+ABL;PL
 
 nikkuma	olete nikkunud	V;ACT;PRS;PRF;POS;IND;2;PL
-nikkuma	ei olevat nikkunudp	V;ACT;PRS;PRF;NEG;QUOT
+nikkuma	ei olevat nikkunud	V;ACT;PRS;PRF;NEG;QUOT
 nikkuma	oleks nikutud	V;PASS;PRS;PRF;POS;COND
 nikkuma	nikkusin	V;ACT;PST;POS;IND;1;SG
 nikkuma	nikutakse	V;PASS;PRS;POS;IND
@@ -17109,7 +17109,7 @@ nikkuma	nikutagu	V;PASS;PRS;POS;IMP
 nikkuma	ärgu nikkugu	V;ACT;PRS;NEG;IMP;3;SG
 nikkuma	oli nikutud	V;PASS;PST;PRF;POS;IND
 nikkuma	nikkusime	V;ACT;PST;POS;IND;1;PL
-nikkuma	ei olnud nikkunudp	V;ACT;PST;PRF;NEG;IND
+nikkuma	ei olnud nikkunud	V;ACT;PST;PRF;NEG;IND
 nikkuma	oleksid nikkunud	V;ACT;PRS;PRF;POS;COND;2;SG
 nikkuma	olgu nikkunud	V;ACT;PRS;PRF;POS;IMP;PL
 nikkuma	oli nikkunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -17123,9 +17123,9 @@ nikkuma	ärgu nikkugu	V;ACT;PRS;NEG;IMP;3;PL
 nikkuma	olgu nikkunud	V;ACT;PRS;PRF;POS;IMP;SG
 nikkuma	nikuti	V;PASS;PST;POS;IND
 nikkuma	ei nikkuvat	V;ACT;PRS;NEG;QUOT
-nikkuma	ei oleks nikutudp	V;PASS;PRS;PRF;NEG;COND
+nikkuma	ei oleks nikutud	V;PASS;PRS;PRF;NEG;COND
 nikkuma	ei nikkunud	V;ACT;PST;NEG;IND
-nikkuma	ei olevat nikutudp	V;PASS;PRS;PRF;NEG;QUOT
+nikkuma	ei olevat nikutud	V;PASS;PRS;PRF;NEG;QUOT
 nikkuma	ei nikuks	V;ACT;PRS;PRF;POS;COND;1;SG
 nikkuma	nikutud	V.PTCP;PASS;PST
 nikkuma	olid nikkunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -17144,7 +17144,7 @@ nikkuma	olgu nikutud	V;PASS;PRS;PRF;POS;IMP
 nikkuma	nikuks	V;ACT;PRS;POS;COND;3;SG
 nikkuma	nikkugu	V;ACT;PRS;POS;IMP;3;PL
 nikkuma	ärgu olgu nikkunud	V;ACT;PRS;PRF;NEG;IMP;SG
-nikkuma	ei ole nikkunudp	V;ACT;PST;NEG;IND
+nikkuma	ei ole nikkunud	V;ACT;PST;NEG;IND
 nikkuma	nikud	V;ACT;PRS;POS;IND;2;SG
 nikkuma	ära niku	V;ACT;PRS;NEG;IMP;2;SG
 nikkuma	ei niku	V;ACT;PRS;NEG;IND
@@ -17172,17 +17172,17 @@ nikkuma	ei nikuta	V;PASS;PRS;NEG;IND
 nikkuma	nikume	V;ACT;PRS;POS;IND;1;PL
 nikkuma	nikun	V;ACT;PRS;POS;IND;1;SG
 nikkuma	ärgem nikkugem	V;ACT;PRS;NEG;IMP;1;PL
-nikkuma	ei oleks nikkunudp	V;ACT;PRS;PRF;NEG;COND
+nikkuma	ei oleks nikkunud	V;ACT;PRS;PRF;NEG;COND
 nikkuma	oleksid nikkunud	V;ACT;PRS;PRF;POS;COND;3;PL
 nikkuma	nikkusite	V;ACT;PST;POS;IND;2;PL
 nikkuma	oleks nikkunud	V;ACT;PRS;PRF;POS;COND;3;SG
 nikkuma	olin nikkunud	V;ACT;PRS;PRF;POS;COND;1;SG
 nikkuma	oled nikkunud	V;ACT;PRS;PRF;POS;IND;2;SG
 nikkuma	oli nikkunud	V;ACT;PRS;PRF;POS;COND;3;SG
-nikkuma	ei ole nikutudp	V;PASS;PRS;PRF;NEG;IND
+nikkuma	ei ole nikutud	V;PASS;PRS;PRF;NEG;IND
 nikkuma	nikuksin	V;ACT;PRS;POS;COND;1;SG
 nikkuma	olen nikkunud	V;ACT;PRS;PRF;POS;IND;1;SG
-nikkuma	ei olnud nikutudp	V;PASS;PST;PRF;NEG;IND
+nikkuma	ei olnud nikutud	V;PASS;PST;PRF;NEG;IND
 nikkuma	ärgu olgu nikutud	V;PASS;PRS;PRF;NEG;IMP
 
 nimetav	nimetavani	N;TERM;SG
@@ -17341,7 +17341,7 @@ nobeelium	nobeeliumdesse	N;IN+ALL;PL
 nobeelium	nobeeliumdelt	N;AT+ABL;PL
 
 nokkima	olete nokkinud	V;ACT;PRS;PRF;POS;IND;2;PL
-nokkima	ei olevat nokkinudp	V;ACT;PRS;PRF;NEG;QUOT
+nokkima	ei olevat nokkinud	V;ACT;PRS;PRF;NEG;QUOT
 nokkima	oleks nokitud	V;PASS;PRS;PRF;POS;COND
 nokkima	nokkisin	V;ACT;PST;POS;IND;1;SG
 nokkima	nokitakse	V;PASS;PRS;POS;IND
@@ -17350,7 +17350,7 @@ nokkima	nokitagu	V;PASS;PRS;POS;IMP
 nokkima	ärgu nokkigu	V;ACT;PRS;NEG;IMP;3;SG
 nokkima	oli nokitud	V;PASS;PST;PRF;POS;IND
 nokkima	nokkisime	V;ACT;PST;POS;IND;1;PL
-nokkima	ei olnud nokkinudp	V;ACT;PST;PRF;NEG;IND
+nokkima	ei olnud nokkinud	V;ACT;PST;PRF;NEG;IND
 nokkima	oleksid nokkinud	V;ACT;PRS;PRF;POS;COND;2;SG
 nokkima	olgu nokkinud	V;ACT;PRS;PRF;POS;IMP;PL
 nokkima	oli nokkinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -17364,9 +17364,9 @@ nokkima	ärgu nokkigu	V;ACT;PRS;NEG;IMP;3;PL
 nokkima	olgu nokkinud	V;ACT;PRS;PRF;POS;IMP;SG
 nokkima	nokiti	V;PASS;PST;POS;IND
 nokkima	ei nokkivat	V;ACT;PRS;NEG;QUOT
-nokkima	ei oleks nokitudp	V;PASS;PRS;PRF;NEG;COND
+nokkima	ei oleks nokitud	V;PASS;PRS;PRF;NEG;COND
 nokkima	ei nokkinud	V;ACT;PST;NEG;IND
-nokkima	ei olevat nokitudp	V;PASS;PRS;PRF;NEG;QUOT
+nokkima	ei olevat nokitud	V;PASS;PRS;PRF;NEG;QUOT
 nokkima	ei nokiks	V;ACT;PRS;PRF;POS;COND;1;SG
 nokkima	nokitud	V.PTCP;PASS;PST
 nokkima	olid nokkinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -17385,7 +17385,7 @@ nokkima	olgu nokitud	V;PASS;PRS;PRF;POS;IMP
 nokkima	nokiks	V;ACT;PRS;POS;COND;3;SG
 nokkima	nokkigu	V;ACT;PRS;POS;IMP;3;PL
 nokkima	ärgu olgu nokkinud	V;ACT;PRS;PRF;NEG;IMP;SG
-nokkima	ei ole nokkinudp	V;ACT;PST;NEG;IND
+nokkima	ei ole nokkinud	V;ACT;PST;NEG;IND
 nokkima	nokid	V;ACT;PRS;POS;IND;2;SG
 nokkima	ära noki	V;ACT;PRS;NEG;IMP;2;SG
 nokkima	ei noki	V;ACT;PRS;NEG;IND
@@ -17413,17 +17413,17 @@ nokkima	ei nokita	V;PASS;PRS;NEG;IND
 nokkima	nokime	V;ACT;PRS;POS;IND;1;PL
 nokkima	nokin	V;ACT;PRS;POS;IND;1;SG
 nokkima	ärgem nokkigem	V;ACT;PRS;NEG;IMP;1;PL
-nokkima	ei oleks nokkinudp	V;ACT;PRS;PRF;NEG;COND
+nokkima	ei oleks nokkinud	V;ACT;PRS;PRF;NEG;COND
 nokkima	oleksid nokkinud	V;ACT;PRS;PRF;POS;COND;3;PL
 nokkima	nokkisite	V;ACT;PST;POS;IND;2;PL
 nokkima	oleks nokkinud	V;ACT;PRS;PRF;POS;COND;3;SG
 nokkima	olin nokkinud	V;ACT;PRS;PRF;POS;COND;1;SG
 nokkima	oled nokkinud	V;ACT;PRS;PRF;POS;IND;2;SG
 nokkima	oli nokkinud	V;ACT;PRS;PRF;POS;COND;3;SG
-nokkima	ei ole nokitudp	V;PASS;PRS;PRF;NEG;IND
+nokkima	ei ole nokitud	V;PASS;PRS;PRF;NEG;IND
 nokkima	nokiksin	V;ACT;PRS;POS;COND;1;SG
 nokkima	olen nokkinud	V;ACT;PRS;PRF;POS;IND;1;SG
-nokkima	ei olnud nokitudp	V;PASS;PST;PRF;NEG;IND
+nokkima	ei olnud nokitud	V;PASS;PST;PRF;NEG;IND
 nokkima	ärgu olgu nokitud	V;PASS;PRS;PRF;NEG;IMP
 
 norralane	norralaseni	N;TERM;SG
@@ -17520,7 +17520,7 @@ number	numbritesse	N;IN+ALL;PL
 number	numbritelt	N;AT+ABL;PL
 
 nussima	olete nussinud	V;ACT;PRS;PRF;POS;IND;2;PL
-nussima	ei olevat nussinudp	V;ACT;PRS;PRF;NEG;QUOT
+nussima	ei olevat nussinud	V;ACT;PRS;PRF;NEG;QUOT
 nussima	oleks nussitud	V;PASS;PRS;PRF;POS;COND
 nussima	nussisin	V;ACT;PST;POS;IND;1;SG
 nussima	nussitakse	V;PASS;PRS;POS;IND
@@ -17529,7 +17529,7 @@ nussima	nussitagu	V;PASS;PRS;POS;IMP
 nussima	ärgu nussigu	V;ACT;PRS;NEG;IMP;3;SG
 nussima	oli nussitud	V;PASS;PST;PRF;POS;IND
 nussima	nussisime	V;ACT;PST;POS;IND;1;PL
-nussima	ei olnud nussinudp	V;ACT;PST;PRF;NEG;IND
+nussima	ei olnud nussinud	V;ACT;PST;PRF;NEG;IND
 nussima	oleksid nussinud	V;ACT;PRS;PRF;POS;COND;2;SG
 nussima	olgu nussinud	V;ACT;PRS;PRF;POS;IMP;PL
 nussima	oli nussinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -17543,9 +17543,9 @@ nussima	ärgu nussigu	V;ACT;PRS;NEG;IMP;3;PL
 nussima	olgu nussinud	V;ACT;PRS;PRF;POS;IMP;SG
 nussima	nussiti	V;PASS;PST;POS;IND
 nussima	ei nussivat	V;ACT;PRS;NEG;QUOT
-nussima	ei oleks nussitudp	V;PASS;PRS;PRF;NEG;COND
+nussima	ei oleks nussitud	V;PASS;PRS;PRF;NEG;COND
 nussima	ei nussinud	V;ACT;PST;NEG;IND
-nussima	ei olevat nussitudp	V;PASS;PRS;PRF;NEG;QUOT
+nussima	ei olevat nussitud	V;PASS;PRS;PRF;NEG;QUOT
 nussima	ei nussiks	V;ACT;PRS;PRF;POS;COND;1;SG
 nussima	nussitud	V.PTCP;PASS;PST
 nussima	olid nussinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -17564,7 +17564,7 @@ nussima	olgu nussitud	V;PASS;PRS;PRF;POS;IMP
 nussima	nussiks	V;ACT;PRS;POS;COND;3;SG
 nussima	nussigu	V;ACT;PRS;POS;IMP;3;PL
 nussima	ärgu olgu nussinud	V;ACT;PRS;PRF;NEG;IMP;SG
-nussima	ei ole nussinudp	V;ACT;PST;NEG;IND
+nussima	ei ole nussinud	V;ACT;PST;NEG;IND
 nussima	nussid	V;ACT;PRS;POS;IND;2;SG
 nussima	ära nussi	V;ACT;PRS;NEG;IMP;2;SG
 nussima	ei nussi	V;ACT;PRS;NEG;IND
@@ -17592,21 +17592,21 @@ nussima	ei nussita	V;PASS;PRS;NEG;IND
 nussima	nussime	V;ACT;PRS;POS;IND;1;PL
 nussima	nussin	V;ACT;PRS;POS;IND;1;SG
 nussima	ärgem nussigem	V;ACT;PRS;NEG;IMP;1;PL
-nussima	ei oleks nussinudp	V;ACT;PRS;PRF;NEG;COND
+nussima	ei oleks nussinud	V;ACT;PRS;PRF;NEG;COND
 nussima	oleksid nussinud	V;ACT;PRS;PRF;POS;COND;3;PL
 nussima	nussisite	V;ACT;PST;POS;IND;2;PL
 nussima	oleks nussinud	V;ACT;PRS;PRF;POS;COND;3;SG
 nussima	olin nussinud	V;ACT;PRS;PRF;POS;COND;1;SG
 nussima	oled nussinud	V;ACT;PRS;PRF;POS;IND;2;SG
 nussima	oli nussinud	V;ACT;PRS;PRF;POS;COND;3;SG
-nussima	ei ole nussitudp	V;PASS;PRS;PRF;NEG;IND
+nussima	ei ole nussitud	V;PASS;PRS;PRF;NEG;IND
 nussima	nussiksin	V;ACT;PRS;POS;COND;1;SG
 nussima	olen nussinud	V;ACT;PRS;PRF;POS;IND;1;SG
-nussima	ei olnud nussitudp	V;PASS;PST;PRF;NEG;IND
+nussima	ei olnud nussitud	V;PASS;PST;PRF;NEG;IND
 nussima	ärgu olgu nussitud	V;PASS;PRS;PRF;NEG;IMP
 
 nutma	olete nutnud	V;ACT;PRS;PRF;POS;IND;2;PL
-nutma	ei olevat nutnudp	V;ACT;PRS;PRF;NEG;QUOT
+nutma	ei olevat nutnud	V;ACT;PRS;PRF;NEG;QUOT
 nutma	oleks nutetud	V;PASS;PRS;PRF;POS;COND
 nutma	nutsin	V;ACT;PST;POS;IND;1;SG
 nutma	nutetakse	V;PASS;PRS;POS;IND
@@ -17615,7 +17615,7 @@ nutma	nutetagu	V;PASS;PRS;POS;IMP
 nutma	ärgu nutku	V;ACT;PRS;NEG;IMP;3;SG
 nutma	oli nutetud	V;PASS;PST;PRF;POS;IND
 nutma	nutsime	V;ACT;PST;POS;IND;1;PL
-nutma	ei olnud nutnudp	V;ACT;PST;PRF;NEG;IND
+nutma	ei olnud nutnud	V;ACT;PST;PRF;NEG;IND
 nutma	oleksid nutnud	V;ACT;PRS;PRF;POS;COND;2;SG
 nutma	olgu nutnud	V;ACT;PRS;PRF;POS;IMP;PL
 nutma	oli nutnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -17629,9 +17629,9 @@ nutma	ärgu nutku	V;ACT;PRS;NEG;IMP;3;PL
 nutma	olgu nutnud	V;ACT;PRS;PRF;POS;IMP;SG
 nutma	nuteti	V;PASS;PST;POS;IND
 nutma	ei nutvat	V;ACT;PRS;NEG;QUOT
-nutma	ei oleks nutetudp	V;PASS;PRS;PRF;NEG;COND
+nutma	ei oleks nutetud	V;PASS;PRS;PRF;NEG;COND
 nutma	ei nutnud	V;ACT;PST;NEG;IND
-nutma	ei olevat nutetudp	V;PASS;PRS;PRF;NEG;QUOT
+nutma	ei olevat nutetud	V;PASS;PRS;PRF;NEG;QUOT
 nutma	ei nutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 nutma	nutetud	V.PTCP;PASS;PST
 nutma	olid nutnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -17650,7 +17650,7 @@ nutma	olgu nutetud	V;PASS;PRS;PRF;POS;IMP
 nutma	nutaks	V;ACT;PRS;POS;COND;3;SG
 nutma	nutku	V;ACT;PRS;POS;IMP;3;PL
 nutma	ärgu olgu nutnud	V;ACT;PRS;PRF;NEG;IMP;SG
-nutma	ei ole nutnudp	V;ACT;PST;NEG;IND
+nutma	ei ole nutnud	V;ACT;PST;NEG;IND
 nutma	nutad	V;ACT;PRS;POS;IND;2;SG
 nutma	ära nuta	V;ACT;PRS;NEG;IMP;2;SG
 nutma	ei nuta	V;ACT;PRS;NEG;IND
@@ -17678,17 +17678,17 @@ nutma	ei nuteta	V;PASS;PRS;NEG;IND
 nutma	nutame	V;ACT;PRS;POS;IND;1;PL
 nutma	nutan	V;ACT;PRS;POS;IND;1;SG
 nutma	ärgem nutkem	V;ACT;PRS;NEG;IMP;1;PL
-nutma	ei oleks nutnudp	V;ACT;PRS;PRF;NEG;COND
+nutma	ei oleks nutnud	V;ACT;PRS;PRF;NEG;COND
 nutma	oleksid nutnud	V;ACT;PRS;PRF;POS;COND;3;PL
 nutma	nutsite	V;ACT;PST;POS;IND;2;PL
 nutma	oleks nutnud	V;ACT;PRS;PRF;POS;COND;3;SG
 nutma	olin nutnud	V;ACT;PRS;PRF;POS;COND;1;SG
 nutma	oled nutnud	V;ACT;PRS;PRF;POS;IND;2;SG
 nutma	oli nutnud	V;ACT;PRS;PRF;POS;COND;3;SG
-nutma	ei ole nutetudp	V;PASS;PRS;PRF;NEG;IND
+nutma	ei ole nutetud	V;PASS;PRS;PRF;NEG;IND
 nutma	nutaksin	V;ACT;PRS;POS;COND;1;SG
 nutma	olen nutnud	V;ACT;PRS;PRF;POS;IND;1;SG
-nutma	ei olnud nutetudp	V;PASS;PST;PRF;NEG;IND
+nutma	ei olnud nutetud	V;PASS;PST;PRF;NEG;IND
 nutma	ärgu olgu nutetud	V;PASS;PRS;PRF;NEG;IMP
 
 nädal	nädalani	N;TERM;SG
@@ -17723,7 +17723,7 @@ nädal	nädalatesse	N;IN+ALL;PL
 nädal	nädalatelt	N;AT+ABL;PL
 
 nägema	olete näinud	V;ACT;PRS;PRF;POS;IND;2;PL
-nägema	ei olevat näinudp	V;ACT;PRS;PRF;NEG;QUOT
+nägema	ei olevat näinud	V;ACT;PRS;PRF;NEG;QUOT
 nägema	oleks nähtud	V;PASS;PRS;PRF;POS;COND
 nägema	nägin	V;ACT;PST;POS;IND;1;SG
 nägema	nähakse	V;PASS;PRS;POS;IND
@@ -17732,7 +17732,7 @@ nägema	nähtagu	V;PASS;PRS;POS;IMP
 nägema	ärgu nähku	V;ACT;PRS;NEG;IMP;3;SG
 nägema	oli nähtud	V;PASS;PST;PRF;POS;IND
 nägema	nägime	V;ACT;PST;POS;IND;1;PL
-nägema	ei olnud näinudp	V;ACT;PST;PRF;NEG;IND
+nägema	ei olnud näinud	V;ACT;PST;PRF;NEG;IND
 nägema	oleksid näinud	V;ACT;PRS;PRF;POS;COND;2;SG
 nägema	olgu näinud	V;ACT;PRS;PRF;POS;IMP;PL
 nägema	oli näinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -17746,9 +17746,9 @@ nägema	ärgu nähku	V;ACT;PRS;NEG;IMP;3;PL
 nägema	olgu näinud	V;ACT;PRS;PRF;POS;IMP;SG
 nägema	nähti	V;PASS;PST;POS;IND
 nägema	ei nägevat	V;ACT;PRS;NEG;QUOT
-nägema	ei oleks nähtudp	V;PASS;PRS;PRF;NEG;COND
+nägema	ei oleks nähtud	V;PASS;PRS;PRF;NEG;COND
 nägema	ei näinud	V;ACT;PST;NEG;IND
-nägema	ei olevat nähtudp	V;PASS;PRS;PRF;NEG;QUOT
+nägema	ei olevat nähtud	V;PASS;PRS;PRF;NEG;QUOT
 nägema	ei näeks	V;ACT;PRS;PRF;POS;COND;1;SG
 nägema	nähtud	V.PTCP;PASS;PST
 nägema	olid näinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -17767,7 +17767,7 @@ nägema	olgu nähtud	V;PASS;PRS;PRF;POS;IMP
 nägema	näeks	V;ACT;PRS;POS;COND;3;SG
 nägema	nähku	V;ACT;PRS;POS;IMP;3;PL
 nägema	ärgu olgu näinud	V;ACT;PRS;PRF;NEG;IMP;SG
-nägema	ei ole näinudp	V;ACT;PST;NEG;IND
+nägema	ei ole näinud	V;ACT;PST;NEG;IND
 nägema	näed	V;ACT;PRS;POS;IND;2;SG
 nägema	ära näe	V;ACT;PRS;NEG;IMP;2;SG
 nägema	ei näe	V;ACT;PRS;NEG;IND
@@ -17795,17 +17795,17 @@ nägema	ei nähta	V;PASS;PRS;NEG;IND
 nägema	näeme	V;ACT;PRS;POS;IND;1;PL
 nägema	näen	V;ACT;PRS;POS;IND;1;SG
 nägema	ärgem nähkem	V;ACT;PRS;NEG;IMP;1;PL
-nägema	ei oleks näinudp	V;ACT;PRS;PRF;NEG;COND
+nägema	ei oleks näinud	V;ACT;PRS;PRF;NEG;COND
 nägema	oleksid näinud	V;ACT;PRS;PRF;POS;COND;3;PL
 nägema	nägite	V;ACT;PST;POS;IND;2;PL
 nägema	oleks näinud	V;ACT;PRS;PRF;POS;COND;3;SG
 nägema	olin näinud	V;ACT;PRS;PRF;POS;COND;1;SG
 nägema	oled näinud	V;ACT;PRS;PRF;POS;IND;2;SG
 nägema	oli näinud	V;ACT;PRS;PRF;POS;COND;3;SG
-nägema	ei ole nähtudp	V;PASS;PRS;PRF;NEG;IND
+nägema	ei ole nähtud	V;PASS;PRS;PRF;NEG;IND
 nägema	näeksin	V;ACT;PRS;POS;COND;1;SG
 nägema	olen näinud	V;ACT;PRS;PRF;POS;IND;1;SG
-nägema	ei olnud nähtudp	V;PASS;PST;PRF;NEG;IND
+nägema	ei olnud nähtud	V;PASS;PST;PRF;NEG;IND
 nägema	ärgu olgu nähtud	V;PASS;PRS;PRF;NEG;IMP
 
 nägu	näoni	N;TERM;SG
@@ -17933,7 +17933,7 @@ näitlejatar	näitlejatardesse	N;IN+ALL;PL
 näitlejatar	näitlejatardelt	N;AT+ABL;PL
 
 närima	olete närinud	V;ACT;PRS;PRF;POS;IND;2;PL
-närima	ei olevat närinudp	V;ACT;PRS;PRF;NEG;QUOT
+närima	ei olevat närinud	V;ACT;PRS;PRF;NEG;QUOT
 närima	oleks näritud	V;PASS;PRS;PRF;POS;COND
 närima	närisin	V;ACT;PST;POS;IND;1;SG
 närima	näritakse	V;PASS;PRS;POS;IND
@@ -17942,7 +17942,7 @@ närima	näritagu	V;PASS;PRS;POS;IMP
 närima	ärgu närigu	V;ACT;PRS;NEG;IMP;3;SG
 närima	oli näritud	V;PASS;PST;PRF;POS;IND
 närima	närisime	V;ACT;PST;POS;IND;1;PL
-närima	ei olnud närinudp	V;ACT;PST;PRF;NEG;IND
+närima	ei olnud närinud	V;ACT;PST;PRF;NEG;IND
 närima	oleksid närinud	V;ACT;PRS;PRF;POS;COND;2;SG
 närima	olgu närinud	V;ACT;PRS;PRF;POS;IMP;PL
 närima	oli närinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -17956,9 +17956,9 @@ närima	ärgu närigu	V;ACT;PRS;NEG;IMP;3;PL
 närima	olgu närinud	V;ACT;PRS;PRF;POS;IMP;SG
 närima	näriti	V;PASS;PST;POS;IND
 närima	ei närivat	V;ACT;PRS;NEG;QUOT
-närima	ei oleks näritudp	V;PASS;PRS;PRF;NEG;COND
+närima	ei oleks näritud	V;PASS;PRS;PRF;NEG;COND
 närima	ei närinud	V;ACT;PST;NEG;IND
-närima	ei olevat näritudp	V;PASS;PRS;PRF;NEG;QUOT
+närima	ei olevat näritud	V;PASS;PRS;PRF;NEG;QUOT
 närima	ei näriks	V;ACT;PRS;PRF;POS;COND;1;SG
 närima	näritud	V.PTCP;PASS;PST
 närima	olid närinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -17977,7 +17977,7 @@ närima	olgu näritud	V;PASS;PRS;PRF;POS;IMP
 närima	näriks	V;ACT;PRS;POS;COND;3;SG
 närima	närigu	V;ACT;PRS;POS;IMP;3;PL
 närima	ärgu olgu närinud	V;ACT;PRS;PRF;NEG;IMP;SG
-närima	ei ole närinudp	V;ACT;PST;NEG;IND
+närima	ei ole närinud	V;ACT;PST;NEG;IND
 närima	närid	V;ACT;PRS;POS;IND;2;SG
 närima	ära näri	V;ACT;PRS;NEG;IMP;2;SG
 närima	ei näri	V;ACT;PRS;NEG;IND
@@ -18005,17 +18005,17 @@ närima	ei närita	V;PASS;PRS;NEG;IND
 närima	närime	V;ACT;PRS;POS;IND;1;PL
 närima	närin	V;ACT;PRS;POS;IND;1;SG
 närima	ärgem närigem	V;ACT;PRS;NEG;IMP;1;PL
-närima	ei oleks närinudp	V;ACT;PRS;PRF;NEG;COND
+närima	ei oleks närinud	V;ACT;PRS;PRF;NEG;COND
 närima	oleksid närinud	V;ACT;PRS;PRF;POS;COND;3;PL
 närima	närisite	V;ACT;PST;POS;IND;2;PL
 närima	oleks närinud	V;ACT;PRS;PRF;POS;COND;3;SG
 närima	olin närinud	V;ACT;PRS;PRF;POS;COND;1;SG
 närima	oled närinud	V;ACT;PRS;PRF;POS;IND;2;SG
 närima	oli närinud	V;ACT;PRS;PRF;POS;COND;3;SG
-närima	ei ole näritudp	V;PASS;PRS;PRF;NEG;IND
+närima	ei ole näritud	V;PASS;PRS;PRF;NEG;IND
 närima	näriksin	V;ACT;PRS;POS;COND;1;SG
 närima	olen närinud	V;ACT;PRS;PRF;POS;IND;1;SG
-närima	ei olnud näritudp	V;PASS;PST;PRF;NEG;IND
+närima	ei olnud näritud	V;PASS;PST;PRF;NEG;IND
 närima	ärgu olgu näritud	V;PASS;PRS;PRF;NEG;IMP
 
 nõges	nõgeseni	N;TERM;SG
@@ -18081,7 +18081,7 @@ nõukogu	nõukogudesse	N;IN+ALL;PL
 nõukogu	nõukogudelt	N;AT+ABL;PL
 
 nülgima	olete nülginud	V;ACT;PRS;PRF;POS;IND;2;PL
-nülgima	ei olevat nülginudp	V;ACT;PRS;PRF;NEG;QUOT
+nülgima	ei olevat nülginud	V;ACT;PRS;PRF;NEG;QUOT
 nülgima	oleks nülitud	V;PASS;PRS;PRF;POS;COND
 nülgima	nülgisin	V;ACT;PST;POS;IND;1;SG
 nülgima	nülitakse	V;PASS;PRS;POS;IND
@@ -18090,7 +18090,7 @@ nülgima	nülitagu	V;PASS;PRS;POS;IMP
 nülgima	ärgu nülgigu	V;ACT;PRS;NEG;IMP;3;SG
 nülgima	oli nülitud	V;PASS;PST;PRF;POS;IND
 nülgima	nülgisime	V;ACT;PST;POS;IND;1;PL
-nülgima	ei olnud nülginudp	V;ACT;PST;PRF;NEG;IND
+nülgima	ei olnud nülginud	V;ACT;PST;PRF;NEG;IND
 nülgima	oleksid nülginud	V;ACT;PRS;PRF;POS;COND;2;SG
 nülgima	olgu nülginud	V;ACT;PRS;PRF;POS;IMP;PL
 nülgima	oli nülginud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -18104,9 +18104,9 @@ nülgima	ärgu nülgigu	V;ACT;PRS;NEG;IMP;3;PL
 nülgima	olgu nülginud	V;ACT;PRS;PRF;POS;IMP;SG
 nülgima	nüliti	V;PASS;PST;POS;IND
 nülgima	ei nülgivat	V;ACT;PRS;NEG;QUOT
-nülgima	ei oleks nülitudp	V;PASS;PRS;PRF;NEG;COND
+nülgima	ei oleks nülitud	V;PASS;PRS;PRF;NEG;COND
 nülgima	ei nülginud	V;ACT;PST;NEG;IND
-nülgima	ei olevat nülitudp	V;PASS;PRS;PRF;NEG;QUOT
+nülgima	ei olevat nülitud	V;PASS;PRS;PRF;NEG;QUOT
 nülgima	ei nüliks	V;ACT;PRS;PRF;POS;COND;1;SG
 nülgima	nülitud	V.PTCP;PASS;PST
 nülgima	olid nülginud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -18125,7 +18125,7 @@ nülgima	olgu nülitud	V;PASS;PRS;PRF;POS;IMP
 nülgima	nüliks	V;ACT;PRS;POS;COND;3;SG
 nülgima	nülgigu	V;ACT;PRS;POS;IMP;3;PL
 nülgima	ärgu olgu nülginud	V;ACT;PRS;PRF;NEG;IMP;SG
-nülgima	ei ole nülginudp	V;ACT;PST;NEG;IND
+nülgima	ei ole nülginud	V;ACT;PST;NEG;IND
 nülgima	nülid	V;ACT;PRS;POS;IND;2;SG
 nülgima	ära nüli	V;ACT;PRS;NEG;IMP;2;SG
 nülgima	ei nüli	V;ACT;PRS;NEG;IND
@@ -18153,17 +18153,17 @@ nülgima	ei nülita	V;PASS;PRS;NEG;IND
 nülgima	nülime	V;ACT;PRS;POS;IND;1;PL
 nülgima	nülin	V;ACT;PRS;POS;IND;1;SG
 nülgima	ärgem nülgigem	V;ACT;PRS;NEG;IMP;1;PL
-nülgima	ei oleks nülginudp	V;ACT;PRS;PRF;NEG;COND
+nülgima	ei oleks nülginud	V;ACT;PRS;PRF;NEG;COND
 nülgima	oleksid nülginud	V;ACT;PRS;PRF;POS;COND;3;PL
 nülgima	nülgisite	V;ACT;PST;POS;IND;2;PL
 nülgima	oleks nülginud	V;ACT;PRS;PRF;POS;COND;3;SG
 nülgima	olin nülginud	V;ACT;PRS;PRF;POS;COND;1;SG
 nülgima	oled nülginud	V;ACT;PRS;PRF;POS;IND;2;SG
 nülgima	oli nülginud	V;ACT;PRS;PRF;POS;COND;3;SG
-nülgima	ei ole nülitudp	V;PASS;PRS;PRF;NEG;IND
+nülgima	ei ole nülitud	V;PASS;PRS;PRF;NEG;IND
 nülgima	nüliksin	V;ACT;PRS;POS;COND;1;SG
 nülgima	olen nülginud	V;ACT;PRS;PRF;POS;IND;1;SG
-nülgima	ei olnud nülitudp	V;PASS;PST;PRF;NEG;IND
+nülgima	ei olnud nülitud	V;PASS;PST;PRF;NEG;IND
 nülgima	ärgu olgu nülitud	V;PASS;PRS;PRF;NEG;IMP
 
 observatoorium	observatooriumini	N;TERM;SG
@@ -18291,7 +18291,7 @@ oimuluu	oimuluudesse	N;IN+ALL;PL
 oimuluu	oimuluudelt	N;AT+ABL;PL
 
 oksendama	olete oksendanud	V;ACT;PRS;PRF;POS;IND;2;PL
-oksendama	ei olevat oksendanudp	V;ACT;PRS;PRF;NEG;QUOT
+oksendama	ei olevat oksendanud	V;ACT;PRS;PRF;NEG;QUOT
 oksendama	oleks oksendatud	V;PASS;PRS;PRF;POS;COND
 oksendama	oksendasin	V;ACT;PST;POS;IND;1;SG
 oksendama	oksendatakse	V;PASS;PRS;POS;IND
@@ -18300,7 +18300,7 @@ oksendama	oksendatagu	V;PASS;PRS;POS;IMP
 oksendama	ärgu oksendagu	V;ACT;PRS;NEG;IMP;3;SG
 oksendama	oli oksendatud	V;PASS;PST;PRF;POS;IND
 oksendama	oksendasime	V;ACT;PST;POS;IND;1;PL
-oksendama	ei olnud oksendanudp	V;ACT;PST;PRF;NEG;IND
+oksendama	ei olnud oksendanud	V;ACT;PST;PRF;NEG;IND
 oksendama	oleksid oksendanud	V;ACT;PRS;PRF;POS;COND;2;SG
 oksendama	olgu oksendanud	V;ACT;PRS;PRF;POS;IMP;PL
 oksendama	oli oksendanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -18314,9 +18314,9 @@ oksendama	ärgu oksendagu	V;ACT;PRS;NEG;IMP;3;PL
 oksendama	olgu oksendanud	V;ACT;PRS;PRF;POS;IMP;SG
 oksendama	oksendati	V;PASS;PST;POS;IND
 oksendama	ei oksendavat	V;ACT;PRS;NEG;QUOT
-oksendama	ei oleks oksendatudp	V;PASS;PRS;PRF;NEG;COND
+oksendama	ei oleks oksendatud	V;PASS;PRS;PRF;NEG;COND
 oksendama	ei oksendanud	V;ACT;PST;NEG;IND
-oksendama	ei olevat oksendatudp	V;PASS;PRS;PRF;NEG;QUOT
+oksendama	ei olevat oksendatud	V;PASS;PRS;PRF;NEG;QUOT
 oksendama	ei oksendaks	V;ACT;PRS;PRF;POS;COND;1;SG
 oksendama	oksendatud	V.PTCP;PASS;PST
 oksendama	olid oksendanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -18335,7 +18335,7 @@ oksendama	olgu oksendatud	V;PASS;PRS;PRF;POS;IMP
 oksendama	oksendaks	V;ACT;PRS;POS;COND;3;SG
 oksendama	oksendagu	V;ACT;PRS;POS;IMP;3;PL
 oksendama	ärgu olgu oksendanud	V;ACT;PRS;PRF;NEG;IMP;SG
-oksendama	ei ole oksendanudp	V;ACT;PST;NEG;IND
+oksendama	ei ole oksendanud	V;ACT;PST;NEG;IND
 oksendama	oksendad	V;ACT;PRS;POS;IND;2;SG
 oksendama	ära oksenda	V;ACT;PRS;NEG;IMP;2;SG
 oksendama	ei oksenda	V;ACT;PRS;NEG;IND
@@ -18363,17 +18363,17 @@ oksendama	ei oksendata	V;PASS;PRS;NEG;IND
 oksendama	oksendame	V;ACT;PRS;POS;IND;1;PL
 oksendama	oksendan	V;ACT;PRS;POS;IND;1;SG
 oksendama	ärgem oksendagem	V;ACT;PRS;NEG;IMP;1;PL
-oksendama	ei oleks oksendanudp	V;ACT;PRS;PRF;NEG;COND
+oksendama	ei oleks oksendanud	V;ACT;PRS;PRF;NEG;COND
 oksendama	oleksid oksendanud	V;ACT;PRS;PRF;POS;COND;3;PL
 oksendama	oksendasite	V;ACT;PST;POS;IND;2;PL
 oksendama	oleks oksendanud	V;ACT;PRS;PRF;POS;COND;3;SG
 oksendama	olin oksendanud	V;ACT;PRS;PRF;POS;COND;1;SG
 oksendama	oled oksendanud	V;ACT;PRS;PRF;POS;IND;2;SG
 oksendama	oli oksendanud	V;ACT;PRS;PRF;POS;COND;3;SG
-oksendama	ei ole oksendatudp	V;PASS;PRS;PRF;NEG;IND
+oksendama	ei ole oksendatud	V;PASS;PRS;PRF;NEG;IND
 oksendama	oksendaksin	V;ACT;PRS;POS;COND;1;SG
 oksendama	olen oksendanud	V;ACT;PRS;PRF;POS;IND;1;SG
-oksendama	ei olnud oksendatudp	V;PASS;PST;PRF;NEG;IND
+oksendama	ei olnud oksendatud	V;PASS;PST;PRF;NEG;IND
 oksendama	ärgu olgu oksendatud	V;PASS;PRS;PRF;NEG;IMP
 
 oksjon	oksjonini	N;TERM;SG
@@ -18439,7 +18439,7 @@ oktoober	oktoobritesse	N;IN+ALL;PL
 oktoober	oktoobritelt	N;AT+ABL;PL
 
 olema	olete olnud	V;ACT;PRS;PRF;POS;IND;2;PL
-olema	ei olevat olnudp	V;ACT;PRS;PRF;NEG;QUOT
+olema	ei olevat olnud	V;ACT;PRS;PRF;NEG;QUOT
 olema	oleks oldud	V;PASS;PRS;PRF;POS;COND
 olema	olin	V;ACT;PST;POS;IND;1;SG
 olema	ollakse	V;PASS;PRS;POS;IND
@@ -18462,9 +18462,9 @@ olema	ärgu olgu	V;ACT;PRS;NEG;IMP;3;PL
 olema	olgu olnud	V;ACT;PRS;PRF;POS;IMP;SG
 olema	oldi	V;PASS;PST;POS;IND
 olema	ei olevat	V;ACT;PRS;NEG;QUOT
-olema	ei oleks oldudp	V;PASS;PRS;PRF;NEG;COND
+olema	ei oleks oldud	V;PASS;PRS;PRF;NEG;COND
 olema	ei olnud	V;ACT;PST;NEG;IND
-olema	ei olevat oldudp	V;PASS;PRS;PRF;NEG;QUOT
+olema	ei olevat oldud	V;PASS;PRS;PRF;NEG;QUOT
 olema	ei oleks	V;ACT;PRS;PRF;POS;COND;1;SG
 olema	oldud	V.PTCP;PASS;PST
 olema	olid olnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -18483,7 +18483,7 @@ olema	olgu oldud	V;PASS;PRS;PRF;POS;IMP
 olema	oleks	V;ACT;PRS;POS;COND;3;SG
 olema	olgu	V;ACT;PRS;POS;IMP;3;PL
 olema	ärgu olgu olnud	V;ACT;PRS;PRF;NEG;IMP;SG
-olema	ei ole olnudp	V;ACT;PST;NEG;IND
+olema	ei ole olnud	V;ACT;PST;NEG;IND
 olema	oled	V;ACT;PRS;POS;IND;2;SG
 olema	ära ole	V;ACT;PRS;NEG;IMP;2;SG
 olema	ei ole	V;ACT;PRS;NEG;IND
@@ -18511,17 +18511,17 @@ olema	ei olda	V;PASS;PRS;NEG;IND
 olema	oleme	V;ACT;PRS;POS;IND;1;PL
 olema	olen	V;ACT;PRS;POS;IND;1;SG
 olema	ärgem olgem	V;ACT;PRS;NEG;IMP;1;PL
-olema	ei oleks olnudp	V;ACT;PRS;PRF;NEG;COND
+olema	ei oleks olnud	V;ACT;PRS;PRF;NEG;COND
 olema	oleksid olnud	V;ACT;PRS;PRF;POS;COND;3;PL
 olema	olite	V;ACT;PST;POS;IND;2;PL
 olema	oleks olnud	V;ACT;PRS;PRF;POS;COND;3;SG
 olema	olin olnud	V;ACT;PRS;PRF;POS;COND;1;SG
 olema	oled olnud	V;ACT;PRS;PRF;POS;IND;2;SG
 olema	oli olnud	V;ACT;PRS;PRF;POS;COND;3;SG
-olema	ei ole oldudp	V;PASS;PRS;PRF;NEG;IND
+olema	ei ole oldud	V;PASS;PRS;PRF;NEG;IND
 olema	oleksin	V;ACT;PRS;POS;COND;1;SG
 olema	olen olnud	V;ACT;PRS;PRF;POS;IND;1;SG
-olema	ei olnud oldudp	V;PASS;PST;PRF;NEG;IND
+olema	ei olnud oldud	V;PASS;PST;PRF;NEG;IND
 olema	ärgu olgu oldud	V;PASS;PRS;PRF;NEG;IMP
 
 oletama	olete oletanud	V;ACT;PRS;PRF;POS;IND;2;PL
@@ -18534,7 +18534,7 @@ oletama	oletatagu	V;PASS;PRS;POS;IMP
 oletama	ärgu oletagu	V;ACT;PRS;NEG;IMP;3;SG
 oletama	oli oletatud	V;PASS;PST;PRF;POS;IND
 oletama	oletasime	V;ACT;PST;POS;IND;1;PL
-oletama	ei olnud oletanudp	V;ACT;PST;PRF;NEG;IND
+oletama	ei olnud oletanud	V;ACT;PST;PRF;NEG;IND
 oletama	oleksid oletanud	V;ACT;PRS;PRF;POS;COND;2;SG
 oletama	olgu oletanud	V;ACT;PRS;PRF;POS;IMP;PL
 oletama	oli oletanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -18607,7 +18607,7 @@ oletama	oli oletanud	V;ACT;PRS;PRF;POS;COND;3;SG
 oletama	ei ole 	V;PASS;PRS;PRF;NEG;IND
 oletama	oletaksin	V;ACT;PRS;POS;COND;1;SG
 oletama	olen oletanud	V;ACT;PRS;PRF;POS;IND;1;SG
-oletama	ei olnud oletatudp	V;PASS;PST;PRF;NEG;IND
+oletama	ei olnud oletatud	V;PASS;PST;PRF;NEG;IND
 oletama	ärgu olgu oletatud	V;PASS;PRS;PRF;NEG;IMP
 
 olev	olevani	N;TERM;SG
@@ -18735,7 +18735,7 @@ oluline	olulistesse	N;IN+ALL;PL
 oluline	olulistelt	N;AT+ABL;PL
 
 omama	olete omanud	V;ACT;PRS;PRF;POS;IND;2;PL
-omama	ei olevat omanudp	V;ACT;PRS;PRF;NEG;QUOT
+omama	ei olevat omanud	V;ACT;PRS;PRF;NEG;QUOT
 omama	oleks omatud	V;PASS;PRS;PRF;POS;COND
 omama	omasin	V;ACT;PST;POS;IND;1;SG
 omama	omatakse	V;PASS;PRS;POS;IND
@@ -18744,7 +18744,7 @@ omama	omatagu	V;PASS;PRS;POS;IMP
 omama	ärgu omagu	V;ACT;PRS;NEG;IMP;3;SG
 omama	oli omatud	V;PASS;PST;PRF;POS;IND
 omama	omasime	V;ACT;PST;POS;IND;1;PL
-omama	ei olnud omanudp	V;ACT;PST;PRF;NEG;IND
+omama	ei olnud omanud	V;ACT;PST;PRF;NEG;IND
 omama	oleksid omanud	V;ACT;PRS;PRF;POS;COND;2;SG
 omama	olgu omanud	V;ACT;PRS;PRF;POS;IMP;PL
 omama	oli omanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -18758,9 +18758,9 @@ omama	ärgu omagu	V;ACT;PRS;NEG;IMP;3;PL
 omama	olgu omanud	V;ACT;PRS;PRF;POS;IMP;SG
 omama	omati	V;PASS;PST;POS;IND
 omama	ei omavat	V;ACT;PRS;NEG;QUOT
-omama	ei oleks omatudp	V;PASS;PRS;PRF;NEG;COND
+omama	ei oleks omatud	V;PASS;PRS;PRF;NEG;COND
 omama	ei omanud	V;ACT;PST;NEG;IND
-omama	ei olevat omatudp	V;PASS;PRS;PRF;NEG;QUOT
+omama	ei olevat omatud	V;PASS;PRS;PRF;NEG;QUOT
 omama	ei omaks	V;ACT;PRS;PRF;POS;COND;1;SG
 omama	omatud	V.PTCP;PASS;PST
 omama	olid omanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -18779,7 +18779,7 @@ omama	olgu omatud	V;PASS;PRS;PRF;POS;IMP
 omama	omaks	V;ACT;PRS;POS;COND;3;SG
 omama	omagu	V;ACT;PRS;POS;IMP;3;PL
 omama	ärgu olgu omanud	V;ACT;PRS;PRF;NEG;IMP;SG
-omama	ei ole omanudp	V;ACT;PST;NEG;IND
+omama	ei ole omanud	V;ACT;PST;NEG;IND
 omama	omad	V;ACT;PRS;POS;IND;2;SG
 omama	ära oma	V;ACT;PRS;NEG;IMP;2;SG
 omama	ei oma	V;ACT;PRS;NEG;IND
@@ -18807,21 +18807,21 @@ omama	ei omata	V;PASS;PRS;NEG;IND
 omama	omame	V;ACT;PRS;POS;IND;1;PL
 omama	oman	V;ACT;PRS;POS;IND;1;SG
 omama	ärgem omagem	V;ACT;PRS;NEG;IMP;1;PL
-omama	ei oleks omanudp	V;ACT;PRS;PRF;NEG;COND
+omama	ei oleks omanud	V;ACT;PRS;PRF;NEG;COND
 omama	oleksid omanud	V;ACT;PRS;PRF;POS;COND;3;PL
 omama	omasite	V;ACT;PST;POS;IND;2;PL
 omama	oleks omanud	V;ACT;PRS;PRF;POS;COND;3;SG
 omama	olin omanud	V;ACT;PRS;PRF;POS;COND;1;SG
 omama	oled omanud	V;ACT;PRS;PRF;POS;IND;2;SG
 omama	oli omanud	V;ACT;PRS;PRF;POS;COND;3;SG
-omama	ei ole omatudp	V;PASS;PRS;PRF;NEG;IND
+omama	ei ole omatud	V;PASS;PRS;PRF;NEG;IND
 omama	omaksin	V;ACT;PRS;POS;COND;1;SG
 omama	olen omanud	V;ACT;PRS;PRF;POS;IND;1;SG
-omama	ei olnud omatudp	V;PASS;PST;PRF;NEG;IND
+omama	ei olnud omatud	V;PASS;PST;PRF;NEG;IND
 omama	ärgu olgu omatud	V;PASS;PRS;PRF;NEG;IMP
 
 omandama	olete omandanud	V;ACT;PRS;PRF;POS;IND;2;PL
-omandama	ei olevat omandanudp	V;ACT;PRS;PRF;NEG;QUOT
+omandama	ei olevat omandanud	V;ACT;PRS;PRF;NEG;QUOT
 omandama	oleks omandatud	V;PASS;PRS;PRF;POS;COND
 omandama	omandasin	V;ACT;PST;POS;IND;1;SG
 omandama	omandatakse	V;PASS;PRS;POS;IND
@@ -18830,7 +18830,7 @@ omandama	omandatagu	V;PASS;PRS;POS;IMP
 omandama	ärgu omandagu	V;ACT;PRS;NEG;IMP;3;SG
 omandama	oli omandatud	V;PASS;PST;PRF;POS;IND
 omandama	omandasime	V;ACT;PST;POS;IND;1;PL
-omandama	ei olnud omandanudp	V;ACT;PST;PRF;NEG;IND
+omandama	ei olnud omandanud	V;ACT;PST;PRF;NEG;IND
 omandama	oleksid omandanud	V;ACT;PRS;PRF;POS;COND;2;SG
 omandama	olgu omandanud	V;ACT;PRS;PRF;POS;IMP;PL
 omandama	oli omandanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -18844,9 +18844,9 @@ omandama	ärgu omandagu	V;ACT;PRS;NEG;IMP;3;PL
 omandama	olgu omandanud	V;ACT;PRS;PRF;POS;IMP;SG
 omandama	omandati	V;PASS;PST;POS;IND
 omandama	ei omandavat	V;ACT;PRS;NEG;QUOT
-omandama	ei oleks omandatudp	V;PASS;PRS;PRF;NEG;COND
+omandama	ei oleks omandatud	V;PASS;PRS;PRF;NEG;COND
 omandama	ei omandanud	V;ACT;PST;NEG;IND
-omandama	ei olevat omandatudp	V;PASS;PRS;PRF;NEG;QUOT
+omandama	ei olevat omandatud	V;PASS;PRS;PRF;NEG;QUOT
 omandama	ei omandaks	V;ACT;PRS;PRF;POS;COND;1;SG
 omandama	omandatud	V.PTCP;PASS;PST
 omandama	olid omandanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -18865,7 +18865,7 @@ omandama	olgu omandatud	V;PASS;PRS;PRF;POS;IMP
 omandama	omandaks	V;ACT;PRS;POS;COND;3;SG
 omandama	omandagu	V;ACT;PRS;POS;IMP;3;PL
 omandama	ärgu olgu omandanud	V;ACT;PRS;PRF;NEG;IMP;SG
-omandama	ei ole omandanudp	V;ACT;PST;NEG;IND
+omandama	ei ole omandanud	V;ACT;PST;NEG;IND
 omandama	omandad	V;ACT;PRS;POS;IND;2;SG
 omandama	ära omanda	V;ACT;PRS;NEG;IMP;2;SG
 omandama	ei omanda	V;ACT;PRS;NEG;IND
@@ -18893,17 +18893,17 @@ omandama	ei omandata	V;PASS;PRS;NEG;IND
 omandama	omandame	V;ACT;PRS;POS;IND;1;PL
 omandama	omandan	V;ACT;PRS;POS;IND;1;SG
 omandama	ärgem omandagem	V;ACT;PRS;NEG;IMP;1;PL
-omandama	ei oleks omandanudp	V;ACT;PRS;PRF;NEG;COND
+omandama	ei oleks omandanud	V;ACT;PRS;PRF;NEG;COND
 omandama	oleksid omandanud	V;ACT;PRS;PRF;POS;COND;3;PL
 omandama	omandasite	V;ACT;PST;POS;IND;2;PL
 omandama	oleks omandanud	V;ACT;PRS;PRF;POS;COND;3;SG
 omandama	olin omandanud	V;ACT;PRS;PRF;POS;COND;1;SG
 omandama	oled omandanud	V;ACT;PRS;PRF;POS;IND;2;SG
 omandama	oli omandanud	V;ACT;PRS;PRF;POS;COND;3;SG
-omandama	ei ole omandatudp	V;PASS;PRS;PRF;NEG;IND
+omandama	ei ole omandatud	V;PASS;PRS;PRF;NEG;IND
 omandama	omandaksin	V;ACT;PRS;POS;COND;1;SG
 omandama	olen omandanud	V;ACT;PRS;PRF;POS;IND;1;SG
-omandama	ei olnud omandatudp	V;PASS;PST;PRF;NEG;IND
+omandama	ei olnud omandatud	V;PASS;PST;PRF;NEG;IND
 omandama	ärgu olgu omandatud	V;PASS;PRS;PRF;NEG;IMP
 
 omastav	omastavani	N;TERM;SG
@@ -19000,7 +19000,7 @@ oopium	oopiumdesse	N;IN+ALL;PL
 oopium	oopiumdelt	N;AT+ABL;PL
 
 ootama	olete oodanud	V;ACT;PRS;PRF;POS;IND;2;PL
-ootama	ei olevat oodanudp	V;ACT;PRS;PRF;NEG;QUOT
+ootama	ei olevat oodanud	V;ACT;PRS;PRF;NEG;QUOT
 ootama	oleks oodatud	V;PASS;PRS;PRF;POS;COND
 ootama	ootasin	V;ACT;PST;POS;IND;1;SG
 ootama	oodatakse	V;PASS;PRS;POS;IND
@@ -19009,7 +19009,7 @@ ootama	oodatagu	V;PASS;PRS;POS;IMP
 ootama	ärgu oodaku	V;ACT;PRS;NEG;IMP;3;SG
 ootama	oli oodatud	V;PASS;PST;PRF;POS;IND
 ootama	ootasime	V;ACT;PST;POS;IND;1;PL
-ootama	ei olnud oodanudp	V;ACT;PST;PRF;NEG;IND
+ootama	ei olnud oodanud	V;ACT;PST;PRF;NEG;IND
 ootama	oleksid oodanud	V;ACT;PRS;PRF;POS;COND;2;SG
 ootama	olgu oodanud	V;ACT;PRS;PRF;POS;IMP;PL
 ootama	oli oodanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -19023,9 +19023,9 @@ ootama	ärgu oodaku	V;ACT;PRS;NEG;IMP;3;PL
 ootama	olgu oodanud	V;ACT;PRS;PRF;POS;IMP;SG
 ootama	oodati	V;PASS;PST;POS;IND
 ootama	ei ootavat	V;ACT;PRS;NEG;QUOT
-ootama	ei oleks oodatudp	V;PASS;PRS;PRF;NEG;COND
+ootama	ei oleks oodatud	V;PASS;PRS;PRF;NEG;COND
 ootama	ei oodanud	V;ACT;PST;NEG;IND
-ootama	ei olevat oodatudp	V;PASS;PRS;PRF;NEG;QUOT
+ootama	ei olevat oodatud	V;PASS;PRS;PRF;NEG;QUOT
 ootama	ei ootaks	V;ACT;PRS;PRF;POS;COND;1;SG
 ootama	oodatud	V.PTCP;PASS;PST
 ootama	olid oodanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -19044,7 +19044,7 @@ ootama	olgu oodatud	V;PASS;PRS;PRF;POS;IMP
 ootama	ootaks	V;ACT;PRS;POS;COND;3;SG
 ootama	oodaku	V;ACT;PRS;POS;IMP;3;PL
 ootama	ärgu olgu oodanud	V;ACT;PRS;PRF;NEG;IMP;SG
-ootama	ei ole oodanudp	V;ACT;PST;NEG;IND
+ootama	ei ole oodanud	V;ACT;PST;NEG;IND
 ootama	ootad	V;ACT;PRS;POS;IND;2;SG
 ootama	ära oota	V;ACT;PRS;NEG;IMP;2;SG
 ootama	ei oota	V;ACT;PRS;NEG;IND
@@ -19072,17 +19072,17 @@ ootama	ei oodata	V;PASS;PRS;NEG;IND
 ootama	ootame	V;ACT;PRS;POS;IND;1;PL
 ootama	ootan	V;ACT;PRS;POS;IND;1;SG
 ootama	ärgem oodakem	V;ACT;PRS;NEG;IMP;1;PL
-ootama	ei oleks oodanudp	V;ACT;PRS;PRF;NEG;COND
+ootama	ei oleks oodanud	V;ACT;PRS;PRF;NEG;COND
 ootama	oleksid oodanud	V;ACT;PRS;PRF;POS;COND;3;PL
 ootama	ootasite	V;ACT;PST;POS;IND;2;PL
 ootama	oleks oodanud	V;ACT;PRS;PRF;POS;COND;3;SG
 ootama	olin oodanud	V;ACT;PRS;PRF;POS;COND;1;SG
 ootama	oled oodanud	V;ACT;PRS;PRF;POS;IND;2;SG
 ootama	oli oodanud	V;ACT;PRS;PRF;POS;COND;3;SG
-ootama	ei ole oodatudp	V;PASS;PRS;PRF;NEG;IND
+ootama	ei ole oodatud	V;PASS;PRS;PRF;NEG;IND
 ootama	ootaksin	V;ACT;PRS;POS;COND;1;SG
 ootama	olen oodanud	V;ACT;PRS;PRF;POS;IND;1;SG
-ootama	ei olnud oodatudp	V;PASS;PST;PRF;NEG;IND
+ootama	ei olnud oodatud	V;PASS;PST;PRF;NEG;IND
 ootama	ärgu olgu oodatud	V;PASS;PRS;PRF;NEG;IMP
 
 optik	optikuni	N;TERM;SG
@@ -19272,7 +19272,7 @@ osastav	osastavatesse	N;IN+ALL;PL
 osastav	osastavatelt	N;AT+ABL;PL
 
 oskama	olete osanud	V;ACT;PRS;PRF;POS;IND;2;PL
-oskama	ei olevat osanudp	V;ACT;PRS;PRF;NEG;QUOT
+oskama	ei olevat osanud	V;ACT;PRS;PRF;NEG;QUOT
 oskama	oleks osatud	V;PASS;PRS;PRF;POS;COND
 oskama	oskasin	V;ACT;PST;POS;IND;1;SG
 oskama	osatakse	V;PASS;PRS;POS;IND
@@ -19281,7 +19281,7 @@ oskama	osatagu	V;PASS;PRS;POS;IMP
 oskama	ärgu osaku	V;ACT;PRS;NEG;IMP;3;SG
 oskama	oli osatud	V;PASS;PST;PRF;POS;IND
 oskama	oskasime	V;ACT;PST;POS;IND;1;PL
-oskama	ei olnud osanudp	V;ACT;PST;PRF;NEG;IND
+oskama	ei olnud osanud	V;ACT;PST;PRF;NEG;IND
 oskama	oleksid osanud	V;ACT;PRS;PRF;POS;COND;2;SG
 oskama	olgu osanud	V;ACT;PRS;PRF;POS;IMP;PL
 oskama	oli osanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -19295,9 +19295,9 @@ oskama	ärgu osaku	V;ACT;PRS;NEG;IMP;3;PL
 oskama	olgu osanud	V;ACT;PRS;PRF;POS;IMP;SG
 oskama	osati	V;PASS;PST;POS;IND
 oskama	ei oskavat	V;ACT;PRS;NEG;QUOT
-oskama	ei oleks osatudp	V;PASS;PRS;PRF;NEG;COND
+oskama	ei oleks osatud	V;PASS;PRS;PRF;NEG;COND
 oskama	ei osanud	V;ACT;PST;NEG;IND
-oskama	ei olevat osatudp	V;PASS;PRS;PRF;NEG;QUOT
+oskama	ei olevat osatud	V;PASS;PRS;PRF;NEG;QUOT
 oskama	ei oskaks	V;ACT;PRS;PRF;POS;COND;1;SG
 oskama	osatud	V.PTCP;PASS;PST
 oskama	olid osanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -19316,7 +19316,7 @@ oskama	olgu osatud	V;PASS;PRS;PRF;POS;IMP
 oskama	oskaks	V;ACT;PRS;POS;COND;3;SG
 oskama	osaku	V;ACT;PRS;POS;IMP;3;PL
 oskama	ärgu olgu osanud	V;ACT;PRS;PRF;NEG;IMP;SG
-oskama	ei ole osanudp	V;ACT;PST;NEG;IND
+oskama	ei ole osanud	V;ACT;PST;NEG;IND
 oskama	oskad	V;ACT;PRS;POS;IND;2;SG
 oskama	ära oska	V;ACT;PRS;NEG;IMP;2;SG
 oskama	ei oska	V;ACT;PRS;NEG;IND
@@ -19344,17 +19344,17 @@ oskama	ei osata	V;PASS;PRS;NEG;IND
 oskama	oskame	V;ACT;PRS;POS;IND;1;PL
 oskama	oskan	V;ACT;PRS;POS;IND;1;SG
 oskama	ärgem osakem	V;ACT;PRS;NEG;IMP;1;PL
-oskama	ei oleks osanudp	V;ACT;PRS;PRF;NEG;COND
+oskama	ei oleks osanud	V;ACT;PRS;PRF;NEG;COND
 oskama	oleksid osanud	V;ACT;PRS;PRF;POS;COND;3;PL
 oskama	oskasite	V;ACT;PST;POS;IND;2;PL
 oskama	oleks osanud	V;ACT;PRS;PRF;POS;COND;3;SG
 oskama	olin osanud	V;ACT;PRS;PRF;POS;COND;1;SG
 oskama	oled osanud	V;ACT;PRS;PRF;POS;IND;2;SG
 oskama	oli osanud	V;ACT;PRS;PRF;POS;COND;3;SG
-oskama	ei ole osatudp	V;PASS;PRS;PRF;NEG;IND
+oskama	ei ole osatud	V;PASS;PRS;PRF;NEG;IND
 oskama	oskaksin	V;ACT;PRS;POS;COND;1;SG
 oskama	olen osanud	V;ACT;PRS;PRF;POS;IND;1;SG
-oskama	ei olnud osatudp	V;PASS;PST;PRF;NEG;IND
+oskama	ei olnud osatud	V;PASS;PST;PRF;NEG;IND
 oskama	ärgu olgu osatud	V;PASS;PRS;PRF;NEG;IMP
 
 osmium	osmiumini	N;TERM;SG
@@ -19389,7 +19389,7 @@ osmium	osmiumdesse	N;IN+ALL;PL
 osmium	osmiumdelt	N;AT+ABL;PL
 
 ostma	olete ostnud	V;ACT;PRS;PRF;POS;IND;2;PL
-ostma	ei olevat ostnudp	V;ACT;PRS;PRF;NEG;QUOT
+ostma	ei olevat ostnud	V;ACT;PRS;PRF;NEG;QUOT
 ostma	oleks ostetud	V;PASS;PRS;PRF;POS;COND
 ostma	ostsin	V;ACT;PST;POS;IND;1;SG
 ostma	ostetakse	V;PASS;PRS;POS;IND
@@ -19398,7 +19398,7 @@ ostma	ostetagu	V;PASS;PRS;POS;IMP
 ostma	ärgu ostku	V;ACT;PRS;NEG;IMP;3;SG
 ostma	oli ostetud	V;PASS;PST;PRF;POS;IND
 ostma	ostsime	V;ACT;PST;POS;IND;1;PL
-ostma	ei olnud ostnudp	V;ACT;PST;PRF;NEG;IND
+ostma	ei olnud ostnud	V;ACT;PST;PRF;NEG;IND
 ostma	oleksid ostnud	V;ACT;PRS;PRF;POS;COND;2;SG
 ostma	olgu ostnud	V;ACT;PRS;PRF;POS;IMP;PL
 ostma	oli ostnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -19412,9 +19412,9 @@ ostma	ärgu ostku	V;ACT;PRS;NEG;IMP;3;PL
 ostma	olgu ostnud	V;ACT;PRS;PRF;POS;IMP;SG
 ostma	osteti	V;PASS;PST;POS;IND
 ostma	ei ostvat	V;ACT;PRS;NEG;QUOT
-ostma	ei oleks ostetudp	V;PASS;PRS;PRF;NEG;COND
+ostma	ei oleks ostetud	V;PASS;PRS;PRF;NEG;COND
 ostma	ei ostnud	V;ACT;PST;NEG;IND
-ostma	ei olevat ostetudp	V;PASS;PRS;PRF;NEG;QUOT
+ostma	ei olevat ostetud	V;PASS;PRS;PRF;NEG;QUOT
 ostma	ei ostaks	V;ACT;PRS;PRF;POS;COND;1;SG
 ostma	ostetud	V.PTCP;PASS;PST
 ostma	olid ostnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -19433,7 +19433,7 @@ ostma	olgu ostetud	V;PASS;PRS;PRF;POS;IMP
 ostma	ostaks	V;ACT;PRS;POS;COND;3;SG
 ostma	ostku	V;ACT;PRS;POS;IMP;3;PL
 ostma	ärgu olgu ostnud	V;ACT;PRS;PRF;NEG;IMP;SG
-ostma	ei ole ostnudp	V;ACT;PST;NEG;IND
+ostma	ei ole ostnud	V;ACT;PST;NEG;IND
 ostma	ostad	V;ACT;PRS;POS;IND;2;SG
 ostma	ära osta	V;ACT;PRS;NEG;IMP;2;SG
 ostma	ei osta	V;ACT;PRS;NEG;IND
@@ -19461,17 +19461,17 @@ ostma	ei osteta	V;PASS;PRS;NEG;IND
 ostma	ostame	V;ACT;PRS;POS;IND;1;PL
 ostma	ostan	V;ACT;PRS;POS;IND;1;SG
 ostma	ärgem ostkem	V;ACT;PRS;NEG;IMP;1;PL
-ostma	ei oleks ostnudp	V;ACT;PRS;PRF;NEG;COND
+ostma	ei oleks ostnud	V;ACT;PRS;PRF;NEG;COND
 ostma	oleksid ostnud	V;ACT;PRS;PRF;POS;COND;3;PL
 ostma	ostsite	V;ACT;PST;POS;IND;2;PL
 ostma	oleks ostnud	V;ACT;PRS;PRF;POS;COND;3;SG
 ostma	olin ostnud	V;ACT;PRS;PRF;POS;COND;1;SG
 ostma	oled ostnud	V;ACT;PRS;PRF;POS;IND;2;SG
 ostma	oli ostnud	V;ACT;PRS;PRF;POS;COND;3;SG
-ostma	ei ole ostetudp	V;PASS;PRS;PRF;NEG;IND
+ostma	ei ole ostetud	V;PASS;PRS;PRF;NEG;IND
 ostma	ostaksin	V;ACT;PRS;POS;COND;1;SG
 ostma	olen ostnud	V;ACT;PRS;PRF;POS;IND;1;SG
-ostma	ei olnud ostetudp	V;PASS;PST;PRF;NEG;IND
+ostma	ei olnud ostetud	V;PASS;PST;PRF;NEG;IND
 ostma	ärgu olgu ostetud	V;PASS;PRS;PRF;NEG;IMP
 
 otsetabamus	otsetabamuseni	N;TERM;SG
@@ -19506,7 +19506,7 @@ otsetabamus	otsetabamustesse	N;IN+ALL;PL
 otsetabamus	otsetabamustelt	N;AT+ABL;PL
 
 otsima	olete otsinud	V;ACT;PRS;PRF;POS;IND;2;PL
-otsima	ei olevat otsinudp	V;ACT;PRS;PRF;NEG;QUOT
+otsima	ei olevat otsinud	V;ACT;PRS;PRF;NEG;QUOT
 otsima	oleks otsitud	V;PASS;PRS;PRF;POS;COND
 otsima	otsisin	V;ACT;PST;POS;IND;1;SG
 otsima	otsitakse	V;PASS;PRS;POS;IND
@@ -19515,7 +19515,7 @@ otsima	otsitagu	V;PASS;PRS;POS;IMP
 otsima	ärgu otsigu	V;ACT;PRS;NEG;IMP;3;SG
 otsima	oli otsitud	V;PASS;PST;PRF;POS;IND
 otsima	otsisime	V;ACT;PST;POS;IND;1;PL
-otsima	ei olnud otsinudp	V;ACT;PST;PRF;NEG;IND
+otsima	ei olnud otsinud	V;ACT;PST;PRF;NEG;IND
 otsima	oleksid otsinud	V;ACT;PRS;PRF;POS;COND;2;SG
 otsima	olgu otsinud	V;ACT;PRS;PRF;POS;IMP;PL
 otsima	oli otsinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -19529,9 +19529,9 @@ otsima	ärgu otsigu	V;ACT;PRS;NEG;IMP;3;PL
 otsima	olgu otsinud	V;ACT;PRS;PRF;POS;IMP;SG
 otsima	otsiti	V;PASS;PST;POS;IND
 otsima	ei otsivat	V;ACT;PRS;NEG;QUOT
-otsima	ei oleks otsitudp	V;PASS;PRS;PRF;NEG;COND
+otsima	ei oleks otsitud	V;PASS;PRS;PRF;NEG;COND
 otsima	ei otsinud	V;ACT;PST;NEG;IND
-otsima	ei olevat otsitudp	V;PASS;PRS;PRF;NEG;QUOT
+otsima	ei olevat otsitud	V;PASS;PRS;PRF;NEG;QUOT
 otsima	ei otsiks	V;ACT;PRS;PRF;POS;COND;1;SG
 otsima	otsitud	V.PTCP;PASS;PST
 otsima	olid otsinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -19550,7 +19550,7 @@ otsima	olgu otsitud	V;PASS;PRS;PRF;POS;IMP
 otsima	otsiks	V;ACT;PRS;POS;COND;3;SG
 otsima	otsigu	V;ACT;PRS;POS;IMP;3;PL
 otsima	ärgu olgu otsinud	V;ACT;PRS;PRF;NEG;IMP;SG
-otsima	ei ole otsinudp	V;ACT;PST;NEG;IND
+otsima	ei ole otsinud	V;ACT;PST;NEG;IND
 otsima	otsid	V;ACT;PRS;POS;IND;2;SG
 otsima	ära otsi	V;ACT;PRS;NEG;IMP;2;SG
 otsima	ei otsi	V;ACT;PRS;NEG;IND
@@ -19578,17 +19578,17 @@ otsima	ei otsita	V;PASS;PRS;NEG;IND
 otsima	otsime	V;ACT;PRS;POS;IND;1;PL
 otsima	otsin	V;ACT;PRS;POS;IND;1;SG
 otsima	ärgem otsigem	V;ACT;PRS;NEG;IMP;1;PL
-otsima	ei oleks otsinudp	V;ACT;PRS;PRF;NEG;COND
+otsima	ei oleks otsinud	V;ACT;PRS;PRF;NEG;COND
 otsima	oleksid otsinud	V;ACT;PRS;PRF;POS;COND;3;PL
 otsima	otsisite	V;ACT;PST;POS;IND;2;PL
 otsima	oleks otsinud	V;ACT;PRS;PRF;POS;COND;3;SG
 otsima	olin otsinud	V;ACT;PRS;PRF;POS;COND;1;SG
 otsima	oled otsinud	V;ACT;PRS;PRF;POS;IND;2;SG
 otsima	oli otsinud	V;ACT;PRS;PRF;POS;COND;3;SG
-otsima	ei ole otsitudp	V;PASS;PRS;PRF;NEG;IND
+otsima	ei ole otsitud	V;PASS;PRS;PRF;NEG;IND
 otsima	otsiksin	V;ACT;PRS;POS;COND;1;SG
 otsima	olen otsinud	V;ACT;PRS;PRF;POS;IND;1;SG
-otsima	ei olnud otsitudp	V;PASS;PST;PRF;NEG;IND
+otsima	ei olnud otsitud	V;PASS;PST;PRF;NEG;IND
 otsima	ärgu olgu otsitud	V;PASS;PRS;PRF;NEG;IMP
 
 otsmikuluu	otsmikuluuni	N;TERM;SG
@@ -19623,7 +19623,7 @@ otsmikuluu	otsmikuluudesse	N;IN+ALL;PL
 otsmikuluu	otsmikuluudelt	N;AT+ABL;PL
 
 paarituma	olete paaritunud	V;ACT;PRS;PRF;POS;IND;2;PL
-paarituma	ei olevat paaritunudp	V;ACT;PRS;PRF;NEG;QUOT
+paarituma	ei olevat paaritunud	V;ACT;PRS;PRF;NEG;QUOT
 paarituma	oleks paaritutud	V;PASS;PRS;PRF;POS;COND
 paarituma	paaritusin	V;ACT;PST;POS;IND;1;SG
 paarituma	paaritutakse	V;PASS;PRS;POS;IND
@@ -19632,7 +19632,7 @@ paarituma	paaritutagu	V;PASS;PRS;POS;IMP
 paarituma	ärgu paaritugu	V;ACT;PRS;NEG;IMP;3;SG
 paarituma	oli paaritutud	V;PASS;PST;PRF;POS;IND
 paarituma	paaritusime	V;ACT;PST;POS;IND;1;PL
-paarituma	ei olnud paaritunudp	V;ACT;PST;PRF;NEG;IND
+paarituma	ei olnud paaritunud	V;ACT;PST;PRF;NEG;IND
 paarituma	oleksid paaritunud	V;ACT;PRS;PRF;POS;COND;2;SG
 paarituma	olgu paaritunud	V;ACT;PRS;PRF;POS;IMP;PL
 paarituma	oli paaritunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -19646,9 +19646,9 @@ paarituma	ärgu paaritugu	V;ACT;PRS;NEG;IMP;3;PL
 paarituma	olgu paaritunud	V;ACT;PRS;PRF;POS;IMP;SG
 paarituma	paarituti	V;PASS;PST;POS;IND
 paarituma	ei paarituvat	V;ACT;PRS;NEG;QUOT
-paarituma	ei oleks paaritutudp	V;PASS;PRS;PRF;NEG;COND
+paarituma	ei oleks paaritutud	V;PASS;PRS;PRF;NEG;COND
 paarituma	ei paaritunud	V;ACT;PST;NEG;IND
-paarituma	ei olevat paaritutudp	V;PASS;PRS;PRF;NEG;QUOT
+paarituma	ei olevat paaritutud	V;PASS;PRS;PRF;NEG;QUOT
 paarituma	ei paarituks	V;ACT;PRS;PRF;POS;COND;1;SG
 paarituma	paaritutud	V.PTCP;PASS;PST
 paarituma	olid paaritunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -19667,7 +19667,7 @@ paarituma	olgu paaritutud	V;PASS;PRS;PRF;POS;IMP
 paarituma	paarituks	V;ACT;PRS;POS;COND;3;SG
 paarituma	paaritugu	V;ACT;PRS;POS;IMP;3;PL
 paarituma	ärgu olgu paaritunud	V;ACT;PRS;PRF;NEG;IMP;SG
-paarituma	ei ole paaritunudp	V;ACT;PST;NEG;IND
+paarituma	ei ole paaritunud	V;ACT;PST;NEG;IND
 paarituma	paaritud	V;ACT;PRS;POS;IND;2;SG
 paarituma	ära paaritu	V;ACT;PRS;NEG;IMP;2;SG
 paarituma	ei paaritu	V;ACT;PRS;NEG;IND
@@ -19695,17 +19695,17 @@ paarituma	ei paarituta	V;PASS;PRS;NEG;IND
 paarituma	paaritume	V;ACT;PRS;POS;IND;1;PL
 paarituma	paaritun	V;ACT;PRS;POS;IND;1;SG
 paarituma	ärgem paaritugem	V;ACT;PRS;NEG;IMP;1;PL
-paarituma	ei oleks paaritunudp	V;ACT;PRS;PRF;NEG;COND
+paarituma	ei oleks paaritunud	V;ACT;PRS;PRF;NEG;COND
 paarituma	oleksid paaritunud	V;ACT;PRS;PRF;POS;COND;3;PL
 paarituma	paaritusite	V;ACT;PST;POS;IND;2;PL
 paarituma	oleks paaritunud	V;ACT;PRS;PRF;POS;COND;3;SG
 paarituma	olin paaritunud	V;ACT;PRS;PRF;POS;COND;1;SG
 paarituma	oled paaritunud	V;ACT;PRS;PRF;POS;IND;2;SG
 paarituma	oli paaritunud	V;ACT;PRS;PRF;POS;COND;3;SG
-paarituma	ei ole paaritutudp	V;PASS;PRS;PRF;NEG;IND
+paarituma	ei ole paaritutud	V;PASS;PRS;PRF;NEG;IND
 paarituma	paarituksin	V;ACT;PRS;POS;COND;1;SG
 paarituma	olen paaritunud	V;ACT;PRS;PRF;POS;IND;1;SG
-paarituma	ei olnud paaritutudp	V;PASS;PST;PRF;NEG;IND
+paarituma	ei olnud paaritutud	V;PASS;PST;PRF;NEG;IND
 paarituma	ärgu olgu paaritutud	V;PASS;PRS;PRF;NEG;IMP
 
 paaritumine	paaritumiseni	N;TERM;SG
@@ -19802,7 +19802,7 @@ pagar	pagaritesse	N;IN+ALL;PL
 pagar	pagaritelt	N;AT+ABL;PL
 
 palataliseerima	olete palataliseerinud	V;ACT;PRS;PRF;POS;IND;2;PL
-palataliseerima	ei olevat palataliseerinudp	V;ACT;PRS;PRF;NEG;QUOT
+palataliseerima	ei olevat palataliseerinud	V;ACT;PRS;PRF;NEG;QUOT
 palataliseerima	oleks palataliseeritud	V;PASS;PRS;PRF;POS;COND
 palataliseerima	palataliseerisin	V;ACT;PST;POS;IND;1;SG
 palataliseerima	palataliseeritakse	V;PASS;PRS;POS;IND
@@ -19811,7 +19811,7 @@ palataliseerima	palataliseeritagu	V;PASS;PRS;POS;IMP
 palataliseerima	ärgu palataliseerigu	V;ACT;PRS;NEG;IMP;3;SG
 palataliseerima	oli palataliseeritud	V;PASS;PST;PRF;POS;IND
 palataliseerima	palataliseerisime	V;ACT;PST;POS;IND;1;PL
-palataliseerima	ei olnud palataliseerinudp	V;ACT;PST;PRF;NEG;IND
+palataliseerima	ei olnud palataliseerinud	V;ACT;PST;PRF;NEG;IND
 palataliseerima	oleksid palataliseerinud	V;ACT;PRS;PRF;POS;COND;2;SG
 palataliseerima	olgu palataliseerinud	V;ACT;PRS;PRF;POS;IMP;PL
 palataliseerima	oli palataliseerinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -19825,9 +19825,9 @@ palataliseerima	ärgu palataliseerigu	V;ACT;PRS;NEG;IMP;3;PL
 palataliseerima	olgu palataliseerinud	V;ACT;PRS;PRF;POS;IMP;SG
 palataliseerima	palataliseeriti	V;PASS;PST;POS;IND
 palataliseerima	ei palataliseerivat	V;ACT;PRS;NEG;QUOT
-palataliseerima	ei oleks palataliseeritudp	V;PASS;PRS;PRF;NEG;COND
+palataliseerima	ei oleks palataliseeritud	V;PASS;PRS;PRF;NEG;COND
 palataliseerima	ei palataliseerinud	V;ACT;PST;NEG;IND
-palataliseerima	ei olevat palataliseeritudp	V;PASS;PRS;PRF;NEG;QUOT
+palataliseerima	ei olevat palataliseeritud	V;PASS;PRS;PRF;NEG;QUOT
 palataliseerima	ei palataliseeriks	V;ACT;PRS;PRF;POS;COND;1;SG
 palataliseerima	palataliseeritud	V.PTCP;PASS;PST
 palataliseerima	olid palataliseerinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -19846,7 +19846,7 @@ palataliseerima	olgu palataliseeritud	V;PASS;PRS;PRF;POS;IMP
 palataliseerima	palataliseeriks	V;ACT;PRS;POS;COND;3;SG
 palataliseerima	palataliseerigu	V;ACT;PRS;POS;IMP;3;PL
 palataliseerima	ärgu olgu palataliseerinud	V;ACT;PRS;PRF;NEG;IMP;SG
-palataliseerima	ei ole palataliseerinudp	V;ACT;PST;NEG;IND
+palataliseerima	ei ole palataliseerinud	V;ACT;PST;NEG;IND
 palataliseerima	palataliseerid	V;ACT;PRS;POS;IND;2;SG
 palataliseerima	ära palataliseeri	V;ACT;PRS;NEG;IMP;2;SG
 palataliseerima	ei palataliseeri	V;ACT;PRS;NEG;IND
@@ -19874,17 +19874,17 @@ palataliseerima	ei palataliseerita	V;PASS;PRS;NEG;IND
 palataliseerima	palataliseerime	V;ACT;PRS;POS;IND;1;PL
 palataliseerima	palataliseerin	V;ACT;PRS;POS;IND;1;SG
 palataliseerima	ärgem palataliseerigem	V;ACT;PRS;NEG;IMP;1;PL
-palataliseerima	ei oleks palataliseerinudp	V;ACT;PRS;PRF;NEG;COND
+palataliseerima	ei oleks palataliseerinud	V;ACT;PRS;PRF;NEG;COND
 palataliseerima	oleksid palataliseerinud	V;ACT;PRS;PRF;POS;COND;3;PL
 palataliseerima	palataliseerisite	V;ACT;PST;POS;IND;2;PL
 palataliseerima	oleks palataliseerinud	V;ACT;PRS;PRF;POS;COND;3;SG
 palataliseerima	olin palataliseerinud	V;ACT;PRS;PRF;POS;COND;1;SG
 palataliseerima	oled palataliseerinud	V;ACT;PRS;PRF;POS;IND;2;SG
 palataliseerima	oli palataliseerinud	V;ACT;PRS;PRF;POS;COND;3;SG
-palataliseerima	ei ole palataliseeritudp	V;PASS;PRS;PRF;NEG;IND
+palataliseerima	ei ole palataliseeritud	V;PASS;PRS;PRF;NEG;IND
 palataliseerima	palataliseeriksin	V;ACT;PRS;POS;COND;1;SG
 palataliseerima	olen palataliseerinud	V;ACT;PRS;PRF;POS;IND;1;SG
-palataliseerima	ei olnud palataliseeritudp	V;PASS;PST;PRF;NEG;IND
+palataliseerima	ei olnud palataliseeritud	V;PASS;PST;PRF;NEG;IND
 palataliseerima	ärgu olgu palataliseeritud	V;PASS;PRS;PRF;NEG;IMP
 
 pallaadium	pallaadiumini	N;TERM;SG
@@ -19919,7 +19919,7 @@ pallaadium	pallaadiumdesse	N;IN+ALL;PL
 pallaadium	pallaadiumdelt	N;AT+ABL;PL
 
 paluma	olete palunud	V;ACT;PRS;PRF;POS;IND;2;PL
-paluma	ei olevat palunudp	V;ACT;PRS;PRF;NEG;QUOT
+paluma	ei olevat palunud	V;ACT;PRS;PRF;NEG;QUOT
 paluma	oleks palutud	V;PASS;PRS;PRF;POS;COND
 paluma	palusin	V;ACT;PST;POS;IND;1;SG
 paluma	palutakse	V;PASS;PRS;POS;IND
@@ -19928,7 +19928,7 @@ paluma	palutagu	V;PASS;PRS;POS;IMP
 paluma	ärgu palugu	V;ACT;PRS;NEG;IMP;3;SG
 paluma	oli palutud	V;PASS;PST;PRF;POS;IND
 paluma	palusime	V;ACT;PST;POS;IND;1;PL
-paluma	ei olnud palunudp	V;ACT;PST;PRF;NEG;IND
+paluma	ei olnud palunud	V;ACT;PST;PRF;NEG;IND
 paluma	oleksid palunud	V;ACT;PRS;PRF;POS;COND;2;SG
 paluma	olgu palunud	V;ACT;PRS;PRF;POS;IMP;PL
 paluma	oli palunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -19942,9 +19942,9 @@ paluma	ärgu palugu	V;ACT;PRS;NEG;IMP;3;PL
 paluma	olgu palunud	V;ACT;PRS;PRF;POS;IMP;SG
 paluma	paluti	V;PASS;PST;POS;IND
 paluma	ei paluvat	V;ACT;PRS;NEG;QUOT
-paluma	ei oleks palutudp	V;PASS;PRS;PRF;NEG;COND
+paluma	ei oleks palutud	V;PASS;PRS;PRF;NEG;COND
 paluma	ei palunud	V;ACT;PST;NEG;IND
-paluma	ei olevat palutudp	V;PASS;PRS;PRF;NEG;QUOT
+paluma	ei olevat palutud	V;PASS;PRS;PRF;NEG;QUOT
 paluma	ei paluks	V;ACT;PRS;PRF;POS;COND;1;SG
 paluma	palutud	V.PTCP;PASS;PST
 paluma	olid palunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -19963,7 +19963,7 @@ paluma	olgu palutud	V;PASS;PRS;PRF;POS;IMP
 paluma	paluks	V;ACT;PRS;POS;COND;3;SG
 paluma	palugu	V;ACT;PRS;POS;IMP;3;PL
 paluma	ärgu olgu palunud	V;ACT;PRS;PRF;NEG;IMP;SG
-paluma	ei ole palunudp	V;ACT;PST;NEG;IND
+paluma	ei ole palunud	V;ACT;PST;NEG;IND
 paluma	palud	V;ACT;PRS;POS;IND;2;SG
 paluma	ära palu	V;ACT;PRS;NEG;IMP;2;SG
 paluma	ei palu	V;ACT;PRS;NEG;IND
@@ -19991,21 +19991,21 @@ paluma	ei paluta	V;PASS;PRS;NEG;IND
 paluma	palume	V;ACT;PRS;POS;IND;1;PL
 paluma	palun	V;ACT;PRS;POS;IND;1;SG
 paluma	ärgem palugem	V;ACT;PRS;NEG;IMP;1;PL
-paluma	ei oleks palunudp	V;ACT;PRS;PRF;NEG;COND
+paluma	ei oleks palunud	V;ACT;PRS;PRF;NEG;COND
 paluma	oleksid palunud	V;ACT;PRS;PRF;POS;COND;3;PL
 paluma	palusite	V;ACT;PST;POS;IND;2;PL
 paluma	oleks palunud	V;ACT;PRS;PRF;POS;COND;3;SG
 paluma	olin palunud	V;ACT;PRS;PRF;POS;COND;1;SG
 paluma	oled palunud	V;ACT;PRS;PRF;POS;IND;2;SG
 paluma	oli palunud	V;ACT;PRS;PRF;POS;COND;3;SG
-paluma	ei ole palutudp	V;PASS;PRS;PRF;NEG;IND
+paluma	ei ole palutud	V;PASS;PRS;PRF;NEG;IND
 paluma	paluksin	V;ACT;PRS;POS;COND;1;SG
 paluma	olen palunud	V;ACT;PRS;PRF;POS;IND;1;SG
-paluma	ei olnud palutudp	V;PASS;PST;PRF;NEG;IND
+paluma	ei olnud palutud	V;PASS;PST;PRF;NEG;IND
 paluma	ärgu olgu palutud	V;PASS;PRS;PRF;NEG;IMP
 
 panema	olete pannud	V;ACT;PRS;PRF;POS;IND;2;PL
-panema	ei olevat pannudp	V;ACT;PRS;PRF;NEG;QUOT
+panema	ei olevat pannud	V;ACT;PRS;PRF;NEG;QUOT
 panema	oleks pandud	V;PASS;PRS;PRF;POS;COND
 panema	panin	V;ACT;PST;POS;IND;1;SG
 panema	pannakse	V;PASS;PRS;POS;IND
@@ -20014,7 +20014,7 @@ panema	pandagu	V;PASS;PRS;POS;IMP
 panema	ärgu pangu	V;ACT;PRS;NEG;IMP;3;SG
 panema	oli pandud	V;PASS;PST;PRF;POS;IND
 panema	panime	V;ACT;PST;POS;IND;1;PL
-panema	ei olnud pannudp	V;ACT;PST;PRF;NEG;IND
+panema	ei olnud pannud	V;ACT;PST;PRF;NEG;IND
 panema	oleksid pannud	V;ACT;PRS;PRF;POS;COND;2;SG
 panema	olgu pannud	V;ACT;PRS;PRF;POS;IMP;PL
 panema	oli pannud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -20028,9 +20028,9 @@ panema	ärgu pangu	V;ACT;PRS;NEG;IMP;3;PL
 panema	olgu pannud	V;ACT;PRS;PRF;POS;IMP;SG
 panema	pandi	V;PASS;PST;POS;IND
 panema	ei panevat	V;ACT;PRS;NEG;QUOT
-panema	ei oleks pandudp	V;PASS;PRS;PRF;NEG;COND
+panema	ei oleks pandud	V;PASS;PRS;PRF;NEG;COND
 panema	ei pannud	V;ACT;PST;NEG;IND
-panema	ei olevat pandudp	V;PASS;PRS;PRF;NEG;QUOT
+panema	ei olevat pandud	V;PASS;PRS;PRF;NEG;QUOT
 panema	ei paneks	V;ACT;PRS;PRF;POS;COND;1;SG
 panema	pandud	V.PTCP;PASS;PST
 panema	olid pannud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -20049,7 +20049,7 @@ panema	olgu pandud	V;PASS;PRS;PRF;POS;IMP
 panema	paneks	V;ACT;PRS;POS;COND;3;SG
 panema	pangu	V;ACT;PRS;POS;IMP;3;PL
 panema	ärgu olgu pannud	V;ACT;PRS;PRF;NEG;IMP;SG
-panema	ei ole pannudp	V;ACT;PST;NEG;IND
+panema	ei ole pannud	V;ACT;PST;NEG;IND
 panema	paned	V;ACT;PRS;POS;IND;2;SG
 panema	ära pane	V;ACT;PRS;NEG;IMP;2;SG
 panema	ei pane	V;ACT;PRS;NEG;IND
@@ -20077,17 +20077,17 @@ panema	ei panda	V;PASS;PRS;NEG;IND
 panema	paneme	V;ACT;PRS;POS;IND;1;PL
 panema	panen	V;ACT;PRS;POS;IND;1;SG
 panema	ärgem pangem	V;ACT;PRS;NEG;IMP;1;PL
-panema	ei oleks pannudp	V;ACT;PRS;PRF;NEG;COND
+panema	ei oleks pannud	V;ACT;PRS;PRF;NEG;COND
 panema	oleksid pannud	V;ACT;PRS;PRF;POS;COND;3;PL
 panema	panite	V;ACT;PST;POS;IND;2;PL
 panema	oleks pannud	V;ACT;PRS;PRF;POS;COND;3;SG
 panema	olin pannud	V;ACT;PRS;PRF;POS;COND;1;SG
 panema	oled pannud	V;ACT;PRS;PRF;POS;IND;2;SG
 panema	oli pannud	V;ACT;PRS;PRF;POS;COND;3;SG
-panema	ei ole pandudp	V;PASS;PRS;PRF;NEG;IND
+panema	ei ole pandud	V;PASS;PRS;PRF;NEG;IND
 panema	paneksin	V;ACT;PRS;POS;COND;1;SG
 panema	olen pannud	V;ACT;PRS;PRF;POS;IND;1;SG
-panema	ei olnud pandudp	V;PASS;PST;PRF;NEG;IND
+panema	ei olnud pandud	V;PASS;PST;PRF;NEG;IND
 panema	ärgu olgu pandud	V;PASS;PRS;PRF;NEG;IMP
 
 pankur	pankurini	N;TERM;SG
@@ -20339,7 +20339,7 @@ peaminister	peaministritesse	N;IN+ALL;PL
 peaminister	peaministritelt	N;AT+ABL;PL
 
 peatama	olete peatanud	V;ACT;PRS;PRF;POS;IND;2;PL
-peatama	ei olevat peatanudp	V;ACT;PRS;PRF;NEG;QUOT
+peatama	ei olevat peatanud	V;ACT;PRS;PRF;NEG;QUOT
 peatama	oleks peatatud	V;PASS;PRS;PRF;POS;COND
 peatama	peatasin	V;ACT;PST;POS;IND;1;SG
 peatama	peatatakse	V;PASS;PRS;POS;IND
@@ -20348,7 +20348,7 @@ peatama	peatatagu	V;PASS;PRS;POS;IMP
 peatama	ärgu peatagu	V;ACT;PRS;NEG;IMP;3;SG
 peatama	oli peatatud	V;PASS;PST;PRF;POS;IND
 peatama	peatasime	V;ACT;PST;POS;IND;1;PL
-peatama	ei olnud peatanudp	V;ACT;PST;PRF;NEG;IND
+peatama	ei olnud peatanud	V;ACT;PST;PRF;NEG;IND
 peatama	oleksid peatanud	V;ACT;PRS;PRF;POS;COND;2;SG
 peatama	olgu peatanud	V;ACT;PRS;PRF;POS;IMP;PL
 peatama	oli peatanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -20362,9 +20362,9 @@ peatama	ärgu peatagu	V;ACT;PRS;NEG;IMP;3;PL
 peatama	olgu peatanud	V;ACT;PRS;PRF;POS;IMP;SG
 peatama	peatati	V;PASS;PST;POS;IND
 peatama	ei peatavat	V;ACT;PRS;NEG;QUOT
-peatama	ei oleks peatatudp	V;PASS;PRS;PRF;NEG;COND
+peatama	ei oleks peatatud	V;PASS;PRS;PRF;NEG;COND
 peatama	ei peatanud	V;ACT;PST;NEG;IND
-peatama	ei olevat peatatudp	V;PASS;PRS;PRF;NEG;QUOT
+peatama	ei olevat peatatud	V;PASS;PRS;PRF;NEG;QUOT
 peatama	ei peataks	V;ACT;PRS;PRF;POS;COND;1;SG
 peatama	peatatud	V.PTCP;PASS;PST
 peatama	olid peatanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -20383,7 +20383,7 @@ peatama	olgu peatatud	V;PASS;PRS;PRF;POS;IMP
 peatama	peataks	V;ACT;PRS;POS;COND;3;SG
 peatama	peatagu	V;ACT;PRS;POS;IMP;3;PL
 peatama	ärgu olgu peatanud	V;ACT;PRS;PRF;NEG;IMP;SG
-peatama	ei ole peatanudp	V;ACT;PST;NEG;IND
+peatama	ei ole peatanud	V;ACT;PST;NEG;IND
 peatama	peatad	V;ACT;PRS;POS;IND;2;SG
 peatama	ära peata	V;ACT;PRS;NEG;IMP;2;SG
 peatama	ei peata	V;ACT;PRS;NEG;IND
@@ -20411,17 +20411,17 @@ peatama	ei peatata	V;PASS;PRS;NEG;IND
 peatama	peatame	V;ACT;PRS;POS;IND;1;PL
 peatama	peatan	V;ACT;PRS;POS;IND;1;SG
 peatama	ärgem peatagem	V;ACT;PRS;NEG;IMP;1;PL
-peatama	ei oleks peatanudp	V;ACT;PRS;PRF;NEG;COND
+peatama	ei oleks peatanud	V;ACT;PRS;PRF;NEG;COND
 peatama	oleksid peatanud	V;ACT;PRS;PRF;POS;COND;3;PL
 peatama	peatasite	V;ACT;PST;POS;IND;2;PL
 peatama	oleks peatanud	V;ACT;PRS;PRF;POS;COND;3;SG
 peatama	olin peatanud	V;ACT;PRS;PRF;POS;COND;1;SG
 peatama	oled peatanud	V;ACT;PRS;PRF;POS;IND;2;SG
 peatama	oli peatanud	V;ACT;PRS;PRF;POS;COND;3;SG
-peatama	ei ole peatatudp	V;PASS;PRS;PRF;NEG;IND
+peatama	ei ole peatatud	V;PASS;PRS;PRF;NEG;IND
 peatama	peataksin	V;ACT;PRS;POS;COND;1;SG
 peatama	olen peatanud	V;ACT;PRS;PRF;POS;IND;1;SG
-peatama	ei olnud peatatudp	V;PASS;PST;PRF;NEG;IND
+peatama	ei olnud peatatud	V;PASS;PST;PRF;NEG;IND
 peatama	ärgu olgu peatatud	V;PASS;PRS;PRF;NEG;IMP
 
 peatus	peatuseni	N;TERM;SG
@@ -20549,7 +20549,7 @@ peenar	peenardesse	N;IN+ALL;PL
 peenar	peenardelt	N;AT+ABL;PL
 
 peenendama	olete peenendanud	V;ACT;PRS;PRF;POS;IND;2;PL
-peenendama	ei olevat peenendanudp	V;ACT;PRS;PRF;NEG;QUOT
+peenendama	ei olevat peenendanud	V;ACT;PRS;PRF;NEG;QUOT
 peenendama	oleks peenendatud	V;PASS;PRS;PRF;POS;COND
 peenendama	peenendasin	V;ACT;PST;POS;IND;1;SG
 peenendama	peenendatakse	V;PASS;PRS;POS;IND
@@ -20558,7 +20558,7 @@ peenendama	peenendatagu	V;PASS;PRS;POS;IMP
 peenendama	ärgu peenendagu	V;ACT;PRS;NEG;IMP;3;SG
 peenendama	oli peenendatud	V;PASS;PST;PRF;POS;IND
 peenendama	peenendasime	V;ACT;PST;POS;IND;1;PL
-peenendama	ei olnud peenendanudp	V;ACT;PST;PRF;NEG;IND
+peenendama	ei olnud peenendanud	V;ACT;PST;PRF;NEG;IND
 peenendama	oleksid peenendanud	V;ACT;PRS;PRF;POS;COND;2;SG
 peenendama	olgu peenendanud	V;ACT;PRS;PRF;POS;IMP;PL
 peenendama	oli peenendanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -20572,9 +20572,9 @@ peenendama	ärgu peenendagu	V;ACT;PRS;NEG;IMP;3;PL
 peenendama	olgu peenendanud	V;ACT;PRS;PRF;POS;IMP;SG
 peenendama	peenendati	V;PASS;PST;POS;IND
 peenendama	ei peenendavat	V;ACT;PRS;NEG;QUOT
-peenendama	ei oleks peenendatudp	V;PASS;PRS;PRF;NEG;COND
+peenendama	ei oleks peenendatud	V;PASS;PRS;PRF;NEG;COND
 peenendama	ei peenendanud	V;ACT;PST;NEG;IND
-peenendama	ei olevat peenendatudp	V;PASS;PRS;PRF;NEG;QUOT
+peenendama	ei olevat peenendatud	V;PASS;PRS;PRF;NEG;QUOT
 peenendama	ei peenendaks	V;ACT;PRS;PRF;POS;COND;1;SG
 peenendama	peenendatud	V.PTCP;PASS;PST
 peenendama	olid peenendanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -20593,7 +20593,7 @@ peenendama	olgu peenendatud	V;PASS;PRS;PRF;POS;IMP
 peenendama	peenendaks	V;ACT;PRS;POS;COND;3;SG
 peenendama	peenendagu	V;ACT;PRS;POS;IMP;3;PL
 peenendama	ärgu olgu peenendanud	V;ACT;PRS;PRF;NEG;IMP;SG
-peenendama	ei ole peenendanudp	V;ACT;PST;NEG;IND
+peenendama	ei ole peenendanud	V;ACT;PST;NEG;IND
 peenendama	peenendad	V;ACT;PRS;POS;IND;2;SG
 peenendama	ära peenenda	V;ACT;PRS;NEG;IMP;2;SG
 peenendama	ei peenenda	V;ACT;PRS;NEG;IND
@@ -20621,17 +20621,17 @@ peenendama	ei peenendata	V;PASS;PRS;NEG;IND
 peenendama	peenendame	V;ACT;PRS;POS;IND;1;PL
 peenendama	peenendan	V;ACT;PRS;POS;IND;1;SG
 peenendama	ärgem peenendagem	V;ACT;PRS;NEG;IMP;1;PL
-peenendama	ei oleks peenendanudp	V;ACT;PRS;PRF;NEG;COND
+peenendama	ei oleks peenendanud	V;ACT;PRS;PRF;NEG;COND
 peenendama	oleksid peenendanud	V;ACT;PRS;PRF;POS;COND;3;PL
 peenendama	peenendasite	V;ACT;PST;POS;IND;2;PL
 peenendama	oleks peenendanud	V;ACT;PRS;PRF;POS;COND;3;SG
 peenendama	olin peenendanud	V;ACT;PRS;PRF;POS;COND;1;SG
 peenendama	oled peenendanud	V;ACT;PRS;PRF;POS;IND;2;SG
 peenendama	oli peenendanud	V;ACT;PRS;PRF;POS;COND;3;SG
-peenendama	ei ole peenendatudp	V;PASS;PRS;PRF;NEG;IND
+peenendama	ei ole peenendatud	V;PASS;PRS;PRF;NEG;IND
 peenendama	peenendaksin	V;ACT;PRS;POS;COND;1;SG
 peenendama	olen peenendanud	V;ACT;PRS;PRF;POS;IND;1;SG
-peenendama	ei olnud peenendatudp	V;PASS;PST;PRF;NEG;IND
+peenendama	ei olnud peenendatud	V;PASS;PST;PRF;NEG;IND
 peenendama	ärgu olgu peenendatud	V;PASS;PRS;PRF;NEG;IMP
 
 peenis	peeniseni	N;TERM;SG
@@ -20821,7 +20821,7 @@ pesa	pesadesse	N;IN+ALL;PL
 pesa	pesadelt	N;AT+ABL;PL
 
 pesema	olete pesnud	V;ACT;PRS;PRF;POS;IND;2;PL
-pesema	ei olevat pesnudp	V;ACT;PRS;PRF;NEG;QUOT
+pesema	ei olevat pesnud	V;ACT;PRS;PRF;NEG;QUOT
 pesema	oleks pestud	V;PASS;PRS;PRF;POS;COND
 pesema	pesin	V;ACT;PST;POS;IND;1;SG
 pesema	pestakse	V;PASS;PRS;POS;IND
@@ -20830,7 +20830,7 @@ pesema	pestagu	V;PASS;PRS;POS;IMP
 pesema	ärgu pesku	V;ACT;PRS;NEG;IMP;3;SG
 pesema	oli pestud	V;PASS;PST;PRF;POS;IND
 pesema	pesime	V;ACT;PST;POS;IND;1;PL
-pesema	ei olnud pesnudp	V;ACT;PST;PRF;NEG;IND
+pesema	ei olnud pesnud	V;ACT;PST;PRF;NEG;IND
 pesema	oleksid pesnud	V;ACT;PRS;PRF;POS;COND;2;SG
 pesema	olgu pesnud	V;ACT;PRS;PRF;POS;IMP;PL
 pesema	oli pesnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -20844,9 +20844,9 @@ pesema	ärgu pesku	V;ACT;PRS;NEG;IMP;3;PL
 pesema	olgu pesnud	V;ACT;PRS;PRF;POS;IMP;SG
 pesema	pesti	V;PASS;PST;POS;IND
 pesema	ei pesevat	V;ACT;PRS;NEG;QUOT
-pesema	ei oleks pestudp	V;PASS;PRS;PRF;NEG;COND
+pesema	ei oleks pestud	V;PASS;PRS;PRF;NEG;COND
 pesema	ei pesnud	V;ACT;PST;NEG;IND
-pesema	ei olevat pestudp	V;PASS;PRS;PRF;NEG;QUOT
+pesema	ei olevat pestud	V;PASS;PRS;PRF;NEG;QUOT
 pesema	ei peseks	V;ACT;PRS;PRF;POS;COND;1;SG
 pesema	pestud	V.PTCP;PASS;PST
 pesema	olid pesnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -20865,7 +20865,7 @@ pesema	olgu pestud	V;PASS;PRS;PRF;POS;IMP
 pesema	peseks	V;ACT;PRS;POS;COND;3;SG
 pesema	pesku	V;ACT;PRS;POS;IMP;3;PL
 pesema	ärgu olgu pesnud	V;ACT;PRS;PRF;NEG;IMP;SG
-pesema	ei ole pesnudp	V;ACT;PST;NEG;IND
+pesema	ei ole pesnud	V;ACT;PST;NEG;IND
 pesema	pesed	V;ACT;PRS;POS;IND;2;SG
 pesema	ära pese	V;ACT;PRS;NEG;IMP;2;SG
 pesema	ei pese	V;ACT;PRS;NEG;IND
@@ -20893,21 +20893,21 @@ pesema	ei pesta	V;PASS;PRS;NEG;IND
 pesema	peseme	V;ACT;PRS;POS;IND;1;PL
 pesema	pesen	V;ACT;PRS;POS;IND;1;SG
 pesema	ärgem peskem	V;ACT;PRS;NEG;IMP;1;PL
-pesema	ei oleks pesnudp	V;ACT;PRS;PRF;NEG;COND
+pesema	ei oleks pesnud	V;ACT;PRS;PRF;NEG;COND
 pesema	oleksid pesnud	V;ACT;PRS;PRF;POS;COND;3;PL
 pesema	pesite	V;ACT;PST;POS;IND;2;PL
 pesema	oleks pesnud	V;ACT;PRS;PRF;POS;COND;3;SG
 pesema	olin pesnud	V;ACT;PRS;PRF;POS;COND;1;SG
 pesema	oled pesnud	V;ACT;PRS;PRF;POS;IND;2;SG
 pesema	oli pesnud	V;ACT;PRS;PRF;POS;COND;3;SG
-pesema	ei ole pestudp	V;PASS;PRS;PRF;NEG;IND
+pesema	ei ole pestud	V;PASS;PRS;PRF;NEG;IND
 pesema	peseksin	V;ACT;PRS;POS;COND;1;SG
 pesema	olen pesnud	V;ACT;PRS;PRF;POS;IND;1;SG
-pesema	ei olnud pestudp	V;PASS;PST;PRF;NEG;IND
+pesema	ei olnud pestud	V;PASS;PST;PRF;NEG;IND
 pesema	ärgu olgu pestud	V;PASS;PRS;PRF;NEG;IMP
 
 petma	olete petnud	V;ACT;PRS;PRF;POS;IND;2;PL
-petma	ei olevat petnudp	V;ACT;PRS;PRF;NEG;QUOT
+petma	ei olevat petnud	V;ACT;PRS;PRF;NEG;QUOT
 petma	oleks petetud	V;PASS;PRS;PRF;POS;COND
 petma	petsin	V;ACT;PST;POS;IND;1;SG
 petma	petetakse	V;PASS;PRS;POS;IND
@@ -20916,7 +20916,7 @@ petma	petetagu	V;PASS;PRS;POS;IMP
 petma	ärgu petku	V;ACT;PRS;NEG;IMP;3;SG
 petma	oli petetud	V;PASS;PST;PRF;POS;IND
 petma	petsime	V;ACT;PST;POS;IND;1;PL
-petma	ei olnud petnudp	V;ACT;PST;PRF;NEG;IND
+petma	ei olnud petnud	V;ACT;PST;PRF;NEG;IND
 petma	oleksid petnud	V;ACT;PRS;PRF;POS;COND;2;SG
 petma	olgu petnud	V;ACT;PRS;PRF;POS;IMP;PL
 petma	oli petnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -20930,9 +20930,9 @@ petma	ärgu petku	V;ACT;PRS;NEG;IMP;3;PL
 petma	olgu petnud	V;ACT;PRS;PRF;POS;IMP;SG
 petma	peteti	V;PASS;PST;POS;IND
 petma	ei petvat	V;ACT;PRS;NEG;QUOT
-petma	ei oleks petetudp	V;PASS;PRS;PRF;NEG;COND
+petma	ei oleks petetud	V;PASS;PRS;PRF;NEG;COND
 petma	ei petnud	V;ACT;PST;NEG;IND
-petma	ei olevat petetudp	V;PASS;PRS;PRF;NEG;QUOT
+petma	ei olevat petetud	V;PASS;PRS;PRF;NEG;QUOT
 petma	ei petaks	V;ACT;PRS;PRF;POS;COND;1;SG
 petma	petetud	V.PTCP;PASS;PST
 petma	olid petnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -20951,7 +20951,7 @@ petma	olgu petetud	V;PASS;PRS;PRF;POS;IMP
 petma	petaks	V;ACT;PRS;POS;COND;3;SG
 petma	petku	V;ACT;PRS;POS;IMP;3;PL
 petma	ärgu olgu petnud	V;ACT;PRS;PRF;NEG;IMP;SG
-petma	ei ole petnudp	V;ACT;PST;NEG;IND
+petma	ei ole petnud	V;ACT;PST;NEG;IND
 petma	petad	V;ACT;PRS;POS;IND;2;SG
 petma	ära peta	V;ACT;PRS;NEG;IMP;2;SG
 petma	ei peta	V;ACT;PRS;NEG;IND
@@ -20979,17 +20979,17 @@ petma	ei peteta	V;PASS;PRS;NEG;IND
 petma	petame	V;ACT;PRS;POS;IND;1;PL
 petma	petan	V;ACT;PRS;POS;IND;1;SG
 petma	ärgem petkem	V;ACT;PRS;NEG;IMP;1;PL
-petma	ei oleks petnudp	V;ACT;PRS;PRF;NEG;COND
+petma	ei oleks petnud	V;ACT;PRS;PRF;NEG;COND
 petma	oleksid petnud	V;ACT;PRS;PRF;POS;COND;3;PL
 petma	petsite	V;ACT;PST;POS;IND;2;PL
 petma	oleks petnud	V;ACT;PRS;PRF;POS;COND;3;SG
 petma	olin petnud	V;ACT;PRS;PRF;POS;COND;1;SG
 petma	oled petnud	V;ACT;PRS;PRF;POS;IND;2;SG
 petma	oli petnud	V;ACT;PRS;PRF;POS;COND;3;SG
-petma	ei ole petetudp	V;PASS;PRS;PRF;NEG;IND
+petma	ei ole petetud	V;PASS;PRS;PRF;NEG;IND
 petma	petaksin	V;ACT;PRS;POS;COND;1;SG
 petma	olen petnud	V;ACT;PRS;PRF;POS;IND;1;SG
-petma	ei olnud petetudp	V;PASS;PST;PRF;NEG;IND
+petma	ei olnud petetud	V;PASS;PST;PRF;NEG;IND
 petma	ärgu olgu petetud	V;PASS;PRS;PRF;NEG;IMP
 
 pikkus	pikkuseni	N;TERM;SG
@@ -21799,7 +21799,7 @@ pudel	pudelitesse	N;IN+ALL;PL
 pudel	pudelitelt	N;AT+ABL;PL
 
 puhuma	olete puhunud	V;ACT;PRS;PRF;POS;IND;2;PL
-puhuma	ei olevat puhunudp	V;ACT;PRS;PRF;NEG;QUOT
+puhuma	ei olevat puhunud	V;ACT;PRS;PRF;NEG;QUOT
 puhuma	oleks puhutud	V;PASS;PRS;PRF;POS;COND
 puhuma	puhusin	V;ACT;PST;POS;IND;1;SG
 puhuma	puhutakse	V;PASS;PRS;POS;IND
@@ -21808,7 +21808,7 @@ puhuma	puhutagu	V;PASS;PRS;POS;IMP
 puhuma	ärgu puhugu	V;ACT;PRS;NEG;IMP;3;SG
 puhuma	oli puhutud	V;PASS;PST;PRF;POS;IND
 puhuma	puhusime	V;ACT;PST;POS;IND;1;PL
-puhuma	ei olnud puhunudp	V;ACT;PST;PRF;NEG;IND
+puhuma	ei olnud puhunud	V;ACT;PST;PRF;NEG;IND
 puhuma	oleksid puhunud	V;ACT;PRS;PRF;POS;COND;2;SG
 puhuma	olgu puhunud	V;ACT;PRS;PRF;POS;IMP;PL
 puhuma	oli puhunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -21822,9 +21822,9 @@ puhuma	ärgu puhugu	V;ACT;PRS;NEG;IMP;3;PL
 puhuma	olgu puhunud	V;ACT;PRS;PRF;POS;IMP;SG
 puhuma	puhuti	V;PASS;PST;POS;IND
 puhuma	ei puhuvat	V;ACT;PRS;NEG;QUOT
-puhuma	ei oleks puhutudp	V;PASS;PRS;PRF;NEG;COND
+puhuma	ei oleks puhutud	V;PASS;PRS;PRF;NEG;COND
 puhuma	ei puhunud	V;ACT;PST;NEG;IND
-puhuma	ei olevat puhutudp	V;PASS;PRS;PRF;NEG;QUOT
+puhuma	ei olevat puhutud	V;PASS;PRS;PRF;NEG;QUOT
 puhuma	ei puhuks	V;ACT;PRS;PRF;POS;COND;1;SG
 puhuma	puhutud	V.PTCP;PASS;PST
 puhuma	olid puhunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -21843,7 +21843,7 @@ puhuma	olgu puhutud	V;PASS;PRS;PRF;POS;IMP
 puhuma	puhuks	V;ACT;PRS;POS;COND;3;SG
 puhuma	puhugu	V;ACT;PRS;POS;IMP;3;PL
 puhuma	ärgu olgu puhunud	V;ACT;PRS;PRF;NEG;IMP;SG
-puhuma	ei ole puhunudp	V;ACT;PST;NEG;IND
+puhuma	ei ole puhunud	V;ACT;PST;NEG;IND
 puhuma	puhud	V;ACT;PRS;POS;IND;2;SG
 puhuma	ära puhu	V;ACT;PRS;NEG;IMP;2;SG
 puhuma	ei puhu	V;ACT;PRS;NEG;IND
@@ -21871,17 +21871,17 @@ puhuma	ei puhuta	V;PASS;PRS;NEG;IND
 puhuma	puhume	V;ACT;PRS;POS;IND;1;PL
 puhuma	puhun	V;ACT;PRS;POS;IND;1;SG
 puhuma	ärgem puhugem	V;ACT;PRS;NEG;IMP;1;PL
-puhuma	ei oleks puhunudp	V;ACT;PRS;PRF;NEG;COND
+puhuma	ei oleks puhunud	V;ACT;PRS;PRF;NEG;COND
 puhuma	oleksid puhunud	V;ACT;PRS;PRF;POS;COND;3;PL
 puhuma	puhusite	V;ACT;PST;POS;IND;2;PL
 puhuma	oleks puhunud	V;ACT;PRS;PRF;POS;COND;3;SG
 puhuma	olin puhunud	V;ACT;PRS;PRF;POS;COND;1;SG
 puhuma	oled puhunud	V;ACT;PRS;PRF;POS;IND;2;SG
 puhuma	oli puhunud	V;ACT;PRS;PRF;POS;COND;3;SG
-puhuma	ei ole puhutudp	V;PASS;PRS;PRF;NEG;IND
+puhuma	ei ole puhutud	V;PASS;PRS;PRF;NEG;IND
 puhuma	puhuksin	V;ACT;PRS;POS;COND;1;SG
 puhuma	olen puhunud	V;ACT;PRS;PRF;POS;IND;1;SG
-puhuma	ei olnud puhutudp	V;PASS;PST;PRF;NEG;IND
+puhuma	ei olnud puhutud	V;PASS;PST;PRF;NEG;IND
 puhuma	ärgu olgu puhutud	V;PASS;PRS;PRF;NEG;IMP
 
 punker	punkrini	N;TERM;SG
@@ -21916,7 +21916,7 @@ punker	punkritesse	N;IN+ALL;PL
 punker	punkritelt	N;AT+ABL;PL
 
 purema	olete purenud	V;ACT;PRS;PRF;POS;IND;2;PL
-purema	ei olevat purenudp	V;ACT;PRS;PRF;NEG;QUOT
+purema	ei olevat purenud	V;ACT;PRS;PRF;NEG;QUOT
 purema	oleks puretud	V;PASS;PRS;PRF;POS;COND
 purema	puresin	V;ACT;PST;POS;IND;1;SG
 purema	puretakse	V;PASS;PRS;POS;IND
@@ -21925,7 +21925,7 @@ purema	puretagu	V;PASS;PRS;POS;IMP
 purema	ärgu puregu	V;ACT;PRS;NEG;IMP;3;SG
 purema	oli puretud	V;PASS;PST;PRF;POS;IND
 purema	puresime	V;ACT;PST;POS;IND;1;PL
-purema	ei olnud purenudp	V;ACT;PST;PRF;NEG;IND
+purema	ei olnud purenud	V;ACT;PST;PRF;NEG;IND
 purema	oleksid purenud	V;ACT;PRS;PRF;POS;COND;2;SG
 purema	olgu purenud	V;ACT;PRS;PRF;POS;IMP;PL
 purema	oli purenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -21939,9 +21939,9 @@ purema	ärgu puregu	V;ACT;PRS;NEG;IMP;3;PL
 purema	olgu purenud	V;ACT;PRS;PRF;POS;IMP;SG
 purema	pureti	V;PASS;PST;POS;IND
 purema	ei purevat	V;ACT;PRS;NEG;QUOT
-purema	ei oleks puretudp	V;PASS;PRS;PRF;NEG;COND
+purema	ei oleks puretud	V;PASS;PRS;PRF;NEG;COND
 purema	ei purenud	V;ACT;PST;NEG;IND
-purema	ei olevat puretudp	V;PASS;PRS;PRF;NEG;QUOT
+purema	ei olevat puretud	V;PASS;PRS;PRF;NEG;QUOT
 purema	ei pureks	V;ACT;PRS;PRF;POS;COND;1;SG
 purema	puretud	V.PTCP;PASS;PST
 purema	olid purenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -21960,7 +21960,7 @@ purema	olgu puretud	V;PASS;PRS;PRF;POS;IMP
 purema	pureks	V;ACT;PRS;POS;COND;3;SG
 purema	puregu	V;ACT;PRS;POS;IMP;3;PL
 purema	ärgu olgu purenud	V;ACT;PRS;PRF;NEG;IMP;SG
-purema	ei ole purenudp	V;ACT;PST;NEG;IND
+purema	ei ole purenud	V;ACT;PST;NEG;IND
 purema	pured	V;ACT;PRS;POS;IND;2;SG
 purema	ära pure	V;ACT;PRS;NEG;IMP;2;SG
 purema	ei pure	V;ACT;PRS;NEG;IND
@@ -21988,17 +21988,17 @@ purema	ei pureta	V;PASS;PRS;NEG;IND
 purema	pureme	V;ACT;PRS;POS;IND;1;PL
 purema	puren	V;ACT;PRS;POS;IND;1;SG
 purema	ärgem puregem	V;ACT;PRS;NEG;IMP;1;PL
-purema	ei oleks purenudp	V;ACT;PRS;PRF;NEG;COND
+purema	ei oleks purenud	V;ACT;PRS;PRF;NEG;COND
 purema	oleksid purenud	V;ACT;PRS;PRF;POS;COND;3;PL
 purema	puresite	V;ACT;PST;POS;IND;2;PL
 purema	oleks purenud	V;ACT;PRS;PRF;POS;COND;3;SG
 purema	olin purenud	V;ACT;PRS;PRF;POS;COND;1;SG
 purema	oled purenud	V;ACT;PRS;PRF;POS;IND;2;SG
 purema	oli purenud	V;ACT;PRS;PRF;POS;COND;3;SG
-purema	ei ole puretudp	V;PASS;PRS;PRF;NEG;IND
+purema	ei ole puretud	V;PASS;PRS;PRF;NEG;IND
 purema	pureksin	V;ACT;PRS;POS;COND;1;SG
 purema	olen purenud	V;ACT;PRS;PRF;POS;IND;1;SG
-purema	ei olnud puretudp	V;PASS;PST;PRF;NEG;IND
+purema	ei olnud puretud	V;PASS;PST;PRF;NEG;IND
 purema	ärgu olgu puretud	V;PASS;PRS;PRF;NEG;IMP
 
 puu	puuni	N;TERM;SG
@@ -22219,7 +22219,7 @@ põldpüü	põldpüüdesse	N;IN+ALL;PL
 põldpüü	põldpüüdelt	N;AT+ABL;PL
 
 põlema	olete põlenud	V;ACT;PRS;PRF;POS;IND;2;PL
-põlema	ei olevat põlenudp	V;ACT;PRS;PRF;NEG;QUOT
+põlema	ei olevat põlenud	V;ACT;PRS;PRF;NEG;QUOT
 põlema	oleks põletud	V;PASS;PRS;PRF;POS;COND
 põlema	põlesin	V;ACT;PST;POS;IND;1;SG
 põlema	põletakse	V;PASS;PRS;POS;IND
@@ -22228,7 +22228,7 @@ põlema	põletagu	V;PASS;PRS;POS;IMP
 põlema	ärgu põlegu	V;ACT;PRS;NEG;IMP;3;SG
 põlema	oli põletud	V;PASS;PST;PRF;POS;IND
 põlema	põlesime	V;ACT;PST;POS;IND;1;PL
-põlema	ei olnud põlenudp	V;ACT;PST;PRF;NEG;IND
+põlema	ei olnud põlenud	V;ACT;PST;PRF;NEG;IND
 põlema	oleksid põlenud	V;ACT;PRS;PRF;POS;COND;2;SG
 põlema	olgu põlenud	V;ACT;PRS;PRF;POS;IMP;PL
 põlema	oli põlenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -22242,9 +22242,9 @@ põlema	ärgu põlegu	V;ACT;PRS;NEG;IMP;3;PL
 põlema	olgu põlenud	V;ACT;PRS;PRF;POS;IMP;SG
 põlema	põleti	V;PASS;PST;POS;IND
 põlema	ei põlevat	V;ACT;PRS;NEG;QUOT
-põlema	ei oleks põletudp	V;PASS;PRS;PRF;NEG;COND
+põlema	ei oleks põletud	V;PASS;PRS;PRF;NEG;COND
 põlema	ei põlenud	V;ACT;PST;NEG;IND
-põlema	ei olevat põletudp	V;PASS;PRS;PRF;NEG;QUOT
+põlema	ei olevat põletud	V;PASS;PRS;PRF;NEG;QUOT
 põlema	ei põleks	V;ACT;PRS;PRF;POS;COND;1;SG
 põlema	põletud	V.PTCP;PASS;PST
 põlema	olid põlenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -22263,7 +22263,7 @@ põlema	olgu põletud	V;PASS;PRS;PRF;POS;IMP
 põlema	põleks	V;ACT;PRS;POS;COND;3;SG
 põlema	põlegu	V;ACT;PRS;POS;IMP;3;PL
 põlema	ärgu olgu põlenud	V;ACT;PRS;PRF;NEG;IMP;SG
-põlema	ei ole põlenudp	V;ACT;PST;NEG;IND
+põlema	ei ole põlenud	V;ACT;PST;NEG;IND
 põlema	põled	V;ACT;PRS;POS;IND;2;SG
 põlema	ära põle	V;ACT;PRS;NEG;IMP;2;SG
 põlema	ei põle	V;ACT;PRS;NEG;IND
@@ -22291,21 +22291,21 @@ põlema	ei põleta	V;PASS;PRS;NEG;IND
 põlema	põleme	V;ACT;PRS;POS;IND;1;PL
 põlema	põlen	V;ACT;PRS;POS;IND;1;SG
 põlema	ärgem põlegem	V;ACT;PRS;NEG;IMP;1;PL
-põlema	ei oleks põlenudp	V;ACT;PRS;PRF;NEG;COND
+põlema	ei oleks põlenud	V;ACT;PRS;PRF;NEG;COND
 põlema	oleksid põlenud	V;ACT;PRS;PRF;POS;COND;3;PL
 põlema	põlesite	V;ACT;PST;POS;IND;2;PL
 põlema	oleks põlenud	V;ACT;PRS;PRF;POS;COND;3;SG
 põlema	olin põlenud	V;ACT;PRS;PRF;POS;COND;1;SG
 põlema	oled põlenud	V;ACT;PRS;PRF;POS;IND;2;SG
 põlema	oli põlenud	V;ACT;PRS;PRF;POS;COND;3;SG
-põlema	ei ole põletudp	V;PASS;PRS;PRF;NEG;IND
+põlema	ei ole põletud	V;PASS;PRS;PRF;NEG;IND
 põlema	põleksin	V;ACT;PRS;POS;COND;1;SG
 põlema	olen põlenud	V;ACT;PRS;PRF;POS;IND;1;SG
-põlema	ei olnud põletudp	V;PASS;PST;PRF;NEG;IND
+põlema	ei olnud põletud	V;PASS;PST;PRF;NEG;IND
 põlema	ärgu olgu põletud	V;PASS;PRS;PRF;NEG;IMP
 
 põletama	olete põletanud	V;ACT;PRS;PRF;POS;IND;2;PL
-põletama	ei olevat põletanudp	V;ACT;PRS;PRF;NEG;QUOT
+põletama	ei olevat põletanud	V;ACT;PRS;PRF;NEG;QUOT
 põletama	oleks põletatud	V;PASS;PRS;PRF;POS;COND
 põletama	põletasin	V;ACT;PST;POS;IND;1;SG
 põletama	põletatakse	V;PASS;PRS;POS;IND
@@ -22314,7 +22314,7 @@ põletama	põletatagu	V;PASS;PRS;POS;IMP
 põletama	ärgu põletagu	V;ACT;PRS;NEG;IMP;3;SG
 põletama	oli põletatud	V;PASS;PST;PRF;POS;IND
 põletama	põletasime	V;ACT;PST;POS;IND;1;PL
-põletama	ei olnud põletanudp	V;ACT;PST;PRF;NEG;IND
+põletama	ei olnud põletanud	V;ACT;PST;PRF;NEG;IND
 põletama	oleksid põletanud	V;ACT;PRS;PRF;POS;COND;2;SG
 põletama	olgu põletanud	V;ACT;PRS;PRF;POS;IMP;PL
 põletama	oli põletanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -22328,9 +22328,9 @@ põletama	ärgu põletagu	V;ACT;PRS;NEG;IMP;3;PL
 põletama	olgu põletanud	V;ACT;PRS;PRF;POS;IMP;SG
 põletama	põletati	V;PASS;PST;POS;IND
 põletama	ei põletavat	V;ACT;PRS;NEG;QUOT
-põletama	ei oleks põletatudp	V;PASS;PRS;PRF;NEG;COND
+põletama	ei oleks põletatud	V;PASS;PRS;PRF;NEG;COND
 põletama	ei põletanud	V;ACT;PST;NEG;IND
-põletama	ei olevat põletatudp	V;PASS;PRS;PRF;NEG;QUOT
+põletama	ei olevat põletatud	V;PASS;PRS;PRF;NEG;QUOT
 põletama	ei põletaks	V;ACT;PRS;PRF;POS;COND;1;SG
 põletama	põletatud	V.PTCP;PASS;PST
 põletama	olid põletanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -22349,7 +22349,7 @@ põletama	olgu põletatud	V;PASS;PRS;PRF;POS;IMP
 põletama	põletaks	V;ACT;PRS;POS;COND;3;SG
 põletama	põletagu	V;ACT;PRS;POS;IMP;3;PL
 põletama	ärgu olgu põletanud	V;ACT;PRS;PRF;NEG;IMP;SG
-põletama	ei ole põletanudp	V;ACT;PST;NEG;IND
+põletama	ei ole põletanud	V;ACT;PST;NEG;IND
 põletama	põletad	V;ACT;PRS;POS;IND;2;SG
 põletama	ära põleta	V;ACT;PRS;NEG;IMP;2;SG
 põletama	ei põleta	V;ACT;PRS;NEG;IND
@@ -22377,17 +22377,17 @@ põletama	ei põletata	V;PASS;PRS;NEG;IND
 põletama	põletame	V;ACT;PRS;POS;IND;1;PL
 põletama	põletan	V;ACT;PRS;POS;IND;1;SG
 põletama	ärgem põletagem	V;ACT;PRS;NEG;IMP;1;PL
-põletama	ei oleks põletanudp	V;ACT;PRS;PRF;NEG;COND
+põletama	ei oleks põletanud	V;ACT;PRS;PRF;NEG;COND
 põletama	oleksid põletanud	V;ACT;PRS;PRF;POS;COND;3;PL
 põletama	põletasite	V;ACT;PST;POS;IND;2;PL
 põletama	oleks põletanud	V;ACT;PRS;PRF;POS;COND;3;SG
 põletama	olin põletanud	V;ACT;PRS;PRF;POS;COND;1;SG
 põletama	oled põletanud	V;ACT;PRS;PRF;POS;IND;2;SG
 põletama	oli põletanud	V;ACT;PRS;PRF;POS;COND;3;SG
-põletama	ei ole põletatudp	V;PASS;PRS;PRF;NEG;IND
+põletama	ei ole põletatud	V;PASS;PRS;PRF;NEG;IND
 põletama	põletaksin	V;ACT;PRS;POS;COND;1;SG
 põletama	olen põletanud	V;ACT;PRS;PRF;POS;IND;1;SG
-põletama	ei olnud põletatudp	V;PASS;PST;PRF;NEG;IND
+põletama	ei olnud põletatud	V;PASS;PST;PRF;NEG;IND
 põletama	ärgu olgu põletatud	V;PASS;PRS;PRF;NEG;IMP
 
 põrand	põrandani	N;TERM;SG
@@ -22453,7 +22453,7 @@ põrgu	põrgutesse	N;IN+ALL;PL
 põrgu	põrgutelt	N;AT+ABL;PL
 
 pöörama	olete pööranud	V;ACT;PRS;PRF;POS;IND;2;PL
-pöörama	ei olevat pööranudp	V;ACT;PRS;PRF;NEG;QUOT
+pöörama	ei olevat pööranud	V;ACT;PRS;PRF;NEG;QUOT
 pöörama	oleks pööratud	V;PASS;PRS;PRF;POS;COND
 pöörama	pöörasin	V;ACT;PST;POS;IND;1;SG
 pöörama	pööratakse	V;PASS;PRS;POS;IND
@@ -22462,7 +22462,7 @@ pöörama	pööratagu	V;PASS;PRS;POS;IMP
 pöörama	ärgu pööraku	V;ACT;PRS;NEG;IMP;3;SG
 pöörama	oli pööratud	V;PASS;PST;PRF;POS;IND
 pöörama	pöörasime	V;ACT;PST;POS;IND;1;PL
-pöörama	ei olnud pööranudp	V;ACT;PST;PRF;NEG;IND
+pöörama	ei olnud pööranud	V;ACT;PST;PRF;NEG;IND
 pöörama	oleksid pööranud	V;ACT;PRS;PRF;POS;COND;2;SG
 pöörama	olgu pööranud	V;ACT;PRS;PRF;POS;IMP;PL
 pöörama	oli pööranud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -22476,9 +22476,9 @@ pöörama	ärgu pööraku	V;ACT;PRS;NEG;IMP;3;PL
 pöörama	olgu pööranud	V;ACT;PRS;PRF;POS;IMP;SG
 pöörama	pöörati	V;PASS;PST;POS;IND
 pöörama	ei pööravat	V;ACT;PRS;NEG;QUOT
-pöörama	ei oleks pööratudp	V;PASS;PRS;PRF;NEG;COND
+pöörama	ei oleks pööratud	V;PASS;PRS;PRF;NEG;COND
 pöörama	ei pööranud	V;ACT;PST;NEG;IND
-pöörama	ei olevat pööratudp	V;PASS;PRS;PRF;NEG;QUOT
+pöörama	ei olevat pööratud	V;PASS;PRS;PRF;NEG;QUOT
 pöörama	ei pööraks	V;ACT;PRS;PRF;POS;COND;1;SG
 pöörama	pööratud	V.PTCP;PASS;PST
 pöörama	olid pööranud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -22497,7 +22497,7 @@ pöörama	olgu pööratud	V;PASS;PRS;PRF;POS;IMP
 pöörama	pööraks	V;ACT;PRS;POS;COND;3;SG
 pöörama	pööraku	V;ACT;PRS;POS;IMP;3;PL
 pöörama	ärgu olgu pööranud	V;ACT;PRS;PRF;NEG;IMP;SG
-pöörama	ei ole pööranudp	V;ACT;PST;NEG;IND
+pöörama	ei ole pööranud	V;ACT;PST;NEG;IND
 pöörama	pöörad	V;ACT;PRS;POS;IND;2;SG
 pöörama	ära pööra	V;ACT;PRS;NEG;IMP;2;SG
 pöörama	ei pööra	V;ACT;PRS;NEG;IND
@@ -22525,21 +22525,21 @@ pöörama	ei pöörata	V;PASS;PRS;NEG;IND
 pöörama	pöörame	V;ACT;PRS;POS;IND;1;PL
 pöörama	pööran	V;ACT;PRS;POS;IND;1;SG
 pöörama	ärgem pöörakem	V;ACT;PRS;NEG;IMP;1;PL
-pöörama	ei oleks pööranudp	V;ACT;PRS;PRF;NEG;COND
+pöörama	ei oleks pööranud	V;ACT;PRS;PRF;NEG;COND
 pöörama	oleksid pööranud	V;ACT;PRS;PRF;POS;COND;3;PL
 pöörama	pöörasite	V;ACT;PST;POS;IND;2;PL
 pöörama	oleks pööranud	V;ACT;PRS;PRF;POS;COND;3;SG
 pöörama	olin pööranud	V;ACT;PRS;PRF;POS;COND;1;SG
 pöörama	oled pööranud	V;ACT;PRS;PRF;POS;IND;2;SG
 pöörama	oli pööranud	V;ACT;PRS;PRF;POS;COND;3;SG
-pöörama	ei ole pööratudp	V;PASS;PRS;PRF;NEG;IND
+pöörama	ei ole pööratud	V;PASS;PRS;PRF;NEG;IND
 pöörama	pööraksin	V;ACT;PRS;POS;COND;1;SG
 pöörama	olen pööranud	V;ACT;PRS;PRF;POS;IND;1;SG
-pöörama	ei olnud pööratudp	V;PASS;PST;PRF;NEG;IND
+pöörama	ei olnud pööratud	V;PASS;PST;PRF;NEG;IND
 pöörama	ärgu olgu pööratud	V;PASS;PRS;PRF;NEG;IMP
 
 pürgima	olete pürginud	V;ACT;PRS;PRF;POS;IND;2;PL
-pürgima	ei olevat pürginudp	V;ACT;PRS;PRF;NEG;QUOT
+pürgima	ei olevat pürginud	V;ACT;PRS;PRF;NEG;QUOT
 pürgima	oleks pürgitud	V;PASS;PRS;PRF;POS;COND
 pürgima	pürgisin	V;ACT;PST;POS;IND;1;SG
 pürgima	pürgitakse	V;PASS;PRS;POS;IND
@@ -22548,7 +22548,7 @@ pürgima	pürgitagu	V;PASS;PRS;POS;IMP
 pürgima	ärgu pürgigu	V;ACT;PRS;NEG;IMP;3;SG
 pürgima	oli pürgitud	V;PASS;PST;PRF;POS;IND
 pürgima	pürgisime	V;ACT;PST;POS;IND;1;PL
-pürgima	ei olnud pürginudp	V;ACT;PST;PRF;NEG;IND
+pürgima	ei olnud pürginud	V;ACT;PST;PRF;NEG;IND
 pürgima	oleksid pürginud	V;ACT;PRS;PRF;POS;COND;2;SG
 pürgima	olgu pürginud	V;ACT;PRS;PRF;POS;IMP;PL
 pürgima	oli pürginud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -22562,9 +22562,9 @@ pürgima	ärgu pürgigu	V;ACT;PRS;NEG;IMP;3;PL
 pürgima	olgu pürginud	V;ACT;PRS;PRF;POS;IMP;SG
 pürgima	pürgiti	V;PASS;PST;POS;IND
 pürgima	ei pürgivat	V;ACT;PRS;NEG;QUOT
-pürgima	ei oleks pürgitudp	V;PASS;PRS;PRF;NEG;COND
+pürgima	ei oleks pürgitud	V;PASS;PRS;PRF;NEG;COND
 pürgima	ei pürginud	V;ACT;PST;NEG;IND
-pürgima	ei olevat pürgitudp	V;PASS;PRS;PRF;NEG;QUOT
+pürgima	ei olevat pürgitud	V;PASS;PRS;PRF;NEG;QUOT
 pürgima	ei pürgiks	V;ACT;PRS;PRF;POS;COND;1;SG
 pürgima	pürgitud	V.PTCP;PASS;PST
 pürgima	olid pürginud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -22583,7 +22583,7 @@ pürgima	olgu pürgitud	V;PASS;PRS;PRF;POS;IMP
 pürgima	pürgiks	V;ACT;PRS;POS;COND;3;SG
 pürgima	pürgigu	V;ACT;PRS;POS;IMP;3;PL
 pürgima	ärgu olgu pürginud	V;ACT;PRS;PRF;NEG;IMP;SG
-pürgima	ei ole pürginudp	V;ACT;PST;NEG;IND
+pürgima	ei ole pürginud	V;ACT;PST;NEG;IND
 pürgima	pürgid	V;ACT;PRS;POS;IND;2;SG
 pürgima	ära pürgi	V;ACT;PRS;NEG;IMP;2;SG
 pürgima	ei pürgi	V;ACT;PRS;NEG;IND
@@ -22611,17 +22611,17 @@ pürgima	ei pürgita	V;PASS;PRS;NEG;IND
 pürgima	pürgime	V;ACT;PRS;POS;IND;1;PL
 pürgima	pürgin	V;ACT;PRS;POS;IND;1;SG
 pürgima	ärgem pürgigem	V;ACT;PRS;NEG;IMP;1;PL
-pürgima	ei oleks pürginudp	V;ACT;PRS;PRF;NEG;COND
+pürgima	ei oleks pürginud	V;ACT;PRS;PRF;NEG;COND
 pürgima	oleksid pürginud	V;ACT;PRS;PRF;POS;COND;3;PL
 pürgima	pürgisite	V;ACT;PST;POS;IND;2;PL
 pürgima	oleks pürginud	V;ACT;PRS;PRF;POS;COND;3;SG
 pürgima	olin pürginud	V;ACT;PRS;PRF;POS;COND;1;SG
 pürgima	oled pürginud	V;ACT;PRS;PRF;POS;IND;2;SG
 pürgima	oli pürginud	V;ACT;PRS;PRF;POS;COND;3;SG
-pürgima	ei ole pürgitudp	V;PASS;PRS;PRF;NEG;IND
+pürgima	ei ole pürgitud	V;PASS;PRS;PRF;NEG;IND
 pürgima	pürgiksin	V;ACT;PRS;POS;COND;1;SG
 pürgima	olen pürginud	V;ACT;PRS;PRF;POS;IND;1;SG
-pürgima	ei olnud pürgitudp	V;PASS;PST;PRF;NEG;IND
+pürgima	ei olnud pürgitud	V;PASS;PST;PRF;NEG;IND
 pürgima	ärgu olgu pürgitud	V;PASS;PRS;PRF;NEG;IMP
 
 püü	püüni	N;TERM;SG
@@ -22656,7 +22656,7 @@ püü	püüdesse	N;IN+ALL;PL
 püü	püüdelt	N;AT+ABL;PL
 
 püüdma	olete püüdnud	V;ACT;PRS;PRF;POS;IND;2;PL
-püüdma	ei olevat püüdnudp	V;ACT;PRS;PRF;NEG;QUOT
+püüdma	ei olevat püüdnud	V;ACT;PRS;PRF;NEG;QUOT
 püüdma	oleks püüetud	V;PASS;PRS;PRF;POS;COND
 püüdma	püüdsin	V;ACT;PST;POS;IND;1;SG
 püüdma	püüetakse	V;PASS;PRS;POS;IND
@@ -22665,7 +22665,7 @@ püüdma	püüetagu	V;PASS;PRS;POS;IMP
 püüdma	ärgu püüdku	V;ACT;PRS;NEG;IMP;3;SG
 püüdma	oli püüetud	V;PASS;PST;PRF;POS;IND
 püüdma	püüdsime	V;ACT;PST;POS;IND;1;PL
-püüdma	ei olnud püüdnudp	V;ACT;PST;PRF;NEG;IND
+püüdma	ei olnud püüdnud	V;ACT;PST;PRF;NEG;IND
 püüdma	oleksid püüdnud	V;ACT;PRS;PRF;POS;COND;2;SG
 püüdma	olgu püüdnud	V;ACT;PRS;PRF;POS;IMP;PL
 püüdma	oli püüdnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -22679,9 +22679,9 @@ püüdma	ärgu püüdku	V;ACT;PRS;NEG;IMP;3;PL
 püüdma	olgu püüdnud	V;ACT;PRS;PRF;POS;IMP;SG
 püüdma	püüeti	V;PASS;PST;POS;IND
 püüdma	ei püüdvat	V;ACT;PRS;NEG;QUOT
-püüdma	ei oleks püüetudp	V;PASS;PRS;PRF;NEG;COND
+püüdma	ei oleks püüetud	V;PASS;PRS;PRF;NEG;COND
 püüdma	ei püüdnud	V;ACT;PST;NEG;IND
-püüdma	ei olevat püüetudp	V;PASS;PRS;PRF;NEG;QUOT
+püüdma	ei olevat püüetud	V;PASS;PRS;PRF;NEG;QUOT
 püüdma	ei püüaks	V;ACT;PRS;PRF;POS;COND;1;SG
 püüdma	püüetud	V.PTCP;PASS;PST
 püüdma	olid püüdnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -22700,7 +22700,7 @@ püüdma	olgu püüetud	V;PASS;PRS;PRF;POS;IMP
 püüdma	püüaks	V;ACT;PRS;POS;COND;3;SG
 püüdma	püüdku	V;ACT;PRS;POS;IMP;3;PL
 püüdma	ärgu olgu püüdnud	V;ACT;PRS;PRF;NEG;IMP;SG
-püüdma	ei ole püüdnudp	V;ACT;PST;NEG;IND
+püüdma	ei ole püüdnud	V;ACT;PST;NEG;IND
 püüdma	püüad	V;ACT;PRS;POS;IND;2;SG
 püüdma	ära püüa	V;ACT;PRS;NEG;IMP;2;SG
 püüdma	ei püüa	V;ACT;PRS;NEG;IND
@@ -22728,17 +22728,17 @@ püüdma	ei püüeta	V;PASS;PRS;NEG;IND
 püüdma	püüame	V;ACT;PRS;POS;IND;1;PL
 püüdma	püüan	V;ACT;PRS;POS;IND;1;SG
 püüdma	ärgem püüdkem	V;ACT;PRS;NEG;IMP;1;PL
-püüdma	ei oleks püüdnudp	V;ACT;PRS;PRF;NEG;COND
+püüdma	ei oleks püüdnud	V;ACT;PRS;PRF;NEG;COND
 püüdma	oleksid püüdnud	V;ACT;PRS;PRF;POS;COND;3;PL
 püüdma	püüdsite	V;ACT;PST;POS;IND;2;PL
 püüdma	oleks püüdnud	V;ACT;PRS;PRF;POS;COND;3;SG
 püüdma	olin püüdnud	V;ACT;PRS;PRF;POS;COND;1;SG
 püüdma	oled püüdnud	V;ACT;PRS;PRF;POS;IND;2;SG
 püüdma	oli püüdnud	V;ACT;PRS;PRF;POS;COND;3;SG
-püüdma	ei ole püüetudp	V;PASS;PRS;PRF;NEG;IND
+püüdma	ei ole püüetud	V;PASS;PRS;PRF;NEG;IND
 püüdma	püüaksin	V;ACT;PRS;POS;COND;1;SG
 püüdma	olen püüdnud	V;ACT;PRS;PRF;POS;IND;1;SG
-püüdma	ei olnud püüetudp	V;PASS;PST;PRF;NEG;IND
+püüdma	ei olnud püüetud	V;PASS;PST;PRF;NEG;IND
 püüdma	ärgu olgu püüetud	V;PASS;PRS;PRF;NEG;IMP
 
 raadium	raadiumini	N;TERM;SG
@@ -23238,7 +23238,7 @@ reenium	reeniumdesse	N;IN+ALL;PL
 reenium	reeniumdelt	N;AT+ABL;PL
 
 reetma	olete reetnud	V;ACT;PRS;PRF;POS;IND;2;PL
-reetma	ei olevat reetnudp	V;ACT;PRS;PRF;NEG;QUOT
+reetma	ei olevat reetnud	V;ACT;PRS;PRF;NEG;QUOT
 reetma	oleks reedetud	V;PASS;PRS;PRF;POS;COND
 reetma	reetsin	V;ACT;PST;POS;IND;1;SG
 reetma	reedetakse	V;PASS;PRS;POS;IND
@@ -23247,7 +23247,7 @@ reetma	reedetagu	V;PASS;PRS;POS;IMP
 reetma	ärgu reetku	V;ACT;PRS;NEG;IMP;3;SG
 reetma	oli reedetud	V;PASS;PST;PRF;POS;IND
 reetma	reetsime	V;ACT;PST;POS;IND;1;PL
-reetma	ei olnud reetnudp	V;ACT;PST;PRF;NEG;IND
+reetma	ei olnud reetnud	V;ACT;PST;PRF;NEG;IND
 reetma	oleksid reetnud	V;ACT;PRS;PRF;POS;COND;2;SG
 reetma	olgu reetnud	V;ACT;PRS;PRF;POS;IMP;PL
 reetma	oli reetnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -23261,9 +23261,9 @@ reetma	ärgu reetku	V;ACT;PRS;NEG;IMP;3;PL
 reetma	olgu reetnud	V;ACT;PRS;PRF;POS;IMP;SG
 reetma	reedeti	V;PASS;PST;POS;IND
 reetma	ei reetvat	V;ACT;PRS;NEG;QUOT
-reetma	ei oleks reedetudp	V;PASS;PRS;PRF;NEG;COND
+reetma	ei oleks reedetud	V;PASS;PRS;PRF;NEG;COND
 reetma	ei reetnud	V;ACT;PST;NEG;IND
-reetma	ei olevat reedetudp	V;PASS;PRS;PRF;NEG;QUOT
+reetma	ei olevat reedetud	V;PASS;PRS;PRF;NEG;QUOT
 reetma	ei reedaks	V;ACT;PRS;PRF;POS;COND;1;SG
 reetma	reedetud	V.PTCP;PASS;PST
 reetma	olid reetnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -23282,7 +23282,7 @@ reetma	olgu reedetud	V;PASS;PRS;PRF;POS;IMP
 reetma	reedaks	V;ACT;PRS;POS;COND;3;SG
 reetma	reetku	V;ACT;PRS;POS;IMP;3;PL
 reetma	ärgu olgu reetnud	V;ACT;PRS;PRF;NEG;IMP;SG
-reetma	ei ole reetnudp	V;ACT;PST;NEG;IND
+reetma	ei ole reetnud	V;ACT;PST;NEG;IND
 reetma	reedad	V;ACT;PRS;POS;IND;2;SG
 reetma	ära reeda	V;ACT;PRS;NEG;IMP;2;SG
 reetma	ei reeda	V;ACT;PRS;NEG;IND
@@ -23310,17 +23310,17 @@ reetma	ei reedeta	V;PASS;PRS;NEG;IND
 reetma	reedame	V;ACT;PRS;POS;IND;1;PL
 reetma	reedan	V;ACT;PRS;POS;IND;1;SG
 reetma	ärgem reetkem	V;ACT;PRS;NEG;IMP;1;PL
-reetma	ei oleks reetnudp	V;ACT;PRS;PRF;NEG;COND
+reetma	ei oleks reetnud	V;ACT;PRS;PRF;NEG;COND
 reetma	oleksid reetnud	V;ACT;PRS;PRF;POS;COND;3;PL
 reetma	reetsite	V;ACT;PST;POS;IND;2;PL
 reetma	oleks reetnud	V;ACT;PRS;PRF;POS;COND;3;SG
 reetma	olin reetnud	V;ACT;PRS;PRF;POS;COND;1;SG
 reetma	oled reetnud	V;ACT;PRS;PRF;POS;IND;2;SG
 reetma	oli reetnud	V;ACT;PRS;PRF;POS;COND;3;SG
-reetma	ei ole reedetudp	V;PASS;PRS;PRF;NEG;IND
+reetma	ei ole reedetud	V;PASS;PRS;PRF;NEG;IND
 reetma	reedaksin	V;ACT;PRS;POS;COND;1;SG
 reetma	olen reetnud	V;ACT;PRS;PRF;POS;IND;1;SG
-reetma	ei olnud reedetudp	V;PASS;PST;PRF;NEG;IND
+reetma	ei olnud reedetud	V;PASS;PST;PRF;NEG;IND
 reetma	ärgu olgu reedetud	V;PASS;PRS;PRF;NEG;IMP
 
 rehekuu	rehekuuni	N;TERM;SG
@@ -23386,7 +23386,7 @@ reisija	reisijatesse	N;IN+ALL;PL
 reisija	reisijatelt	N;AT+ABL;PL
 
 reisima	olete reisinud	V;ACT;PRS;PRF;POS;IND;2;PL
-reisima	ei olevat reisinudp	V;ACT;PRS;PRF;NEG;QUOT
+reisima	ei olevat reisinud	V;ACT;PRS;PRF;NEG;QUOT
 reisima	oleks reisitud	V;PASS;PRS;PRF;POS;COND
 reisima	reisisin	V;ACT;PST;POS;IND;1;SG
 reisima	reisitakse	V;PASS;PRS;POS;IND
@@ -23395,7 +23395,7 @@ reisima	reisitagu	V;PASS;PRS;POS;IMP
 reisima	ärgu reisigu	V;ACT;PRS;NEG;IMP;3;SG
 reisima	oli reisitud	V;PASS;PST;PRF;POS;IND
 reisima	reisisime	V;ACT;PST;POS;IND;1;PL
-reisima	ei olnud reisinudp	V;ACT;PST;PRF;NEG;IND
+reisima	ei olnud reisinud	V;ACT;PST;PRF;NEG;IND
 reisima	oleksid reisinud	V;ACT;PRS;PRF;POS;COND;2;SG
 reisima	olgu reisinud	V;ACT;PRS;PRF;POS;IMP;PL
 reisima	oli reisinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -23409,9 +23409,9 @@ reisima	ärgu reisigu	V;ACT;PRS;NEG;IMP;3;PL
 reisima	olgu reisinud	V;ACT;PRS;PRF;POS;IMP;SG
 reisima	reisiti	V;PASS;PST;POS;IND
 reisima	ei reisivat	V;ACT;PRS;NEG;QUOT
-reisima	ei oleks reisitudp	V;PASS;PRS;PRF;NEG;COND
+reisima	ei oleks reisitud	V;PASS;PRS;PRF;NEG;COND
 reisima	ei reisinud	V;ACT;PST;NEG;IND
-reisima	ei olevat reisitudp	V;PASS;PRS;PRF;NEG;QUOT
+reisima	ei olevat reisitud	V;PASS;PRS;PRF;NEG;QUOT
 reisima	ei reisiks	V;ACT;PRS;PRF;POS;COND;1;SG
 reisima	reisitud	V.PTCP;PASS;PST
 reisima	olid reisinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -23430,7 +23430,7 @@ reisima	olgu reisitud	V;PASS;PRS;PRF;POS;IMP
 reisima	reisiks	V;ACT;PRS;POS;COND;3;SG
 reisima	reisigu	V;ACT;PRS;POS;IMP;3;PL
 reisima	ärgu olgu reisinud	V;ACT;PRS;PRF;NEG;IMP;SG
-reisima	ei ole reisinudp	V;ACT;PST;NEG;IND
+reisima	ei ole reisinud	V;ACT;PST;NEG;IND
 reisima	reisid	V;ACT;PRS;POS;IND;2;SG
 reisima	ära reisi	V;ACT;PRS;NEG;IMP;2;SG
 reisima	ei reisi	V;ACT;PRS;NEG;IND
@@ -23458,17 +23458,17 @@ reisima	ei reisita	V;PASS;PRS;NEG;IND
 reisima	reisime	V;ACT;PRS;POS;IND;1;PL
 reisima	reisin	V;ACT;PRS;POS;IND;1;SG
 reisima	ärgem reisigem	V;ACT;PRS;NEG;IMP;1;PL
-reisima	ei oleks reisinudp	V;ACT;PRS;PRF;NEG;COND
+reisima	ei oleks reisinud	V;ACT;PRS;PRF;NEG;COND
 reisima	oleksid reisinud	V;ACT;PRS;PRF;POS;COND;3;PL
 reisima	reisisite	V;ACT;PST;POS;IND;2;PL
 reisima	oleks reisinud	V;ACT;PRS;PRF;POS;COND;3;SG
 reisima	olin reisinud	V;ACT;PRS;PRF;POS;COND;1;SG
 reisima	oled reisinud	V;ACT;PRS;PRF;POS;IND;2;SG
 reisima	oli reisinud	V;ACT;PRS;PRF;POS;COND;3;SG
-reisima	ei ole reisitudp	V;PASS;PRS;PRF;NEG;IND
+reisima	ei ole reisitud	V;PASS;PRS;PRF;NEG;IND
 reisima	reisiksin	V;ACT;PRS;POS;COND;1;SG
 reisima	olen reisinud	V;ACT;PRS;PRF;POS;IND;1;SG
-reisima	ei olnud reisitudp	V;PASS;PST;PRF;NEG;IND
+reisima	ei olnud reisitud	V;PASS;PST;PRF;NEG;IND
 reisima	ärgu olgu reisitud	V;PASS;PRS;PRF;NEG;IMP
 
 rida	reani	N;TERM;SG
@@ -23565,7 +23565,7 @@ riietumine	riietumistesse	N;IN+ALL;PL
 riietumine	riietumistelt	N;AT+ABL;PL
 
 rikastuma	olete rikastunud	V;ACT;PRS;PRF;POS;IND;2;PL
-rikastuma	ei olevat rikastunudp	V;ACT;PRS;PRF;NEG;QUOT
+rikastuma	ei olevat rikastunud	V;ACT;PRS;PRF;NEG;QUOT
 rikastuma	oleks rikastutud	V;PASS;PRS;PRF;POS;COND
 rikastuma	rikastusin	V;ACT;PST;POS;IND;1;SG
 rikastuma	rikastutakse	V;PASS;PRS;POS;IND
@@ -23574,7 +23574,7 @@ rikastuma	rikastutagu	V;PASS;PRS;POS;IMP
 rikastuma	ärgu rikastugu	V;ACT;PRS;NEG;IMP;3;SG
 rikastuma	oli rikastutud	V;PASS;PST;PRF;POS;IND
 rikastuma	rikastusime	V;ACT;PST;POS;IND;1;PL
-rikastuma	ei olnud rikastunudp	V;ACT;PST;PRF;NEG;IND
+rikastuma	ei olnud rikastunud	V;ACT;PST;PRF;NEG;IND
 rikastuma	oleksid rikastunud	V;ACT;PRS;PRF;POS;COND;2;SG
 rikastuma	olgu rikastunud	V;ACT;PRS;PRF;POS;IMP;PL
 rikastuma	oli rikastunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -23588,9 +23588,9 @@ rikastuma	ärgu rikastugu	V;ACT;PRS;NEG;IMP;3;PL
 rikastuma	olgu rikastunud	V;ACT;PRS;PRF;POS;IMP;SG
 rikastuma	rikastuti	V;PASS;PST;POS;IND
 rikastuma	ei rikastuvat	V;ACT;PRS;NEG;QUOT
-rikastuma	ei oleks rikastutudp	V;PASS;PRS;PRF;NEG;COND
+rikastuma	ei oleks rikastutud	V;PASS;PRS;PRF;NEG;COND
 rikastuma	ei rikastunud	V;ACT;PST;NEG;IND
-rikastuma	ei olevat rikastutudp	V;PASS;PRS;PRF;NEG;QUOT
+rikastuma	ei olevat rikastutud	V;PASS;PRS;PRF;NEG;QUOT
 rikastuma	ei rikastuks	V;ACT;PRS;PRF;POS;COND;1;SG
 rikastuma	rikastutud	V.PTCP;PASS;PST
 rikastuma	olid rikastunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -23609,7 +23609,7 @@ rikastuma	olgu rikastutud	V;PASS;PRS;PRF;POS;IMP
 rikastuma	rikastuks	V;ACT;PRS;POS;COND;3;SG
 rikastuma	rikastugu	V;ACT;PRS;POS;IMP;3;PL
 rikastuma	ärgu olgu rikastunud	V;ACT;PRS;PRF;NEG;IMP;SG
-rikastuma	ei ole rikastunudp	V;ACT;PST;NEG;IND
+rikastuma	ei ole rikastunud	V;ACT;PST;NEG;IND
 rikastuma	rikastud	V;ACT;PRS;POS;IND;2;SG
 rikastuma	ära rikastu	V;ACT;PRS;NEG;IMP;2;SG
 rikastuma	ei rikastu	V;ACT;PRS;NEG;IND
@@ -23637,17 +23637,17 @@ rikastuma	ei rikastuta	V;PASS;PRS;NEG;IND
 rikastuma	rikastume	V;ACT;PRS;POS;IND;1;PL
 rikastuma	rikastun	V;ACT;PRS;POS;IND;1;SG
 rikastuma	ärgem rikastugem	V;ACT;PRS;NEG;IMP;1;PL
-rikastuma	ei oleks rikastunudp	V;ACT;PRS;PRF;NEG;COND
+rikastuma	ei oleks rikastunud	V;ACT;PRS;PRF;NEG;COND
 rikastuma	oleksid rikastunud	V;ACT;PRS;PRF;POS;COND;3;PL
 rikastuma	rikastusite	V;ACT;PST;POS;IND;2;PL
 rikastuma	oleks rikastunud	V;ACT;PRS;PRF;POS;COND;3;SG
 rikastuma	olin rikastunud	V;ACT;PRS;PRF;POS;COND;1;SG
 rikastuma	oled rikastunud	V;ACT;PRS;PRF;POS;IND;2;SG
 rikastuma	oli rikastunud	V;ACT;PRS;PRF;POS;COND;3;SG
-rikastuma	ei ole rikastutudp	V;PASS;PRS;PRF;NEG;IND
+rikastuma	ei ole rikastutud	V;PASS;PRS;PRF;NEG;IND
 rikastuma	rikastuksin	V;ACT;PRS;POS;COND;1;SG
 rikastuma	olen rikastunud	V;ACT;PRS;PRF;POS;IND;1;SG
-rikastuma	ei olnud rikastutudp	V;PASS;PST;PRF;NEG;IND
+rikastuma	ei olnud rikastutud	V;PASS;PST;PRF;NEG;IND
 rikastuma	ärgu olgu rikastutud	V;PASS;PRS;PRF;NEG;IMP
 
 rinnahoidja	rinnahoidjani	N;TERM;SG
@@ -23775,7 +23775,7 @@ roodium	roodiumdesse	N;IN+ALL;PL
 roodium	roodiumdelt	N;AT+ABL;PL
 
 roojama	olete roojanud	V;ACT;PRS;PRF;POS;IND;2;PL
-roojama	ei olevat roojanudp	V;ACT;PRS;PRF;NEG;QUOT
+roojama	ei olevat roojanud	V;ACT;PRS;PRF;NEG;QUOT
 roojama	oleks roojatud	V;PASS;PRS;PRF;POS;COND
 roojama	roojasin	V;ACT;PST;POS;IND;1;SG
 roojama	roojatakse	V;PASS;PRS;POS;IND
@@ -23784,7 +23784,7 @@ roojama	roojatagu	V;PASS;PRS;POS;IMP
 roojama	ärgu roojaku	V;ACT;PRS;NEG;IMP;3;SG
 roojama	oli roojatud	V;PASS;PST;PRF;POS;IND
 roojama	roojasime	V;ACT;PST;POS;IND;1;PL
-roojama	ei olnud roojanudp	V;ACT;PST;PRF;NEG;IND
+roojama	ei olnud roojanud	V;ACT;PST;PRF;NEG;IND
 roojama	oleksid roojanud	V;ACT;PRS;PRF;POS;COND;2;SG
 roojama	olgu roojanud	V;ACT;PRS;PRF;POS;IMP;PL
 roojama	oli roojanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -23798,9 +23798,9 @@ roojama	ärgu roojaku	V;ACT;PRS;NEG;IMP;3;PL
 roojama	olgu roojanud	V;ACT;PRS;PRF;POS;IMP;SG
 roojama	roojati	V;PASS;PST;POS;IND
 roojama	ei roojavat	V;ACT;PRS;NEG;QUOT
-roojama	ei oleks roojatudp	V;PASS;PRS;PRF;NEG;COND
+roojama	ei oleks roojatud	V;PASS;PRS;PRF;NEG;COND
 roojama	ei roojanud	V;ACT;PST;NEG;IND
-roojama	ei olevat roojatudp	V;PASS;PRS;PRF;NEG;QUOT
+roojama	ei olevat roojatud	V;PASS;PRS;PRF;NEG;QUOT
 roojama	ei roojaks	V;ACT;PRS;PRF;POS;COND;1;SG
 roojama	roojatud	V.PTCP;PASS;PST
 roojama	olid roojanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -23819,7 +23819,7 @@ roojama	olgu roojatud	V;PASS;PRS;PRF;POS;IMP
 roojama	roojaks	V;ACT;PRS;POS;COND;3;SG
 roojama	roojaku	V;ACT;PRS;POS;IMP;3;PL
 roojama	ärgu olgu roojanud	V;ACT;PRS;PRF;NEG;IMP;SG
-roojama	ei ole roojanudp	V;ACT;PST;NEG;IND
+roojama	ei ole roojanud	V;ACT;PST;NEG;IND
 roojama	roojad	V;ACT;PRS;POS;IND;2;SG
 roojama	ära rooja	V;ACT;PRS;NEG;IMP;2;SG
 roojama	ei rooja	V;ACT;PRS;NEG;IND
@@ -23847,17 +23847,17 @@ roojama	ei roojata	V;PASS;PRS;NEG;IND
 roojama	roojame	V;ACT;PRS;POS;IND;1;PL
 roojama	roojan	V;ACT;PRS;POS;IND;1;SG
 roojama	ärgem roojakem	V;ACT;PRS;NEG;IMP;1;PL
-roojama	ei oleks roojanudp	V;ACT;PRS;PRF;NEG;COND
+roojama	ei oleks roojanud	V;ACT;PRS;PRF;NEG;COND
 roojama	oleksid roojanud	V;ACT;PRS;PRF;POS;COND;3;PL
 roojama	roojasite	V;ACT;PST;POS;IND;2;PL
 roojama	oleks roojanud	V;ACT;PRS;PRF;POS;COND;3;SG
 roojama	olin roojanud	V;ACT;PRS;PRF;POS;COND;1;SG
 roojama	oled roojanud	V;ACT;PRS;PRF;POS;IND;2;SG
 roojama	oli roojanud	V;ACT;PRS;PRF;POS;COND;3;SG
-roojama	ei ole roojatudp	V;PASS;PRS;PRF;NEG;IND
+roojama	ei ole roojatud	V;PASS;PRS;PRF;NEG;IND
 roojama	roojaksin	V;ACT;PRS;POS;COND;1;SG
 roojama	olen roojanud	V;ACT;PRS;PRF;POS;IND;1;SG
-roojama	ei olnud roojatudp	V;PASS;PST;PRF;NEG;IND
+roojama	ei olnud roojatud	V;PASS;PST;PRF;NEG;IND
 roojama	ärgu olgu roojatud	V;PASS;PRS;PRF;NEG;IMP
 
 roojamine	roojamiseni	N;TERM;SG
@@ -24171,7 +24171,7 @@ rästik	rästikutesse	N;IN+ALL;PL
 rästik	rästikutelt	N;AT+ABL;PL
 
 rääkima	olete rääkinud	V;ACT;PRS;PRF;POS;IND;2;PL
-rääkima	ei olevat rääkinudp	V;ACT;PRS;PRF;NEG;QUOT
+rääkima	ei olevat rääkinud	V;ACT;PRS;PRF;NEG;QUOT
 rääkima	oleks räägitud	V;PASS;PRS;PRF;POS;COND
 rääkima	rääkisin	V;ACT;PST;POS;IND;1;SG
 rääkima	räägitakse	V;PASS;PRS;POS;IND
@@ -24180,7 +24180,7 @@ rääkima	räägitagu	V;PASS;PRS;POS;IMP
 rääkima	ärgu rääkigu	V;ACT;PRS;NEG;IMP;3;SG
 rääkima	oli räägitud	V;PASS;PST;PRF;POS;IND
 rääkima	rääkisime	V;ACT;PST;POS;IND;1;PL
-rääkima	ei olnud rääkinudp	V;ACT;PST;PRF;NEG;IND
+rääkima	ei olnud rääkinud	V;ACT;PST;PRF;NEG;IND
 rääkima	oleksid rääkinud	V;ACT;PRS;PRF;POS;COND;2;SG
 rääkima	olgu rääkinud	V;ACT;PRS;PRF;POS;IMP;PL
 rääkima	oli rääkinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -24194,9 +24194,9 @@ rääkima	ärgu rääkigu	V;ACT;PRS;NEG;IMP;3;PL
 rääkima	olgu rääkinud	V;ACT;PRS;PRF;POS;IMP;SG
 rääkima	räägiti	V;PASS;PST;POS;IND
 rääkima	ei rääkivat	V;ACT;PRS;NEG;QUOT
-rääkima	ei oleks räägitudp	V;PASS;PRS;PRF;NEG;COND
+rääkima	ei oleks räägitud	V;PASS;PRS;PRF;NEG;COND
 rääkima	ei rääkinud	V;ACT;PST;NEG;IND
-rääkima	ei olevat räägitudp	V;PASS;PRS;PRF;NEG;QUOT
+rääkima	ei olevat räägitud	V;PASS;PRS;PRF;NEG;QUOT
 rääkima	ei räägiks	V;ACT;PRS;PRF;POS;COND;1;SG
 rääkima	räägitud	V.PTCP;PASS;PST
 rääkima	olid rääkinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -24215,7 +24215,7 @@ rääkima	olgu räägitud	V;PASS;PRS;PRF;POS;IMP
 rääkima	räägiks	V;ACT;PRS;POS;COND;3;SG
 rääkima	rääkigu	V;ACT;PRS;POS;IMP;3;PL
 rääkima	ärgu olgu rääkinud	V;ACT;PRS;PRF;NEG;IMP;SG
-rääkima	ei ole rääkinudp	V;ACT;PST;NEG;IND
+rääkima	ei ole rääkinud	V;ACT;PST;NEG;IND
 rääkima	räägid	V;ACT;PRS;POS;IND;2;SG
 rääkima	ära räägi	V;ACT;PRS;NEG;IMP;2;SG
 rääkima	ei räägi	V;ACT;PRS;NEG;IND
@@ -24243,17 +24243,17 @@ rääkima	ei räägita	V;PASS;PRS;NEG;IND
 rääkima	räägime	V;ACT;PRS;POS;IND;1;PL
 rääkima	räägin	V;ACT;PRS;POS;IND;1;SG
 rääkima	ärgem rääkigem	V;ACT;PRS;NEG;IMP;1;PL
-rääkima	ei oleks rääkinudp	V;ACT;PRS;PRF;NEG;COND
+rääkima	ei oleks rääkinud	V;ACT;PRS;PRF;NEG;COND
 rääkima	oleksid rääkinud	V;ACT;PRS;PRF;POS;COND;3;PL
 rääkima	rääkisite	V;ACT;PST;POS;IND;2;PL
 rääkima	oleks rääkinud	V;ACT;PRS;PRF;POS;COND;3;SG
 rääkima	olin rääkinud	V;ACT;PRS;PRF;POS;COND;1;SG
 rääkima	oled rääkinud	V;ACT;PRS;PRF;POS;IND;2;SG
 rääkima	oli rääkinud	V;ACT;PRS;PRF;POS;COND;3;SG
-rääkima	ei ole räägitudp	V;PASS;PRS;PRF;NEG;IND
+rääkima	ei ole räägitud	V;PASS;PRS;PRF;NEG;IND
 rääkima	räägiksin	V;ACT;PRS;POS;COND;1;SG
 rääkima	olen rääkinud	V;ACT;PRS;PRF;POS;IND;1;SG
-rääkima	ei olnud räägitudp	V;PASS;PST;PRF;NEG;IND
+rääkima	ei olnud räägitud	V;PASS;PST;PRF;NEG;IND
 rääkima	ärgu olgu räägitud	V;PASS;PRS;PRF;NEG;IMP
 
 rõhukamber	rõhukambrini	N;TERM;SG
@@ -24319,7 +24319,7 @@ röntgeenium	röntgeeniumdesse	N;IN+ALL;PL
 röntgeenium	röntgeeniumdelt	N;AT+ABL;PL
 
 ründama	olete rünnanud	V;ACT;PRS;PRF;POS;IND;2;PL
-ründama	ei olevat rünnanudp	V;ACT;PRS;PRF;NEG;QUOT
+ründama	ei olevat rünnanud	V;ACT;PRS;PRF;NEG;QUOT
 ründama	oleks rünnatud	V;PASS;PRS;PRF;POS;COND
 ründama	ründasin	V;ACT;PST;POS;IND;1;SG
 ründama	rünnatakse	V;PASS;PRS;POS;IND
@@ -24328,7 +24328,7 @@ ründama	rünnatagu	V;PASS;PRS;POS;IMP
 ründama	ärgu rünnaku	V;ACT;PRS;NEG;IMP;3;SG
 ründama	oli rünnatud	V;PASS;PST;PRF;POS;IND
 ründama	ründasime	V;ACT;PST;POS;IND;1;PL
-ründama	ei olnud rünnanudp	V;ACT;PST;PRF;NEG;IND
+ründama	ei olnud rünnanud	V;ACT;PST;PRF;NEG;IND
 ründama	oleksid rünnanud	V;ACT;PRS;PRF;POS;COND;2;SG
 ründama	olgu rünnanud	V;ACT;PRS;PRF;POS;IMP;PL
 ründama	oli rünnanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -24342,9 +24342,9 @@ ründama	ärgu rünnaku	V;ACT;PRS;NEG;IMP;3;PL
 ründama	olgu rünnanud	V;ACT;PRS;PRF;POS;IMP;SG
 ründama	rünnati	V;PASS;PST;POS;IND
 ründama	ei ründavat	V;ACT;PRS;NEG;QUOT
-ründama	ei oleks rünnatudp	V;PASS;PRS;PRF;NEG;COND
+ründama	ei oleks rünnatud	V;PASS;PRS;PRF;NEG;COND
 ründama	ei rünnanud	V;ACT;PST;NEG;IND
-ründama	ei olevat rünnatudp	V;PASS;PRS;PRF;NEG;QUOT
+ründama	ei olevat rünnatud	V;PASS;PRS;PRF;NEG;QUOT
 ründama	ei ründaks	V;ACT;PRS;PRF;POS;COND;1;SG
 ründama	rünnatud	V.PTCP;PASS;PST
 ründama	olid rünnanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -24363,7 +24363,7 @@ ründama	olgu rünnatud	V;PASS;PRS;PRF;POS;IMP
 ründama	ründaks	V;ACT;PRS;POS;COND;3;SG
 ründama	rünnaku	V;ACT;PRS;POS;IMP;3;PL
 ründama	ärgu olgu rünnanud	V;ACT;PRS;PRF;NEG;IMP;SG
-ründama	ei ole rünnanudp	V;ACT;PST;NEG;IND
+ründama	ei ole rünnanud	V;ACT;PST;NEG;IND
 ründama	ründad	V;ACT;PRS;POS;IND;2;SG
 ründama	ära ründa	V;ACT;PRS;NEG;IMP;2;SG
 ründama	ei ründa	V;ACT;PRS;NEG;IND
@@ -24391,17 +24391,17 @@ ründama	ei rünnata	V;PASS;PRS;NEG;IND
 ründama	ründame	V;ACT;PRS;POS;IND;1;PL
 ründama	ründan	V;ACT;PRS;POS;IND;1;SG
 ründama	ärgem rünnakem	V;ACT;PRS;NEG;IMP;1;PL
-ründama	ei oleks rünnanudp	V;ACT;PRS;PRF;NEG;COND
+ründama	ei oleks rünnanud	V;ACT;PRS;PRF;NEG;COND
 ründama	oleksid rünnanud	V;ACT;PRS;PRF;POS;COND;3;PL
 ründama	ründasite	V;ACT;PST;POS;IND;2;PL
 ründama	oleks rünnanud	V;ACT;PRS;PRF;POS;COND;3;SG
 ründama	olin rünnanud	V;ACT;PRS;PRF;POS;COND;1;SG
 ründama	oled rünnanud	V;ACT;PRS;PRF;POS;IND;2;SG
 ründama	oli rünnanud	V;ACT;PRS;PRF;POS;COND;3;SG
-ründama	ei ole rünnatudp	V;PASS;PRS;PRF;NEG;IND
+ründama	ei ole rünnatud	V;PASS;PRS;PRF;NEG;IND
 ründama	ründaksin	V;ACT;PRS;POS;COND;1;SG
 ründama	olen rünnanud	V;ACT;PRS;PRF;POS;IND;1;SG
-ründama	ei olnud rünnatudp	V;PASS;PST;PRF;NEG;IND
+ründama	ei olnud rünnatud	V;PASS;PST;PRF;NEG;IND
 ründama	ärgu olgu rünnatud	V;PASS;PRS;PRF;NEG;IMP
 
 rüütel	rüütlini	N;TERM;SG
@@ -24436,7 +24436,7 @@ rüütel	rüütlitesse	N;IN+ALL;PL
 rüütel	rüütlitelt	N;AT+ABL;PL
 
 saabuma	olete saabunud	V;ACT;PRS;PRF;POS;IND;2;PL
-saabuma	ei olevat saabunudp	V;ACT;PRS;PRF;NEG;QUOT
+saabuma	ei olevat saabunud	V;ACT;PRS;PRF;NEG;QUOT
 saabuma	oleks saabutud	V;PASS;PRS;PRF;POS;COND
 saabuma	saabusin	V;ACT;PST;POS;IND;1;SG
 saabuma	saabutakse	V;PASS;PRS;POS;IND
@@ -24445,7 +24445,7 @@ saabuma	saabutagu	V;PASS;PRS;POS;IMP
 saabuma	ärgu saabugu	V;ACT;PRS;NEG;IMP;3;SG
 saabuma	oli saabutud	V;PASS;PST;PRF;POS;IND
 saabuma	saabusime	V;ACT;PST;POS;IND;1;PL
-saabuma	ei olnud saabunudp	V;ACT;PST;PRF;NEG;IND
+saabuma	ei olnud saabunud	V;ACT;PST;PRF;NEG;IND
 saabuma	oleksid saabunud	V;ACT;PRS;PRF;POS;COND;2;SG
 saabuma	olgu saabunud	V;ACT;PRS;PRF;POS;IMP;PL
 saabuma	oli saabunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -24459,9 +24459,9 @@ saabuma	ärgu saabugu	V;ACT;PRS;NEG;IMP;3;PL
 saabuma	olgu saabunud	V;ACT;PRS;PRF;POS;IMP;SG
 saabuma	saabuti	V;PASS;PST;POS;IND
 saabuma	ei saabuvat	V;ACT;PRS;NEG;QUOT
-saabuma	ei oleks saabutudp	V;PASS;PRS;PRF;NEG;COND
+saabuma	ei oleks saabutud	V;PASS;PRS;PRF;NEG;COND
 saabuma	ei saabunud	V;ACT;PST;NEG;IND
-saabuma	ei olevat saabutudp	V;PASS;PRS;PRF;NEG;QUOT
+saabuma	ei olevat saabutud	V;PASS;PRS;PRF;NEG;QUOT
 saabuma	ei saabuks	V;ACT;PRS;PRF;POS;COND;1;SG
 saabuma	saabutud	V.PTCP;PASS;PST
 saabuma	olid saabunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -24480,7 +24480,7 @@ saabuma	olgu saabutud	V;PASS;PRS;PRF;POS;IMP
 saabuma	saabuks	V;ACT;PRS;POS;COND;3;SG
 saabuma	saabugu	V;ACT;PRS;POS;IMP;3;PL
 saabuma	ärgu olgu saabunud	V;ACT;PRS;PRF;NEG;IMP;SG
-saabuma	ei ole saabunudp	V;ACT;PST;NEG;IND
+saabuma	ei ole saabunud	V;ACT;PST;NEG;IND
 saabuma	saabud	V;ACT;PRS;POS;IND;2;SG
 saabuma	ära saabu	V;ACT;PRS;NEG;IMP;2;SG
 saabuma	ei saabu	V;ACT;PRS;NEG;IND
@@ -24508,21 +24508,21 @@ saabuma	ei saabuta	V;PASS;PRS;NEG;IND
 saabuma	saabume	V;ACT;PRS;POS;IND;1;PL
 saabuma	saabun	V;ACT;PRS;POS;IND;1;SG
 saabuma	ärgem saabugem	V;ACT;PRS;NEG;IMP;1;PL
-saabuma	ei oleks saabunudp	V;ACT;PRS;PRF;NEG;COND
+saabuma	ei oleks saabunud	V;ACT;PRS;PRF;NEG;COND
 saabuma	oleksid saabunud	V;ACT;PRS;PRF;POS;COND;3;PL
 saabuma	saabusite	V;ACT;PST;POS;IND;2;PL
 saabuma	oleks saabunud	V;ACT;PRS;PRF;POS;COND;3;SG
 saabuma	olin saabunud	V;ACT;PRS;PRF;POS;COND;1;SG
 saabuma	oled saabunud	V;ACT;PRS;PRF;POS;IND;2;SG
 saabuma	oli saabunud	V;ACT;PRS;PRF;POS;COND;3;SG
-saabuma	ei ole saabutudp	V;PASS;PRS;PRF;NEG;IND
+saabuma	ei ole saabutud	V;PASS;PRS;PRF;NEG;IND
 saabuma	saabuksin	V;ACT;PRS;POS;COND;1;SG
 saabuma	olen saabunud	V;ACT;PRS;PRF;POS;IND;1;SG
-saabuma	ei olnud saabutudp	V;PASS;PST;PRF;NEG;IND
+saabuma	ei olnud saabutud	V;PASS;PST;PRF;NEG;IND
 saabuma	ärgu olgu saabutud	V;PASS;PRS;PRF;NEG;IMP
 
 saama	olete saanud	V;ACT;PRS;PRF;POS;IND;2;PL
-saama	ei olevat saanudp	V;ACT;PRS;PRF;NEG;QUOT
+saama	ei olevat saanud	V;ACT;PRS;PRF;NEG;QUOT
 saama	oleks saadud	V;PASS;PRS;PRF;POS;COND
 saama	sain	V;ACT;PST;POS;IND;1;SG
 saama	saadakse	V;PASS;PRS;POS;IND
@@ -24531,7 +24531,7 @@ saama	saadagu	V;PASS;PRS;POS;IMP
 saama	ärgu saagu	V;ACT;PRS;NEG;IMP;3;SG
 saama	oli saadud	V;PASS;PST;PRF;POS;IND
 saama	saime	V;ACT;PST;POS;IND;1;PL
-saama	ei olnud saanudp	V;ACT;PST;PRF;NEG;IND
+saama	ei olnud saanud	V;ACT;PST;PRF;NEG;IND
 saama	oleksid saanud	V;ACT;PRS;PRF;POS;COND;2;SG
 saama	olgu saanud	V;ACT;PRS;PRF;POS;IMP;PL
 saama	oli saanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -24545,9 +24545,9 @@ saama	ärgu saagu	V;ACT;PRS;NEG;IMP;3;PL
 saama	olgu saanud	V;ACT;PRS;PRF;POS;IMP;SG
 saama	saadi	V;PASS;PST;POS;IND
 saama	ei saavat	V;ACT;PRS;NEG;QUOT
-saama	ei oleks saadudp	V;PASS;PRS;PRF;NEG;COND
+saama	ei oleks saadud	V;PASS;PRS;PRF;NEG;COND
 saama	ei saanud	V;ACT;PST;NEG;IND
-saama	ei olevat saadudp	V;PASS;PRS;PRF;NEG;QUOT
+saama	ei olevat saadud	V;PASS;PRS;PRF;NEG;QUOT
 saama	ei saaks	V;ACT;PRS;PRF;POS;COND;1;SG
 saama	saadud	V.PTCP;PASS;PST
 saama	olid saanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -24566,7 +24566,7 @@ saama	olgu saadud	V;PASS;PRS;PRF;POS;IMP
 saama	saaks	V;ACT;PRS;POS;COND;3;SG
 saama	saagu	V;ACT;PRS;POS;IMP;3;PL
 saama	ärgu olgu saanud	V;ACT;PRS;PRF;NEG;IMP;SG
-saama	ei ole saanudp	V;ACT;PST;NEG;IND
+saama	ei ole saanud	V;ACT;PST;NEG;IND
 saama	saad	V;ACT;PRS;POS;IND;2;SG
 saama	ära saa	V;ACT;PRS;NEG;IMP;2;SG
 saama	ei saa	V;ACT;PRS;NEG;IND
@@ -24594,21 +24594,21 @@ saama	ei saada	V;PASS;PRS;NEG;IND
 saama	saame	V;ACT;PRS;POS;IND;1;PL
 saama	saan	V;ACT;PRS;POS;IND;1;SG
 saama	ärgem saagem	V;ACT;PRS;NEG;IMP;1;PL
-saama	ei oleks saanudp	V;ACT;PRS;PRF;NEG;COND
+saama	ei oleks saanud	V;ACT;PRS;PRF;NEG;COND
 saama	oleksid saanud	V;ACT;PRS;PRF;POS;COND;3;PL
 saama	saite	V;ACT;PST;POS;IND;2;PL
 saama	oleks saanud	V;ACT;PRS;PRF;POS;COND;3;SG
 saama	olin saanud	V;ACT;PRS;PRF;POS;COND;1;SG
 saama	oled saanud	V;ACT;PRS;PRF;POS;IND;2;SG
 saama	oli saanud	V;ACT;PRS;PRF;POS;COND;3;SG
-saama	ei ole saadudp	V;PASS;PRS;PRF;NEG;IND
+saama	ei ole saadud	V;PASS;PRS;PRF;NEG;IND
 saama	saaksin	V;ACT;PRS;POS;COND;1;SG
 saama	olen saanud	V;ACT;PRS;PRF;POS;IND;1;SG
-saama	ei olnud saadudp	V;PASS;PST;PRF;NEG;IND
+saama	ei olnud saadud	V;PASS;PST;PRF;NEG;IND
 saama	ärgu olgu saadud	V;PASS;PRS;PRF;NEG;IMP
 
 saatma	olete saatnud	V;ACT;PRS;PRF;POS;IND;2;PL
-saatma	ei olevat saatnudp	V;ACT;PRS;PRF;NEG;QUOT
+saatma	ei olevat saatnud	V;ACT;PRS;PRF;NEG;QUOT
 saatma	oleks saadetud	V;PASS;PRS;PRF;POS;COND
 saatma	saatsin	V;ACT;PST;POS;IND;1;SG
 saatma	saadetakse	V;PASS;PRS;POS;IND
@@ -24617,7 +24617,7 @@ saatma	saadetagu	V;PASS;PRS;POS;IMP
 saatma	ärgu saatku	V;ACT;PRS;NEG;IMP;3;SG
 saatma	oli saadetud	V;PASS;PST;PRF;POS;IND
 saatma	saatsime	V;ACT;PST;POS;IND;1;PL
-saatma	ei olnud saatnudp	V;ACT;PST;PRF;NEG;IND
+saatma	ei olnud saatnud	V;ACT;PST;PRF;NEG;IND
 saatma	oleksid saatnud	V;ACT;PRS;PRF;POS;COND;2;SG
 saatma	olgu saatnud	V;ACT;PRS;PRF;POS;IMP;PL
 saatma	oli saatnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -24631,9 +24631,9 @@ saatma	ärgu saatku	V;ACT;PRS;NEG;IMP;3;PL
 saatma	olgu saatnud	V;ACT;PRS;PRF;POS;IMP;SG
 saatma	saadeti	V;PASS;PST;POS;IND
 saatma	ei saatvat	V;ACT;PRS;NEG;QUOT
-saatma	ei oleks saadetudp	V;PASS;PRS;PRF;NEG;COND
+saatma	ei oleks saadetud	V;PASS;PRS;PRF;NEG;COND
 saatma	ei saatnud	V;ACT;PST;NEG;IND
-saatma	ei olevat saadetudp	V;PASS;PRS;PRF;NEG;QUOT
+saatma	ei olevat saadetud	V;PASS;PRS;PRF;NEG;QUOT
 saatma	ei saadaks	V;ACT;PRS;PRF;POS;COND;1;SG
 saatma	saadetud	V.PTCP;PASS;PST
 saatma	olid saatnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -24652,7 +24652,7 @@ saatma	olgu saadetud	V;PASS;PRS;PRF;POS;IMP
 saatma	saadaks	V;ACT;PRS;POS;COND;3;SG
 saatma	saatku	V;ACT;PRS;POS;IMP;3;PL
 saatma	ärgu olgu saatnud	V;ACT;PRS;PRF;NEG;IMP;SG
-saatma	ei ole saatnudp	V;ACT;PST;NEG;IND
+saatma	ei ole saatnud	V;ACT;PST;NEG;IND
 saatma	saadad	V;ACT;PRS;POS;IND;2;SG
 saatma	ära saada	V;ACT;PRS;NEG;IMP;2;SG
 saatma	ei saada	V;ACT;PRS;NEG;IND
@@ -24680,17 +24680,17 @@ saatma	ei saadeta	V;PASS;PRS;NEG;IND
 saatma	saadame	V;ACT;PRS;POS;IND;1;PL
 saatma	saadan	V;ACT;PRS;POS;IND;1;SG
 saatma	ärgem saatkem	V;ACT;PRS;NEG;IMP;1;PL
-saatma	ei oleks saatnudp	V;ACT;PRS;PRF;NEG;COND
+saatma	ei oleks saatnud	V;ACT;PRS;PRF;NEG;COND
 saatma	oleksid saatnud	V;ACT;PRS;PRF;POS;COND;3;PL
 saatma	saatsite	V;ACT;PST;POS;IND;2;PL
 saatma	oleks saatnud	V;ACT;PRS;PRF;POS;COND;3;SG
 saatma	olin saatnud	V;ACT;PRS;PRF;POS;COND;1;SG
 saatma	oled saatnud	V;ACT;PRS;PRF;POS;IND;2;SG
 saatma	oli saatnud	V;ACT;PRS;PRF;POS;COND;3;SG
-saatma	ei ole saadetudp	V;PASS;PRS;PRF;NEG;IND
+saatma	ei ole saadetud	V;PASS;PRS;PRF;NEG;IND
 saatma	saadaksin	V;ACT;PRS;POS;COND;1;SG
 saatma	olen saatnud	V;ACT;PRS;PRF;POS;IND;1;SG
-saatma	ei olnud saadetudp	V;PASS;PST;PRF;NEG;IND
+saatma	ei olnud saadetud	V;PASS;PST;PRF;NEG;IND
 saatma	ärgu olgu saadetud	V;PASS;PRS;PRF;NEG;IMP
 
 saav	saavani	N;TERM;SG
@@ -24787,7 +24787,7 @@ sadam	sadamatesse	N;IN+ALL;PL
 sadam	sadamatelt	N;AT+ABL;PL
 
 sadama	olete sadanud	V;ACT;PRS;PRF;POS;IND;2;PL
-sadama	ei olevat sadanudp	V;ACT;PRS;PRF;NEG;QUOT
+sadama	ei olevat sadanud	V;ACT;PRS;PRF;NEG;QUOT
 sadama	oleks sajatud	V;PASS;PRS;PRF;POS;COND
 sadama	sadasin	V;ACT;PST;POS;IND;1;SG
 sadama	sajatakse	V;PASS;PRS;POS;IND
@@ -24796,7 +24796,7 @@ sadama	sajatagu	V;PASS;PRS;POS;IMP
 sadama	ärgu sadagu	V;ACT;PRS;NEG;IMP;3;SG
 sadama	oli sajatud	V;PASS;PST;PRF;POS;IND
 sadama	sadasime	V;ACT;PST;POS;IND;1;PL
-sadama	ei olnud sadanudp	V;ACT;PST;PRF;NEG;IND
+sadama	ei olnud sadanud	V;ACT;PST;PRF;NEG;IND
 sadama	oleksid sadanud	V;ACT;PRS;PRF;POS;COND;2;SG
 sadama	olgu sadanud	V;ACT;PRS;PRF;POS;IMP;PL
 sadama	oli sadanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -24810,9 +24810,9 @@ sadama	ärgu sadagu	V;ACT;PRS;NEG;IMP;3;PL
 sadama	olgu sadanud	V;ACT;PRS;PRF;POS;IMP;SG
 sadama	sajati	V;PASS;PST;POS;IND
 sadama	ei sadavat	V;ACT;PRS;NEG;QUOT
-sadama	ei oleks sajatudp	V;PASS;PRS;PRF;NEG;COND
+sadama	ei oleks sajatud	V;PASS;PRS;PRF;NEG;COND
 sadama	ei sadanud	V;ACT;PST;NEG;IND
-sadama	ei olevat sajatudp	V;PASS;PRS;PRF;NEG;QUOT
+sadama	ei olevat sajatud	V;PASS;PRS;PRF;NEG;QUOT
 sadama	ei sajaks	V;ACT;PRS;PRF;POS;COND;1;SG
 sadama	sajatud	V.PTCP;PASS;PST
 sadama	olid sadanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -24831,7 +24831,7 @@ sadama	olgu sajatud	V;PASS;PRS;PRF;POS;IMP
 sadama	sajaks	V;ACT;PRS;POS;COND;3;SG
 sadama	sadagu	V;ACT;PRS;POS;IMP;3;PL
 sadama	ärgu olgu sadanud	V;ACT;PRS;PRF;NEG;IMP;SG
-sadama	ei ole sadanudp	V;ACT;PST;NEG;IND
+sadama	ei ole sadanud	V;ACT;PST;NEG;IND
 sadama	sajad	V;ACT;PRS;POS;IND;2;SG
 sadama	ära saja	V;ACT;PRS;NEG;IMP;2;SG
 sadama	ei saja	V;ACT;PRS;NEG;IND
@@ -24859,17 +24859,17 @@ sadama	ei sajata	V;PASS;PRS;NEG;IND
 sadama	sajame	V;ACT;PRS;POS;IND;1;PL
 sadama	sajan	V;ACT;PRS;POS;IND;1;SG
 sadama	ärgem sadagem	V;ACT;PRS;NEG;IMP;1;PL
-sadama	ei oleks sadanudp	V;ACT;PRS;PRF;NEG;COND
+sadama	ei oleks sadanud	V;ACT;PRS;PRF;NEG;COND
 sadama	oleksid sadanud	V;ACT;PRS;PRF;POS;COND;3;PL
 sadama	sadasite	V;ACT;PST;POS;IND;2;PL
 sadama	oleks sadanud	V;ACT;PRS;PRF;POS;COND;3;SG
 sadama	olin sadanud	V;ACT;PRS;PRF;POS;COND;1;SG
 sadama	oled sadanud	V;ACT;PRS;PRF;POS;IND;2;SG
 sadama	oli sadanud	V;ACT;PRS;PRF;POS;COND;3;SG
-sadama	ei ole sajatudp	V;PASS;PRS;PRF;NEG;IND
+sadama	ei ole sajatud	V;PASS;PRS;PRF;NEG;IND
 sadama	sajaksin	V;ACT;PRS;POS;COND;1;SG
 sadama	olen sadanud	V;ACT;PRS;PRF;POS;IND;1;SG
-sadama	ei olnud sajatudp	V;PASS;PST;PRF;NEG;IND
+sadama	ei olnud sajatud	V;PASS;PST;PRF;NEG;IND
 sadama	ärgu olgu sajatud	V;PASS;PRS;PRF;NEG;IMP
 
 sahkluu	sahkluuni	N;TERM;SG
@@ -25090,7 +25090,7 @@ sarnaluu	sarnaluudesse	N;IN+ALL;PL
 sarnaluu	sarnaluudelt	N;AT+ABL;PL
 
 aitama	olete aidanud	V;ACT;PRS;PRF;POS;IND;2;PL
-aitama	ei olevat aidanudp	V;ACT;PRS;PRF;NEG;QUOT
+aitama	ei olevat aidanud	V;ACT;PRS;PRF;NEG;QUOT
 aitama	oleks aidatud	V;PASS;PRS;PRF;POS;COND
 aitama	aitasin	V;ACT;PST;POS;IND;1;SG
 aitama	aidatakse	V;PASS;PRS;POS;IND
@@ -25099,7 +25099,7 @@ aitama	aidatagu	V;PASS;PRS;POS;IMP
 aitama	ärgu aidaku	V;ACT;PRS;NEG;IMP;3;SG
 aitama	oli aidatud	V;PASS;PST;PRF;POS;IND
 aitama	aitasime	V;ACT;PST;POS;IND;1;PL
-aitama	ei olnud aidanudp	V;ACT;PST;PRF;NEG;IND
+aitama	ei olnud aidanud	V;ACT;PST;PRF;NEG;IND
 aitama	oleksid aidanud	V;ACT;PRS;PRF;POS;COND;2;SG
 aitama	olgu aidanud	V;ACT;PRS;PRF;POS;IMP;PL
 aitama	oli aidanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -25113,9 +25113,9 @@ aitama	ärgu aidaku	V;ACT;PRS;NEG;IMP;3;PL
 aitama	olgu aidanud	V;ACT;PRS;PRF;POS;IMP;SG
 aitama	aidati	V;PASS;PST;POS;IND
 aitama	ei aitavat	V;ACT;PRS;NEG;QUOT
-aitama	ei oleks aidatudp	V;PASS;PRS;PRF;NEG;COND
+aitama	ei oleks aidatud	V;PASS;PRS;PRF;NEG;COND
 aitama	ei aidanud	V;ACT;PST;NEG;IND
-aitama	ei olevat aidatudp	V;PASS;PRS;PRF;NEG;QUOT
+aitama	ei olevat aidatud	V;PASS;PRS;PRF;NEG;QUOT
 aitama	ei aitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 aitama	aidatud	V.PTCP;PASS;PST
 aitama	olid aidanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -25134,7 +25134,7 @@ aitama	olgu aidatud	V;PASS;PRS;PRF;POS;IMP
 aitama	aitaks	V;ACT;PRS;POS;COND;3;SG
 aitama	aidaku	V;ACT;PRS;POS;IMP;3;PL
 aitama	ärgu olgu aidanud	V;ACT;PRS;PRF;NEG;IMP;SG
-aitama	ei ole aidanudp	V;ACT;PST;NEG;IND
+aitama	ei ole aidanud	V;ACT;PST;NEG;IND
 aitama	aitad	V;ACT;PRS;POS;IND;2;SG
 aitama	ära aita	V;ACT;PRS;NEG;IMP;2;SG
 aitama	ei aita	V;ACT;PRS;NEG;IND
@@ -25162,17 +25162,17 @@ aitama	ei aidata	V;PASS;PRS;NEG;IND
 aitama	aitame	V;ACT;PRS;POS;IND;1;PL
 aitama	aitan	V;ACT;PRS;POS;IND;1;SG
 aitama	ärgem aidakem	V;ACT;PRS;NEG;IMP;1;PL
-aitama	ei oleks aidanudp	V;ACT;PRS;PRF;NEG;COND
+aitama	ei oleks aidanud	V;ACT;PRS;PRF;NEG;COND
 aitama	oleksid aidanud	V;ACT;PRS;PRF;POS;COND;3;PL
 aitama	aitasite	V;ACT;PST;POS;IND;2;PL
 aitama	oleks aidanud	V;ACT;PRS;PRF;POS;COND;3;SG
 aitama	olin aidanud	V;ACT;PRS;PRF;POS;COND;1;SG
 aitama	oled aidanud	V;ACT;PRS;PRF;POS;IND;2;SG
 aitama	oli aidanud	V;ACT;PRS;PRF;POS;COND;3;SG
-aitama	ei ole aidatudp	V;PASS;PRS;PRF;NEG;IND
+aitama	ei ole aidatud	V;PASS;PRS;PRF;NEG;IND
 aitama	aitaksin	V;ACT;PRS;POS;COND;1;SG
 aitama	olen aidanud	V;ACT;PRS;PRF;POS;IND;1;SG
-aitama	ei olnud aidatudp	V;PASS;PST;PRF;NEG;IND
+aitama	ei olnud aidatud	V;PASS;PST;PRF;NEG;IND
 aitama	ärgu olgu aidatud	V;PASS;PRS;PRF;NEG;IMP
 
 seaborgium	seaborgiumini	N;TERM;SG
@@ -25331,7 +25331,7 @@ ajaloolane	ajaloolastesse	N;IN+ALL;PL
 ajaloolane	ajaloolastelt	N;AT+ABL;PL
 
 ajama	olete ajanud	V;ACT;PRS;PRF;POS;IND;2;PL
-ajama	ei olevat ajanudp	V;ACT;PRS;PRF;NEG;QUOT
+ajama	ei olevat ajanud	V;ACT;PRS;PRF;NEG;QUOT
 ajama	oleks ajatud	V;PASS;PRS;PRF;POS;COND
 ajama	ajasin	V;ACT;PST;POS;IND;1;SG
 ajama	ajatakse	V;PASS;PRS;POS;IND
@@ -25340,7 +25340,7 @@ ajama	ajatagu	V;PASS;PRS;POS;IMP
 ajama	ärgu ajagu	V;ACT;PRS;NEG;IMP;3;SG
 ajama	oli ajatud	V;PASS;PST;PRF;POS;IND
 ajama	ajasime	V;ACT;PST;POS;IND;1;PL
-ajama	ei olnud ajanudp	V;ACT;PST;PRF;NEG;IND
+ajama	ei olnud ajanud	V;ACT;PST;PRF;NEG;IND
 ajama	oleksid ajanud	V;ACT;PRS;PRF;POS;COND;2;SG
 ajama	olgu ajanud	V;ACT;PRS;PRF;POS;IMP;PL
 ajama	oli ajanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -25354,9 +25354,9 @@ ajama	ärgu ajagu	V;ACT;PRS;NEG;IMP;3;PL
 ajama	olgu ajanud	V;ACT;PRS;PRF;POS;IMP;SG
 ajama	ajati	V;PASS;PST;POS;IND
 ajama	ei ajavat	V;ACT;PRS;NEG;QUOT
-ajama	ei oleks ajatudp	V;PASS;PRS;PRF;NEG;COND
+ajama	ei oleks ajatud	V;PASS;PRS;PRF;NEG;COND
 ajama	ei ajanud	V;ACT;PST;NEG;IND
-ajama	ei olevat ajatudp	V;PASS;PRS;PRF;NEG;QUOT
+ajama	ei olevat ajatud	V;PASS;PRS;PRF;NEG;QUOT
 ajama	ei ajaks	V;ACT;PRS;PRF;POS;COND;1;SG
 ajama	ajatud	V.PTCP;PASS;PST
 ajama	olid ajanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -25375,7 +25375,7 @@ ajama	olgu ajatud	V;PASS;PRS;PRF;POS;IMP
 ajama	ajaks	V;ACT;PRS;POS;COND;3;SG
 ajama	ajagu	V;ACT;PRS;POS;IMP;3;PL
 ajama	ärgu olgu ajanud	V;ACT;PRS;PRF;NEG;IMP;SG
-ajama	ei ole ajanudp	V;ACT;PST;NEG;IND
+ajama	ei ole ajanud	V;ACT;PST;NEG;IND
 ajama	ajad	V;ACT;PRS;POS;IND;2;SG
 ajama	ära aja	V;ACT;PRS;NEG;IMP;2;SG
 ajama	ei aja	V;ACT;PRS;NEG;IND
@@ -25403,21 +25403,21 @@ ajama	ei ajata	V;PASS;PRS;NEG;IND
 ajama	ajame	V;ACT;PRS;POS;IND;1;PL
 ajama	ajan	V;ACT;PRS;POS;IND;1;SG
 ajama	ärgem ajagem	V;ACT;PRS;NEG;IMP;1;PL
-ajama	ei oleks ajanudp	V;ACT;PRS;PRF;NEG;COND
+ajama	ei oleks ajanud	V;ACT;PRS;PRF;NEG;COND
 ajama	oleksid ajanud	V;ACT;PRS;PRF;POS;COND;3;PL
 ajama	ajasite	V;ACT;PST;POS;IND;2;PL
 ajama	oleks ajanud	V;ACT;PRS;PRF;POS;COND;3;SG
 ajama	olin ajanud	V;ACT;PRS;PRF;POS;COND;1;SG
 ajama	oled ajanud	V;ACT;PRS;PRF;POS;IND;2;SG
 ajama	oli ajanud	V;ACT;PRS;PRF;POS;COND;3;SG
-ajama	ei ole ajatudp	V;PASS;PRS;PRF;NEG;IND
+ajama	ei ole ajatud	V;PASS;PRS;PRF;NEG;IND
 ajama	ajaksin	V;ACT;PRS;POS;COND;1;SG
 ajama	olen ajanud	V;ACT;PRS;PRF;POS;IND;1;SG
-ajama	ei olnud ajatudp	V;PASS;PST;PRF;NEG;IND
+ajama	ei olnud ajatud	V;PASS;PST;PRF;NEG;IND
 ajama	ärgu olgu ajatud	V;PASS;PRS;PRF;NEG;IMP
 
 seisma	olete seisnud	V;ACT;PRS;PRF;POS;IND;2;PL
-seisma	ei olevat seisnudp	V;ACT;PRS;PRF;NEG;QUOT
+seisma	ei olevat seisnud	V;ACT;PRS;PRF;NEG;QUOT
 seisma	oleks seistud	V;PASS;PRS;PRF;POS;COND
 seisma	seisin	V;ACT;PST;POS;IND;1;SG
 seisma	seistakse	V;PASS;PRS;POS;IND
@@ -25426,7 +25426,7 @@ seisma	seistagu	V;PASS;PRS;POS;IMP
 seisma	ärgu seisku	V;ACT;PRS;NEG;IMP;3;SG
 seisma	oli seistud	V;PASS;PST;PRF;POS;IND
 seisma	seisime	V;ACT;PST;POS;IND;1;PL
-seisma	ei olnud seisnudp	V;ACT;PST;PRF;NEG;IND
+seisma	ei olnud seisnud	V;ACT;PST;PRF;NEG;IND
 seisma	oleksid seisnud	V;ACT;PRS;PRF;POS;COND;2;SG
 seisma	olgu seisnud	V;ACT;PRS;PRF;POS;IMP;PL
 seisma	oli seisnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -25440,9 +25440,9 @@ seisma	ärgu seisku	V;ACT;PRS;NEG;IMP;3;PL
 seisma	olgu seisnud	V;ACT;PRS;PRF;POS;IMP;SG
 seisma	seisti	V;PASS;PST;POS;IND
 seisma	ei seisvat	V;ACT;PRS;NEG;QUOT
-seisma	ei oleks seistudp	V;PASS;PRS;PRF;NEG;COND
+seisma	ei oleks seistud	V;PASS;PRS;PRF;NEG;COND
 seisma	ei seisnud	V;ACT;PST;NEG;IND
-seisma	ei olevat seistudp	V;PASS;PRS;PRF;NEG;QUOT
+seisma	ei olevat seistud	V;PASS;PRS;PRF;NEG;QUOT
 seisma	ei seisaks	V;ACT;PRS;PRF;POS;COND;1;SG
 seisma	seistud	V.PTCP;PASS;PST
 seisma	olid seisnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -25461,7 +25461,7 @@ seisma	olgu seistud	V;PASS;PRS;PRF;POS;IMP
 seisma	seisaks	V;ACT;PRS;POS;COND;3;SG
 seisma	seisku	V;ACT;PRS;POS;IMP;3;PL
 seisma	ärgu olgu seisnud	V;ACT;PRS;PRF;NEG;IMP;SG
-seisma	ei ole seisnudp	V;ACT;PST;NEG;IND
+seisma	ei ole seisnud	V;ACT;PST;NEG;IND
 seisma	seisad	V;ACT;PRS;POS;IND;2;SG
 seisma	ära seisa	V;ACT;PRS;NEG;IMP;2;SG
 seisma	ei seisa	V;ACT;PRS;NEG;IND
@@ -25489,17 +25489,17 @@ seisma	ei seista	V;PASS;PRS;NEG;IND
 seisma	seisame	V;ACT;PRS;POS;IND;1;PL
 seisma	seisan	V;ACT;PRS;POS;IND;1;SG
 seisma	ärgem seiskem	V;ACT;PRS;NEG;IMP;1;PL
-seisma	ei oleks seisnudp	V;ACT;PRS;PRF;NEG;COND
+seisma	ei oleks seisnud	V;ACT;PRS;PRF;NEG;COND
 seisma	oleksid seisnud	V;ACT;PRS;PRF;POS;COND;3;PL
 seisma	seisite	V;ACT;PST;POS;IND;2;PL
 seisma	oleks seisnud	V;ACT;PRS;PRF;POS;COND;3;SG
 seisma	olin seisnud	V;ACT;PRS;PRF;POS;COND;1;SG
 seisma	oled seisnud	V;ACT;PRS;PRF;POS;IND;2;SG
 seisma	oli seisnud	V;ACT;PRS;PRF;POS;COND;3;SG
-seisma	ei ole seistudp	V;PASS;PRS;PRF;NEG;IND
+seisma	ei ole seistud	V;PASS;PRS;PRF;NEG;IND
 seisma	seisaksin	V;ACT;PRS;POS;COND;1;SG
 seisma	olen seisnud	V;ACT;PRS;PRF;POS;IND;1;SG
-seisma	ei olnud seistudp	V;PASS;PST;PRF;NEG;IND
+seisma	ei olnud seistud	V;PASS;PST;PRF;NEG;IND
 seisma	ärgu olgu seistud	V;PASS;PRS;PRF;NEG;IMP
 
 sekretär	sekretärini	N;TERM;SG
@@ -25565,7 +25565,7 @@ seksuaalpartner	seksuaalpartneritesse	N;IN+ALL;PL
 seksuaalpartner	seksuaalpartneritelt	N;AT+ABL;PL
 
 seletama	olete seletanud	V;ACT;PRS;PRF;POS;IND;2;PL
-seletama	ei olevat seletanudp	V;ACT;PRS;PRF;NEG;QUOT
+seletama	ei olevat seletanud	V;ACT;PRS;PRF;NEG;QUOT
 seletama	oleks seletatud	V;PASS;PRS;PRF;POS;COND
 seletama	seletasin	V;ACT;PST;POS;IND;1;SG
 seletama	seletatakse	V;PASS;PRS;POS;IND
@@ -25574,7 +25574,7 @@ seletama	seletatagu	V;PASS;PRS;POS;IMP
 seletama	ärgu seletagu	V;ACT;PRS;NEG;IMP;3;SG
 seletama	oli seletatud	V;PASS;PST;PRF;POS;IND
 seletama	seletasime	V;ACT;PST;POS;IND;1;PL
-seletama	ei olnud seletanudp	V;ACT;PST;PRF;NEG;IND
+seletama	ei olnud seletanud	V;ACT;PST;PRF;NEG;IND
 seletama	oleksid seletanud	V;ACT;PRS;PRF;POS;COND;2;SG
 seletama	olgu seletanud	V;ACT;PRS;PRF;POS;IMP;PL
 seletama	oli seletanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -25588,9 +25588,9 @@ seletama	ärgu seletagu	V;ACT;PRS;NEG;IMP;3;PL
 seletama	olgu seletanud	V;ACT;PRS;PRF;POS;IMP;SG
 seletama	seletati	V;PASS;PST;POS;IND
 seletama	ei seletavat	V;ACT;PRS;NEG;QUOT
-seletama	ei oleks seletatudp	V;PASS;PRS;PRF;NEG;COND
+seletama	ei oleks seletatud	V;PASS;PRS;PRF;NEG;COND
 seletama	ei seletanud	V;ACT;PST;NEG;IND
-seletama	ei olevat seletatudp	V;PASS;PRS;PRF;NEG;QUOT
+seletama	ei olevat seletatud	V;PASS;PRS;PRF;NEG;QUOT
 seletama	ei seletaks	V;ACT;PRS;PRF;POS;COND;1;SG
 seletama	seletatud	V.PTCP;PASS;PST
 seletama	olid seletanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -25609,7 +25609,7 @@ seletama	olgu seletatud	V;PASS;PRS;PRF;POS;IMP
 seletama	seletaks	V;ACT;PRS;POS;COND;3;SG
 seletama	seletagu	V;ACT;PRS;POS;IMP;3;PL
 seletama	ärgu olgu seletanud	V;ACT;PRS;PRF;NEG;IMP;SG
-seletama	ei ole seletanudp	V;ACT;PST;NEG;IND
+seletama	ei ole seletanud	V;ACT;PST;NEG;IND
 seletama	seletad	V;ACT;PRS;POS;IND;2;SG
 seletama	ära seleta	V;ACT;PRS;NEG;IMP;2;SG
 seletama	ei seleta	V;ACT;PRS;NEG;IND
@@ -25637,21 +25637,21 @@ seletama	ei seletata	V;PASS;PRS;NEG;IND
 seletama	seletame	V;ACT;PRS;POS;IND;1;PL
 seletama	seletan	V;ACT;PRS;POS;IND;1;SG
 seletama	ärgem seletagem	V;ACT;PRS;NEG;IMP;1;PL
-seletama	ei oleks seletanudp	V;ACT;PRS;PRF;NEG;COND
+seletama	ei oleks seletanud	V;ACT;PRS;PRF;NEG;COND
 seletama	oleksid seletanud	V;ACT;PRS;PRF;POS;COND;3;PL
 seletama	seletasite	V;ACT;PST;POS;IND;2;PL
 seletama	oleks seletanud	V;ACT;PRS;PRF;POS;COND;3;SG
 seletama	olin seletanud	V;ACT;PRS;PRF;POS;COND;1;SG
 seletama	oled seletanud	V;ACT;PRS;PRF;POS;IND;2;SG
 seletama	oli seletanud	V;ACT;PRS;PRF;POS;COND;3;SG
-seletama	ei ole seletatudp	V;PASS;PRS;PRF;NEG;IND
+seletama	ei ole seletatud	V;PASS;PRS;PRF;NEG;IND
 seletama	seletaksin	V;ACT;PRS;POS;COND;1;SG
 seletama	olen seletanud	V;ACT;PRS;PRF;POS;IND;1;SG
-seletama	ei olnud seletatudp	V;PASS;PST;PRF;NEG;IND
+seletama	ei olnud seletatud	V;PASS;PST;PRF;NEG;IND
 seletama	ärgu olgu seletatud	V;PASS;PRS;PRF;NEG;IMP
 
 selgitama	olete selgitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-selgitama	ei olevat selgitanudp	V;ACT;PRS;PRF;NEG;QUOT
+selgitama	ei olevat selgitanud	V;ACT;PRS;PRF;NEG;QUOT
 selgitama	oleks selgitatud	V;PASS;PRS;PRF;POS;COND
 selgitama	selgitasin	V;ACT;PST;POS;IND;1;SG
 selgitama	selgitatakse	V;PASS;PRS;POS;IND
@@ -25660,7 +25660,7 @@ selgitama	selgitatagu	V;PASS;PRS;POS;IMP
 selgitama	ärgu selgitagu	V;ACT;PRS;NEG;IMP;3;SG
 selgitama	oli selgitatud	V;PASS;PST;PRF;POS;IND
 selgitama	selgitasime	V;ACT;PST;POS;IND;1;PL
-selgitama	ei olnud selgitanudp	V;ACT;PST;PRF;NEG;IND
+selgitama	ei olnud selgitanud	V;ACT;PST;PRF;NEG;IND
 selgitama	oleksid selgitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 selgitama	olgu selgitanud	V;ACT;PRS;PRF;POS;IMP;PL
 selgitama	oli selgitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -25674,9 +25674,9 @@ selgitama	ärgu selgitagu	V;ACT;PRS;NEG;IMP;3;PL
 selgitama	olgu selgitanud	V;ACT;PRS;PRF;POS;IMP;SG
 selgitama	selgitati	V;PASS;PST;POS;IND
 selgitama	ei selgitavat	V;ACT;PRS;NEG;QUOT
-selgitama	ei oleks selgitatudp	V;PASS;PRS;PRF;NEG;COND
+selgitama	ei oleks selgitatud	V;PASS;PRS;PRF;NEG;COND
 selgitama	ei selgitanud	V;ACT;PST;NEG;IND
-selgitama	ei olevat selgitatudp	V;PASS;PRS;PRF;NEG;QUOT
+selgitama	ei olevat selgitatud	V;PASS;PRS;PRF;NEG;QUOT
 selgitama	ei selgitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 selgitama	selgitatud	V.PTCP;PASS;PST
 selgitama	olid selgitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -25695,7 +25695,7 @@ selgitama	olgu selgitatud	V;PASS;PRS;PRF;POS;IMP
 selgitama	selgitaks	V;ACT;PRS;POS;COND;3;SG
 selgitama	selgitagu	V;ACT;PRS;POS;IMP;3;PL
 selgitama	ärgu olgu selgitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-selgitama	ei ole selgitanudp	V;ACT;PST;NEG;IND
+selgitama	ei ole selgitanud	V;ACT;PST;NEG;IND
 selgitama	selgitad	V;ACT;PRS;POS;IND;2;SG
 selgitama	ära selgita	V;ACT;PRS;NEG;IMP;2;SG
 selgitama	ei selgita	V;ACT;PRS;NEG;IND
@@ -25723,17 +25723,17 @@ selgitama	ei selgitata	V;PASS;PRS;NEG;IND
 selgitama	selgitame	V;ACT;PRS;POS;IND;1;PL
 selgitama	selgitan	V;ACT;PRS;POS;IND;1;SG
 selgitama	ärgem selgitagem	V;ACT;PRS;NEG;IMP;1;PL
-selgitama	ei oleks selgitanudp	V;ACT;PRS;PRF;NEG;COND
+selgitama	ei oleks selgitanud	V;ACT;PRS;PRF;NEG;COND
 selgitama	oleksid selgitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 selgitama	selgitasite	V;ACT;PST;POS;IND;2;PL
 selgitama	oleks selgitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 selgitama	olin selgitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 selgitama	oled selgitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 selgitama	oli selgitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-selgitama	ei ole selgitatudp	V;PASS;PRS;PRF;NEG;IND
+selgitama	ei ole selgitatud	V;PASS;PRS;PRF;NEG;IND
 selgitama	selgitaksin	V;ACT;PRS;POS;COND;1;SG
 selgitama	olen selgitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-selgitama	ei olnud selgitatudp	V;PASS;PST;PRF;NEG;IND
+selgitama	ei olnud selgitatud	V;PASS;PST;PRF;NEG;IND
 selgitama	ärgu olgu selgitatud	V;PASS;PRS;PRF;NEG;IMP
 
 seller	sellerini	N;TERM;SG
@@ -25954,7 +25954,7 @@ sidrun	sidrunitesse	N;IN+ALL;PL
 sidrun	sidrunitelt	N;AT+ABL;PL
 
 siduma	olete sidunud	V;ACT;PRS;PRF;POS;IND;2;PL
-siduma	ei olevat sidunudp	V;ACT;PRS;PRF;NEG;QUOT
+siduma	ei olevat sidunud	V;ACT;PRS;PRF;NEG;QUOT
 siduma	oleks seotud	V;PASS;PRS;PRF;POS;COND
 siduma	sidusin	V;ACT;PST;POS;IND;1;SG
 siduma	seotakse	V;PASS;PRS;POS;IND
@@ -25963,7 +25963,7 @@ siduma	seotagu	V;PASS;PRS;POS;IMP
 siduma	ärgu sidugu	V;ACT;PRS;NEG;IMP;3;SG
 siduma	oli seotud	V;PASS;PST;PRF;POS;IND
 siduma	sidusime	V;ACT;PST;POS;IND;1;PL
-siduma	ei olnud sidunudp	V;ACT;PST;PRF;NEG;IND
+siduma	ei olnud sidunud	V;ACT;PST;PRF;NEG;IND
 siduma	oleksid sidunud	V;ACT;PRS;PRF;POS;COND;2;SG
 siduma	olgu sidunud	V;ACT;PRS;PRF;POS;IMP;PL
 siduma	oli sidunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -25977,9 +25977,9 @@ siduma	ärgu sidugu	V;ACT;PRS;NEG;IMP;3;PL
 siduma	olgu sidunud	V;ACT;PRS;PRF;POS;IMP;SG
 siduma	seoti	V;PASS;PST;POS;IND
 siduma	ei siduvat	V;ACT;PRS;NEG;QUOT
-siduma	ei oleks seotudp	V;PASS;PRS;PRF;NEG;COND
+siduma	ei oleks seotud	V;PASS;PRS;PRF;NEG;COND
 siduma	ei sidunud	V;ACT;PST;NEG;IND
-siduma	ei olevat seotudp	V;PASS;PRS;PRF;NEG;QUOT
+siduma	ei olevat seotud	V;PASS;PRS;PRF;NEG;QUOT
 siduma	ei seoks	V;ACT;PRS;PRF;POS;COND;1;SG
 siduma	seotud	V.PTCP;PASS;PST
 siduma	olid sidunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -25998,7 +25998,7 @@ siduma	olgu seotud	V;PASS;PRS;PRF;POS;IMP
 siduma	seoks	V;ACT;PRS;POS;COND;3;SG
 siduma	sidugu	V;ACT;PRS;POS;IMP;3;PL
 siduma	ärgu olgu sidunud	V;ACT;PRS;PRF;NEG;IMP;SG
-siduma	ei ole sidunudp	V;ACT;PST;NEG;IND
+siduma	ei ole sidunud	V;ACT;PST;NEG;IND
 siduma	seod	V;ACT;PRS;POS;IND;2;SG
 siduma	ära seo	V;ACT;PRS;NEG;IMP;2;SG
 siduma	ei seo	V;ACT;PRS;NEG;IND
@@ -26026,17 +26026,17 @@ siduma	ei seota	V;PASS;PRS;NEG;IND
 siduma	seome	V;ACT;PRS;POS;IND;1;PL
 siduma	seon	V;ACT;PRS;POS;IND;1;SG
 siduma	ärgem sidugem	V;ACT;PRS;NEG;IMP;1;PL
-siduma	ei oleks sidunudp	V;ACT;PRS;PRF;NEG;COND
+siduma	ei oleks sidunud	V;ACT;PRS;PRF;NEG;COND
 siduma	oleksid sidunud	V;ACT;PRS;PRF;POS;COND;3;PL
 siduma	sidusite	V;ACT;PST;POS;IND;2;PL
 siduma	oleks sidunud	V;ACT;PRS;PRF;POS;COND;3;SG
 siduma	olin sidunud	V;ACT;PRS;PRF;POS;COND;1;SG
 siduma	oled sidunud	V;ACT;PRS;PRF;POS;IND;2;SG
 siduma	oli sidunud	V;ACT;PRS;PRF;POS;COND;3;SG
-siduma	ei ole seotudp	V;PASS;PRS;PRF;NEG;IND
+siduma	ei ole seotud	V;PASS;PRS;PRF;NEG;IND
 siduma	seoksin	V;ACT;PRS;POS;COND;1;SG
 siduma	olen sidunud	V;ACT;PRS;PRF;POS;IND;1;SG
-siduma	ei olnud seotudp	V;PASS;PST;PRF;NEG;IND
+siduma	ei olnud seotud	V;PASS;PST;PRF;NEG;IND
 siduma	ärgu olgu seotud	V;PASS;PRS;PRF;NEG;IMP
 
 sigar	sigarini	N;TERM;SG
@@ -26164,7 +26164,7 @@ aken	akendesseaknaisse	N;IN+ALL;PL
 aken	akendeltaknailt	N;AT+ABL;PL
 
 sinatama	olete sinatanud	V;ACT;PRS;PRF;POS;IND;2;PL
-sinatama	ei olevat sinatanudp	V;ACT;PRS;PRF;NEG;QUOT
+sinatama	ei olevat sinatanud	V;ACT;PRS;PRF;NEG;QUOT
 sinatama	oleks sinatatud	V;PASS;PRS;PRF;POS;COND
 sinatama	sinatasin	V;ACT;PST;POS;IND;1;SG
 sinatama	sinatatakse	V;PASS;PRS;POS;IND
@@ -26173,7 +26173,7 @@ sinatama	sinatatagu	V;PASS;PRS;POS;IMP
 sinatama	ärgu sinatagu	V;ACT;PRS;NEG;IMP;3;SG
 sinatama	oli sinatatud	V;PASS;PST;PRF;POS;IND
 sinatama	sinatasime	V;ACT;PST;POS;IND;1;PL
-sinatama	ei olnud sinatanudp	V;ACT;PST;PRF;NEG;IND
+sinatama	ei olnud sinatanud	V;ACT;PST;PRF;NEG;IND
 sinatama	oleksid sinatanud	V;ACT;PRS;PRF;POS;COND;2;SG
 sinatama	olgu sinatanud	V;ACT;PRS;PRF;POS;IMP;PL
 sinatama	oli sinatanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -26187,9 +26187,9 @@ sinatama	ärgu sinatagu	V;ACT;PRS;NEG;IMP;3;PL
 sinatama	olgu sinatanud	V;ACT;PRS;PRF;POS;IMP;SG
 sinatama	sinatati	V;PASS;PST;POS;IND
 sinatama	ei sinatavat	V;ACT;PRS;NEG;QUOT
-sinatama	ei oleks sinatatudp	V;PASS;PRS;PRF;NEG;COND
+sinatama	ei oleks sinatatud	V;PASS;PRS;PRF;NEG;COND
 sinatama	ei sinatanud	V;ACT;PST;NEG;IND
-sinatama	ei olevat sinatatudp	V;PASS;PRS;PRF;NEG;QUOT
+sinatama	ei olevat sinatatud	V;PASS;PRS;PRF;NEG;QUOT
 sinatama	ei sinataks	V;ACT;PRS;PRF;POS;COND;1;SG
 sinatama	sinatatud	V.PTCP;PASS;PST
 sinatama	olid sinatanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -26208,7 +26208,7 @@ sinatama	olgu sinatatud	V;PASS;PRS;PRF;POS;IMP
 sinatama	sinataks	V;ACT;PRS;POS;COND;3;SG
 sinatama	sinatagu	V;ACT;PRS;POS;IMP;3;PL
 sinatama	ärgu olgu sinatanud	V;ACT;PRS;PRF;NEG;IMP;SG
-sinatama	ei ole sinatanudp	V;ACT;PST;NEG;IND
+sinatama	ei ole sinatanud	V;ACT;PST;NEG;IND
 sinatama	sinatad	V;ACT;PRS;POS;IND;2;SG
 sinatama	ära sinata	V;ACT;PRS;NEG;IMP;2;SG
 sinatama	ei sinata	V;ACT;PRS;NEG;IND
@@ -26236,17 +26236,17 @@ sinatama	ei sinatata	V;PASS;PRS;NEG;IND
 sinatama	sinatame	V;ACT;PRS;POS;IND;1;PL
 sinatama	sinatan	V;ACT;PRS;POS;IND;1;SG
 sinatama	ärgem sinatagem	V;ACT;PRS;NEG;IMP;1;PL
-sinatama	ei oleks sinatanudp	V;ACT;PRS;PRF;NEG;COND
+sinatama	ei oleks sinatanud	V;ACT;PRS;PRF;NEG;COND
 sinatama	oleksid sinatanud	V;ACT;PRS;PRF;POS;COND;3;PL
 sinatama	sinatasite	V;ACT;PST;POS;IND;2;PL
 sinatama	oleks sinatanud	V;ACT;PRS;PRF;POS;COND;3;SG
 sinatama	olin sinatanud	V;ACT;PRS;PRF;POS;COND;1;SG
 sinatama	oled sinatanud	V;ACT;PRS;PRF;POS;IND;2;SG
 sinatama	oli sinatanud	V;ACT;PRS;PRF;POS;COND;3;SG
-sinatama	ei ole sinatatudp	V;PASS;PRS;PRF;NEG;IND
+sinatama	ei ole sinatatud	V;PASS;PRS;PRF;NEG;IND
 sinatama	sinataksin	V;ACT;PRS;POS;COND;1;SG
 sinatama	olen sinatanud	V;ACT;PRS;PRF;POS;IND;1;SG
-sinatama	ei olnud sinatatudp	V;PASS;PST;PRF;NEG;IND
+sinatama	ei olnud sinatatud	V;PASS;PST;PRF;NEG;IND
 sinatama	ärgu olgu sinatatud	V;PASS;PRS;PRF;NEG;IMP
 
 sinine	siniseni	N;TERM;SG
@@ -26374,7 +26374,7 @@ sisseütlev	sisseütlevatesse	N;IN+ALL;PL
 sisseütlev	sisseütlevatelt	N;AT+ABL;PL
 
 sittuma	olete sittunud	V;ACT;PRS;PRF;POS;IND;2;PL
-sittuma	ei olevat sittunudp	V;ACT;PRS;PRF;NEG;QUOT
+sittuma	ei olevat sittunud	V;ACT;PRS;PRF;NEG;QUOT
 sittuma	oleks situtud	V;PASS;PRS;PRF;POS;COND
 sittuma	sittusin	V;ACT;PST;POS;IND;1;SG
 sittuma	situtakse	V;PASS;PRS;POS;IND
@@ -26383,7 +26383,7 @@ sittuma	situtagu	V;PASS;PRS;POS;IMP
 sittuma	ärgu sittugu	V;ACT;PRS;NEG;IMP;3;SG
 sittuma	oli situtud	V;PASS;PST;PRF;POS;IND
 sittuma	sittusime	V;ACT;PST;POS;IND;1;PL
-sittuma	ei olnud sittunudp	V;ACT;PST;PRF;NEG;IND
+sittuma	ei olnud sittunud	V;ACT;PST;PRF;NEG;IND
 sittuma	oleksid sittunud	V;ACT;PRS;PRF;POS;COND;2;SG
 sittuma	olgu sittunud	V;ACT;PRS;PRF;POS;IMP;PL
 sittuma	oli sittunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -26397,9 +26397,9 @@ sittuma	ärgu sittugu	V;ACT;PRS;NEG;IMP;3;PL
 sittuma	olgu sittunud	V;ACT;PRS;PRF;POS;IMP;SG
 sittuma	situti	V;PASS;PST;POS;IND
 sittuma	ei sittuvat	V;ACT;PRS;NEG;QUOT
-sittuma	ei oleks situtudp	V;PASS;PRS;PRF;NEG;COND
+sittuma	ei oleks situtud	V;PASS;PRS;PRF;NEG;COND
 sittuma	ei sittunud	V;ACT;PST;NEG;IND
-sittuma	ei olevat situtudp	V;PASS;PRS;PRF;NEG;QUOT
+sittuma	ei olevat situtud	V;PASS;PRS;PRF;NEG;QUOT
 sittuma	ei situks	V;ACT;PRS;PRF;POS;COND;1;SG
 sittuma	situtud	V.PTCP;PASS;PST
 sittuma	olid sittunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -26418,7 +26418,7 @@ sittuma	olgu situtud	V;PASS;PRS;PRF;POS;IMP
 sittuma	situks	V;ACT;PRS;POS;COND;3;SG
 sittuma	sittugu	V;ACT;PRS;POS;IMP;3;PL
 sittuma	ärgu olgu sittunud	V;ACT;PRS;PRF;NEG;IMP;SG
-sittuma	ei ole sittunudp	V;ACT;PST;NEG;IND
+sittuma	ei ole sittunud	V;ACT;PST;NEG;IND
 sittuma	situd	V;ACT;PRS;POS;IND;2;SG
 sittuma	ära situ	V;ACT;PRS;NEG;IMP;2;SG
 sittuma	ei situ	V;ACT;PRS;NEG;IND
@@ -26446,17 +26446,17 @@ sittuma	ei situta	V;PASS;PRS;NEG;IND
 sittuma	situme	V;ACT;PRS;POS;IND;1;PL
 sittuma	situn	V;ACT;PRS;POS;IND;1;SG
 sittuma	ärgem sittugem	V;ACT;PRS;NEG;IMP;1;PL
-sittuma	ei oleks sittunudp	V;ACT;PRS;PRF;NEG;COND
+sittuma	ei oleks sittunud	V;ACT;PRS;PRF;NEG;COND
 sittuma	oleksid sittunud	V;ACT;PRS;PRF;POS;COND;3;PL
 sittuma	sittusite	V;ACT;PST;POS;IND;2;PL
 sittuma	oleks sittunud	V;ACT;PRS;PRF;POS;COND;3;SG
 sittuma	olin sittunud	V;ACT;PRS;PRF;POS;COND;1;SG
 sittuma	oled sittunud	V;ACT;PRS;PRF;POS;IND;2;SG
 sittuma	oli sittunud	V;ACT;PRS;PRF;POS;COND;3;SG
-sittuma	ei ole situtudp	V;PASS;PRS;PRF;NEG;IND
+sittuma	ei ole situtud	V;PASS;PRS;PRF;NEG;IND
 sittuma	situksin	V;ACT;PRS;POS;COND;1;SG
 sittuma	olen sittunud	V;ACT;PRS;PRF;POS;IND;1;SG
-sittuma	ei olnud situtudp	V;PASS;PST;PRF;NEG;IND
+sittuma	ei olnud situtud	V;PASS;PST;PRF;NEG;IND
 sittuma	ärgu olgu situtud	V;PASS;PRS;PRF;NEG;IMP
 
 skandium	skandiumini	N;TERM;SG
@@ -26739,7 +26739,7 @@ soomlane	soomlastesse	N;IN+ALL;PL
 soomlane	soomlastelt	N;AT+ABL;PL
 
 soovima	olete soovinud	V;ACT;PRS;PRF;POS;IND;2;PL
-soovima	ei olevat soovinudp	V;ACT;PRS;PRF;NEG;QUOT
+soovima	ei olevat soovinud	V;ACT;PRS;PRF;NEG;QUOT
 soovima	oleks soovitud	V;PASS;PRS;PRF;POS;COND
 soovima	soovisin	V;ACT;PST;POS;IND;1;SG
 soovima	soovitakse	V;PASS;PRS;POS;IND
@@ -26748,7 +26748,7 @@ soovima	soovitagu	V;PASS;PRS;POS;IMP
 soovima	ärgu soovigu	V;ACT;PRS;NEG;IMP;3;SG
 soovima	oli soovitud	V;PASS;PST;PRF;POS;IND
 soovima	soovisime	V;ACT;PST;POS;IND;1;PL
-soovima	ei olnud soovinudp	V;ACT;PST;PRF;NEG;IND
+soovima	ei olnud soovinud	V;ACT;PST;PRF;NEG;IND
 soovima	oleksid soovinud	V;ACT;PRS;PRF;POS;COND;2;SG
 soovima	olgu soovinud	V;ACT;PRS;PRF;POS;IMP;PL
 soovima	oli soovinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -26762,9 +26762,9 @@ soovima	ärgu soovigu	V;ACT;PRS;NEG;IMP;3;PL
 soovima	olgu soovinud	V;ACT;PRS;PRF;POS;IMP;SG
 soovima	sooviti	V;PASS;PST;POS;IND
 soovima	ei soovivat	V;ACT;PRS;NEG;QUOT
-soovima	ei oleks soovitudp	V;PASS;PRS;PRF;NEG;COND
+soovima	ei oleks soovitud	V;PASS;PRS;PRF;NEG;COND
 soovima	ei soovinud	V;ACT;PST;NEG;IND
-soovima	ei olevat soovitudp	V;PASS;PRS;PRF;NEG;QUOT
+soovima	ei olevat soovitud	V;PASS;PRS;PRF;NEG;QUOT
 soovima	ei sooviks	V;ACT;PRS;PRF;POS;COND;1;SG
 soovima	soovitud	V.PTCP;PASS;PST
 soovima	olid soovinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -26783,7 +26783,7 @@ soovima	olgu soovitud	V;PASS;PRS;PRF;POS;IMP
 soovima	sooviks	V;ACT;PRS;POS;COND;3;SG
 soovima	soovigu	V;ACT;PRS;POS;IMP;3;PL
 soovima	ärgu olgu soovinud	V;ACT;PRS;PRF;NEG;IMP;SG
-soovima	ei ole soovinudp	V;ACT;PST;NEG;IND
+soovima	ei ole soovinud	V;ACT;PST;NEG;IND
 soovima	soovid	V;ACT;PRS;POS;IND;2;SG
 soovima	ära soovi	V;ACT;PRS;NEG;IMP;2;SG
 soovima	ei soovi	V;ACT;PRS;NEG;IND
@@ -26811,17 +26811,17 @@ soovima	ei soovita	V;PASS;PRS;NEG;IND
 soovima	soovime	V;ACT;PRS;POS;IND;1;PL
 soovima	soovin	V;ACT;PRS;POS;IND;1;SG
 soovima	ärgem soovigem	V;ACT;PRS;NEG;IMP;1;PL
-soovima	ei oleks soovinudp	V;ACT;PRS;PRF;NEG;COND
+soovima	ei oleks soovinud	V;ACT;PRS;PRF;NEG;COND
 soovima	oleksid soovinud	V;ACT;PRS;PRF;POS;COND;3;PL
 soovima	soovisite	V;ACT;PST;POS;IND;2;PL
 soovima	oleks soovinud	V;ACT;PRS;PRF;POS;COND;3;SG
 soovima	olin soovinud	V;ACT;PRS;PRF;POS;COND;1;SG
 soovima	oled soovinud	V;ACT;PRS;PRF;POS;IND;2;SG
 soovima	oli soovinud	V;ACT;PRS;PRF;POS;COND;3;SG
-soovima	ei ole soovitudp	V;PASS;PRS;PRF;NEG;IND
+soovima	ei ole soovitud	V;PASS;PRS;PRF;NEG;IND
 soovima	sooviksin	V;ACT;PRS;POS;COND;1;SG
 soovima	olen soovinud	V;ACT;PRS;PRF;POS;IND;1;SG
-soovima	ei olnud soovitudp	V;PASS;PST;PRF;NEG;IND
+soovima	ei olnud soovitud	V;PASS;PST;PRF;NEG;IND
 soovima	ärgu olgu soovitud	V;PASS;PRS;PRF;NEG;IMP
 
 alaleütlev	alaleütlevani	N;TERM;SG
@@ -26980,7 +26980,7 @@ alam	alamatesse	N;IN+ALL;PL
 alam	alamatelt	N;AT+ABL;PL
 
 spioneerima	olete spioneerinud	V;ACT;PRS;PRF;POS;IND;2;PL
-spioneerima	ei olevat spioneerinudp	V;ACT;PRS;PRF;NEG;QUOT
+spioneerima	ei olevat spioneerinud	V;ACT;PRS;PRF;NEG;QUOT
 spioneerima	oleks spioneeritud	V;PASS;PRS;PRF;POS;COND
 spioneerima	spioneerisin	V;ACT;PST;POS;IND;1;SG
 spioneerima	spioneeritakse	V;PASS;PRS;POS;IND
@@ -26989,7 +26989,7 @@ spioneerima	spioneeritagu	V;PASS;PRS;POS;IMP
 spioneerima	ärgu spioneerigu	V;ACT;PRS;NEG;IMP;3;SG
 spioneerima	oli spioneeritud	V;PASS;PST;PRF;POS;IND
 spioneerima	spioneerisime	V;ACT;PST;POS;IND;1;PL
-spioneerima	ei olnud spioneerinudp	V;ACT;PST;PRF;NEG;IND
+spioneerima	ei olnud spioneerinud	V;ACT;PST;PRF;NEG;IND
 spioneerima	oleksid spioneerinud	V;ACT;PRS;PRF;POS;COND;2;SG
 spioneerima	olgu spioneerinud	V;ACT;PRS;PRF;POS;IMP;PL
 spioneerima	oli spioneerinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -27003,9 +27003,9 @@ spioneerima	ärgu spioneerigu	V;ACT;PRS;NEG;IMP;3;PL
 spioneerima	olgu spioneerinud	V;ACT;PRS;PRF;POS;IMP;SG
 spioneerima	spioneeriti	V;PASS;PST;POS;IND
 spioneerima	ei spioneerivat	V;ACT;PRS;NEG;QUOT
-spioneerima	ei oleks spioneeritudp	V;PASS;PRS;PRF;NEG;COND
+spioneerima	ei oleks spioneeritud	V;PASS;PRS;PRF;NEG;COND
 spioneerima	ei spioneerinud	V;ACT;PST;NEG;IND
-spioneerima	ei olevat spioneeritudp	V;PASS;PRS;PRF;NEG;QUOT
+spioneerima	ei olevat spioneeritud	V;PASS;PRS;PRF;NEG;QUOT
 spioneerima	ei spioneeriks	V;ACT;PRS;PRF;POS;COND;1;SG
 spioneerima	spioneeritud	V.PTCP;PASS;PST
 spioneerima	olid spioneerinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -27024,7 +27024,7 @@ spioneerima	olgu spioneeritud	V;PASS;PRS;PRF;POS;IMP
 spioneerima	spioneeriks	V;ACT;PRS;POS;COND;3;SG
 spioneerima	spioneerigu	V;ACT;PRS;POS;IMP;3;PL
 spioneerima	ärgu olgu spioneerinud	V;ACT;PRS;PRF;NEG;IMP;SG
-spioneerima	ei ole spioneerinudp	V;ACT;PST;NEG;IND
+spioneerima	ei ole spioneerinud	V;ACT;PST;NEG;IND
 spioneerima	spioneerid	V;ACT;PRS;POS;IND;2;SG
 spioneerima	ära spioneeri	V;ACT;PRS;NEG;IMP;2;SG
 spioneerima	ei spioneeri	V;ACT;PRS;NEG;IND
@@ -27052,17 +27052,17 @@ spioneerima	ei spioneerita	V;PASS;PRS;NEG;IND
 spioneerima	spioneerime	V;ACT;PRS;POS;IND;1;PL
 spioneerima	spioneerin	V;ACT;PRS;POS;IND;1;SG
 spioneerima	ärgem spioneerigem	V;ACT;PRS;NEG;IMP;1;PL
-spioneerima	ei oleks spioneerinudp	V;ACT;PRS;PRF;NEG;COND
+spioneerima	ei oleks spioneerinud	V;ACT;PRS;PRF;NEG;COND
 spioneerima	oleksid spioneerinud	V;ACT;PRS;PRF;POS;COND;3;PL
 spioneerima	spioneerisite	V;ACT;PST;POS;IND;2;PL
 spioneerima	oleks spioneerinud	V;ACT;PRS;PRF;POS;COND;3;SG
 spioneerima	olin spioneerinud	V;ACT;PRS;PRF;POS;COND;1;SG
 spioneerima	oled spioneerinud	V;ACT;PRS;PRF;POS;IND;2;SG
 spioneerima	oli spioneerinud	V;ACT;PRS;PRF;POS;COND;3;SG
-spioneerima	ei ole spioneeritudp	V;PASS;PRS;PRF;NEG;IND
+spioneerima	ei ole spioneeritud	V;PASS;PRS;PRF;NEG;IND
 spioneerima	spioneeriksin	V;ACT;PRS;POS;COND;1;SG
 spioneerima	olen spioneerinud	V;ACT;PRS;PRF;POS;IND;1;SG
-spioneerima	ei olnud spioneeritudp	V;PASS;PST;PRF;NEG;IND
+spioneerima	ei olnud spioneeritud	V;PASS;PST;PRF;NEG;IND
 spioneerima	ärgu olgu spioneeritud	V;PASS;PRS;PRF;NEG;IMP
 
 statistika	statistikani	N;TERM;SG
@@ -27190,7 +27190,7 @@ algaja	algajatesse	N;IN+ALL;PL
 algaja	algajatelt	N;AT+ABL;PL
 
 algama	olete alanud	V;ACT;PRS;PRF;POS;IND;2;PL
-algama	ei olevat alanudp	V;ACT;PRS;PRF;NEG;QUOT
+algama	ei olevat alanud	V;ACT;PRS;PRF;NEG;QUOT
 algama	oleks alatud	V;PASS;PRS;PRF;POS;COND
 algama	algasin	V;ACT;PST;POS;IND;1;SG
 algama	alatakse	V;PASS;PRS;POS;IND
@@ -27199,7 +27199,7 @@ algama	alatagu	V;PASS;PRS;POS;IMP
 algama	ärgu alaku	V;ACT;PRS;NEG;IMP;3;SG
 algama	oli alatud	V;PASS;PST;PRF;POS;IND
 algama	algasime	V;ACT;PST;POS;IND;1;PL
-algama	ei olnud alanudp	V;ACT;PST;PRF;NEG;IND
+algama	ei olnud alanud	V;ACT;PST;PRF;NEG;IND
 algama	oleksid alanud	V;ACT;PRS;PRF;POS;COND;2;SG
 algama	olgu alanud	V;ACT;PRS;PRF;POS;IMP;PL
 algama	oli alanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -27213,9 +27213,9 @@ algama	ärgu alaku	V;ACT;PRS;NEG;IMP;3;PL
 algama	olgu alanud	V;ACT;PRS;PRF;POS;IMP;SG
 algama	alati	V;PASS;PST;POS;IND
 algama	ei algavat	V;ACT;PRS;NEG;QUOT
-algama	ei oleks alatudp	V;PASS;PRS;PRF;NEG;COND
+algama	ei oleks alatud	V;PASS;PRS;PRF;NEG;COND
 algama	ei alanud	V;ACT;PST;NEG;IND
-algama	ei olevat alatudp	V;PASS;PRS;PRF;NEG;QUOT
+algama	ei olevat alatud	V;PASS;PRS;PRF;NEG;QUOT
 algama	ei algaks	V;ACT;PRS;PRF;POS;COND;1;SG
 algama	alatud	V.PTCP;PASS;PST
 algama	olid alanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -27234,7 +27234,7 @@ algama	olgu alatud	V;PASS;PRS;PRF;POS;IMP
 algama	algaks	V;ACT;PRS;POS;COND;3;SG
 algama	alaku	V;ACT;PRS;POS;IMP;3;PL
 algama	ärgu olgu alanud	V;ACT;PRS;PRF;NEG;IMP;SG
-algama	ei ole alanudp	V;ACT;PST;NEG;IND
+algama	ei ole alanud	V;ACT;PST;NEG;IND
 algama	algad	V;ACT;PRS;POS;IND;2;SG
 algama	ära alga	V;ACT;PRS;NEG;IMP;2;SG
 algama	ei alga	V;ACT;PRS;NEG;IND
@@ -27262,17 +27262,17 @@ algama	ei alata	V;PASS;PRS;NEG;IND
 algama	algame	V;ACT;PRS;POS;IND;1;PL
 algama	algan	V;ACT;PRS;POS;IND;1;SG
 algama	ärgem alakem	V;ACT;PRS;NEG;IMP;1;PL
-algama	ei oleks alanudp	V;ACT;PRS;PRF;NEG;COND
+algama	ei oleks alanud	V;ACT;PRS;PRF;NEG;COND
 algama	oleksid alanud	V;ACT;PRS;PRF;POS;COND;3;PL
 algama	algasite	V;ACT;PST;POS;IND;2;PL
 algama	oleks alanud	V;ACT;PRS;PRF;POS;COND;3;SG
 algama	olin alanud	V;ACT;PRS;PRF;POS;COND;1;SG
 algama	oled alanud	V;ACT;PRS;PRF;POS;IND;2;SG
 algama	oli alanud	V;ACT;PRS;PRF;POS;COND;3;SG
-algama	ei ole alatudp	V;PASS;PRS;PRF;NEG;IND
+algama	ei ole alatud	V;PASS;PRS;PRF;NEG;IND
 algama	algaksin	V;ACT;PRS;POS;COND;1;SG
 algama	olen alanud	V;ACT;PRS;PRF;POS;IND;1;SG
-algama	ei olnud alatudp	V;PASS;PST;PRF;NEG;IND
+algama	ei olnud alatud	V;PASS;PST;PRF;NEG;IND
 algama	ärgu olgu alatud	V;PASS;PRS;PRF;NEG;IMP
 
 suhkur	suhkruni	N;TERM;SG
@@ -27307,7 +27307,7 @@ suhkur	suhkrutesse	N;IN+ALL;PL
 suhkur	suhkrutelt	N;AT+ABL;PL
 
 suitsetama	olete suitsetanud	V;ACT;PRS;PRF;POS;IND;2;PL
-suitsetama	ei olevat suitsetanudp	V;ACT;PRS;PRF;NEG;QUOT
+suitsetama	ei olevat suitsetanud	V;ACT;PRS;PRF;NEG;QUOT
 suitsetama	oleks suitsetatud	V;PASS;PRS;PRF;POS;COND
 suitsetama	suitsetasin	V;ACT;PST;POS;IND;1;SG
 suitsetama	suitsetatakse	V;PASS;PRS;POS;IND
@@ -27316,7 +27316,7 @@ suitsetama	suitsetatagu	V;PASS;PRS;POS;IMP
 suitsetama	ärgu suitsetagu	V;ACT;PRS;NEG;IMP;3;SG
 suitsetama	oli suitsetatud	V;PASS;PST;PRF;POS;IND
 suitsetama	suitsetasime	V;ACT;PST;POS;IND;1;PL
-suitsetama	ei olnud suitsetanudp	V;ACT;PST;PRF;NEG;IND
+suitsetama	ei olnud suitsetanud	V;ACT;PST;PRF;NEG;IND
 suitsetama	oleksid suitsetanud	V;ACT;PRS;PRF;POS;COND;2;SG
 suitsetama	olgu suitsetanud	V;ACT;PRS;PRF;POS;IMP;PL
 suitsetama	oli suitsetanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -27330,9 +27330,9 @@ suitsetama	ärgu suitsetagu	V;ACT;PRS;NEG;IMP;3;PL
 suitsetama	olgu suitsetanud	V;ACT;PRS;PRF;POS;IMP;SG
 suitsetama	suitsetati	V;PASS;PST;POS;IND
 suitsetama	ei suitsetavat	V;ACT;PRS;NEG;QUOT
-suitsetama	ei oleks suitsetatudp	V;PASS;PRS;PRF;NEG;COND
+suitsetama	ei oleks suitsetatud	V;PASS;PRS;PRF;NEG;COND
 suitsetama	ei suitsetanud	V;ACT;PST;NEG;IND
-suitsetama	ei olevat suitsetatudp	V;PASS;PRS;PRF;NEG;QUOT
+suitsetama	ei olevat suitsetatud	V;PASS;PRS;PRF;NEG;QUOT
 suitsetama	ei suitsetaks	V;ACT;PRS;PRF;POS;COND;1;SG
 suitsetama	suitsetatud	V.PTCP;PASS;PST
 suitsetama	olid suitsetanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -27351,7 +27351,7 @@ suitsetama	olgu suitsetatud	V;PASS;PRS;PRF;POS;IMP
 suitsetama	suitsetaks	V;ACT;PRS;POS;COND;3;SG
 suitsetama	suitsetagu	V;ACT;PRS;POS;IMP;3;PL
 suitsetama	ärgu olgu suitsetanud	V;ACT;PRS;PRF;NEG;IMP;SG
-suitsetama	ei ole suitsetanudp	V;ACT;PST;NEG;IND
+suitsetama	ei ole suitsetanud	V;ACT;PST;NEG;IND
 suitsetama	suitsetad	V;ACT;PRS;POS;IND;2;SG
 suitsetama	ära suitseta	V;ACT;PRS;NEG;IMP;2;SG
 suitsetama	ei suitseta	V;ACT;PRS;NEG;IND
@@ -27379,21 +27379,21 @@ suitsetama	ei suitsetata	V;PASS;PRS;NEG;IND
 suitsetama	suitsetame	V;ACT;PRS;POS;IND;1;PL
 suitsetama	suitsetan	V;ACT;PRS;POS;IND;1;SG
 suitsetama	ärgem suitsetagem	V;ACT;PRS;NEG;IMP;1;PL
-suitsetama	ei oleks suitsetanudp	V;ACT;PRS;PRF;NEG;COND
+suitsetama	ei oleks suitsetanud	V;ACT;PRS;PRF;NEG;COND
 suitsetama	oleksid suitsetanud	V;ACT;PRS;PRF;POS;COND;3;PL
 suitsetama	suitsetasite	V;ACT;PST;POS;IND;2;PL
 suitsetama	oleks suitsetanud	V;ACT;PRS;PRF;POS;COND;3;SG
 suitsetama	olin suitsetanud	V;ACT;PRS;PRF;POS;COND;1;SG
 suitsetama	oled suitsetanud	V;ACT;PRS;PRF;POS;IND;2;SG
 suitsetama	oli suitsetanud	V;ACT;PRS;PRF;POS;COND;3;SG
-suitsetama	ei ole suitsetatudp	V;PASS;PRS;PRF;NEG;IND
+suitsetama	ei ole suitsetatud	V;PASS;PRS;PRF;NEG;IND
 suitsetama	suitsetaksin	V;ACT;PRS;POS;COND;1;SG
 suitsetama	olen suitsetanud	V;ACT;PRS;PRF;POS;IND;1;SG
-suitsetama	ei olnud suitsetatudp	V;PASS;PST;PRF;NEG;IND
+suitsetama	ei olnud suitsetatud	V;PASS;PST;PRF;NEG;IND
 suitsetama	ärgu olgu suitsetatud	V;PASS;PRS;PRF;NEG;IMP
 
 summutama	olete summutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-summutama	ei olevat summutanudp	V;ACT;PRS;PRF;NEG;QUOT
+summutama	ei olevat summutanud	V;ACT;PRS;PRF;NEG;QUOT
 summutama	oleks summutatud	V;PASS;PRS;PRF;POS;COND
 summutama	summutasin	V;ACT;PST;POS;IND;1;SG
 summutama	summutatakse	V;PASS;PRS;POS;IND
@@ -27402,7 +27402,7 @@ summutama	summutatagu	V;PASS;PRS;POS;IMP
 summutama	ärgu summutagu	V;ACT;PRS;NEG;IMP;3;SG
 summutama	oli summutatud	V;PASS;PST;PRF;POS;IND
 summutama	summutasime	V;ACT;PST;POS;IND;1;PL
-summutama	ei olnud summutanudp	V;ACT;PST;PRF;NEG;IND
+summutama	ei olnud summutanud	V;ACT;PST;PRF;NEG;IND
 summutama	oleksid summutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 summutama	olgu summutanud	V;ACT;PRS;PRF;POS;IMP;PL
 summutama	oli summutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -27416,9 +27416,9 @@ summutama	ärgu summutagu	V;ACT;PRS;NEG;IMP;3;PL
 summutama	olgu summutanud	V;ACT;PRS;PRF;POS;IMP;SG
 summutama	summutati	V;PASS;PST;POS;IND
 summutama	ei summutavat	V;ACT;PRS;NEG;QUOT
-summutama	ei oleks summutatudp	V;PASS;PRS;PRF;NEG;COND
+summutama	ei oleks summutatud	V;PASS;PRS;PRF;NEG;COND
 summutama	ei summutanud	V;ACT;PST;NEG;IND
-summutama	ei olevat summutatudp	V;PASS;PRS;PRF;NEG;QUOT
+summutama	ei olevat summutatud	V;PASS;PRS;PRF;NEG;QUOT
 summutama	ei summutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 summutama	summutatud	V.PTCP;PASS;PST
 summutama	olid summutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -27437,7 +27437,7 @@ summutama	olgu summutatud	V;PASS;PRS;PRF;POS;IMP
 summutama	summutaks	V;ACT;PRS;POS;COND;3;SG
 summutama	summutagu	V;ACT;PRS;POS;IMP;3;PL
 summutama	ärgu olgu summutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-summutama	ei ole summutanudp	V;ACT;PST;NEG;IND
+summutama	ei ole summutanud	V;ACT;PST;NEG;IND
 summutama	summutad	V;ACT;PRS;POS;IND;2;SG
 summutama	ära summuta	V;ACT;PRS;NEG;IMP;2;SG
 summutama	ei summuta	V;ACT;PRS;NEG;IND
@@ -27465,21 +27465,21 @@ summutama	ei summutata	V;PASS;PRS;NEG;IND
 summutama	summutame	V;ACT;PRS;POS;IND;1;PL
 summutama	summutan	V;ACT;PRS;POS;IND;1;SG
 summutama	ärgem summutagem	V;ACT;PRS;NEG;IMP;1;PL
-summutama	ei oleks summutanudp	V;ACT;PRS;PRF;NEG;COND
+summutama	ei oleks summutanud	V;ACT;PRS;PRF;NEG;COND
 summutama	oleksid summutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 summutama	summutasite	V;ACT;PST;POS;IND;2;PL
 summutama	oleks summutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 summutama	olin summutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 summutama	oled summutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 summutama	oli summutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-summutama	ei ole summutatudp	V;PASS;PRS;PRF;NEG;IND
+summutama	ei ole summutatud	V;PASS;PRS;PRF;NEG;IND
 summutama	summutaksin	V;ACT;PRS;POS;COND;1;SG
 summutama	olen summutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-summutama	ei olnud summutatudp	V;PASS;PST;PRF;NEG;IND
+summutama	ei olnud summutatud	V;PASS;PST;PRF;NEG;IND
 summutama	ärgu olgu summutatud	V;PASS;PRS;PRF;NEG;IMP
 
 surema	olete surnud	V;ACT;PRS;PRF;POS;IND;2;PL
-surema	ei olevat surnudp	V;ACT;PRS;PRF;NEG;QUOT
+surema	ei olevat surnud	V;ACT;PRS;PRF;NEG;QUOT
 surema	oleks surdud	V;PASS;PRS;PRF;POS;COND
 surema	surin	V;ACT;PST;POS;IND;1;SG
 surema	surrakse	V;PASS;PRS;POS;IND
@@ -27488,7 +27488,7 @@ surema	surdagu	V;PASS;PRS;POS;IMP
 surema	ärgu surgu	V;ACT;PRS;NEG;IMP;3;SG
 surema	oli surdud	V;PASS;PST;PRF;POS;IND
 surema	surime	V;ACT;PST;POS;IND;1;PL
-surema	ei olnud surnudp	V;ACT;PST;PRF;NEG;IND
+surema	ei olnud surnud	V;ACT;PST;PRF;NEG;IND
 surema	oleksid surnud	V;ACT;PRS;PRF;POS;COND;2;SG
 surema	olgu surnud	V;ACT;PRS;PRF;POS;IMP;PL
 surema	oli surnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -27502,9 +27502,9 @@ surema	ärgu surgu	V;ACT;PRS;NEG;IMP;3;PL
 surema	olgu surnud	V;ACT;PRS;PRF;POS;IMP;SG
 surema	surdi	V;PASS;PST;POS;IND
 surema	ei surevat	V;ACT;PRS;NEG;QUOT
-surema	ei oleks surdudp	V;PASS;PRS;PRF;NEG;COND
+surema	ei oleks surdud	V;PASS;PRS;PRF;NEG;COND
 surema	ei surnud	V;ACT;PST;NEG;IND
-surema	ei olevat surdudp	V;PASS;PRS;PRF;NEG;QUOT
+surema	ei olevat surdud	V;PASS;PRS;PRF;NEG;QUOT
 surema	ei sureks	V;ACT;PRS;PRF;POS;COND;1;SG
 surema	surdud	V.PTCP;PASS;PST
 surema	olid surnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -27523,7 +27523,7 @@ surema	olgu surdud	V;PASS;PRS;PRF;POS;IMP
 surema	sureks	V;ACT;PRS;POS;COND;3;SG
 surema	surgu	V;ACT;PRS;POS;IMP;3;PL
 surema	ärgu olgu surnud	V;ACT;PRS;PRF;NEG;IMP;SG
-surema	ei ole surnudp	V;ACT;PST;NEG;IND
+surema	ei ole surnud	V;ACT;PST;NEG;IND
 surema	sured	V;ACT;PRS;POS;IND;2;SG
 surema	ära sure	V;ACT;PRS;NEG;IMP;2;SG
 surema	ei sure	V;ACT;PRS;NEG;IND
@@ -27551,21 +27551,21 @@ surema	ei surda	V;PASS;PRS;NEG;IND
 surema	sureme	V;ACT;PRS;POS;IND;1;PL
 surema	suren	V;ACT;PRS;POS;IND;1;SG
 surema	ärgem surgem	V;ACT;PRS;NEG;IMP;1;PL
-surema	ei oleks surnudp	V;ACT;PRS;PRF;NEG;COND
+surema	ei oleks surnud	V;ACT;PRS;PRF;NEG;COND
 surema	oleksid surnud	V;ACT;PRS;PRF;POS;COND;3;PL
 surema	surite	V;ACT;PST;POS;IND;2;PL
 surema	oleks surnud	V;ACT;PRS;PRF;POS;COND;3;SG
 surema	olin surnud	V;ACT;PRS;PRF;POS;COND;1;SG
 surema	oled surnud	V;ACT;PRS;PRF;POS;IND;2;SG
 surema	oli surnud	V;ACT;PRS;PRF;POS;COND;3;SG
-surema	ei ole surdudp	V;PASS;PRS;PRF;NEG;IND
+surema	ei ole surdud	V;PASS;PRS;PRF;NEG;IND
 surema	sureksin	V;ACT;PRS;POS;COND;1;SG
 surema	olen surnud	V;ACT;PRS;PRF;POS;IND;1;SG
-surema	ei olnud surdudp	V;PASS;PST;PRF;NEG;IND
+surema	ei olnud surdud	V;PASS;PST;PRF;NEG;IND
 surema	ärgu olgu surdud	V;PASS;PRS;PRF;NEG;IMP
 
 surmama	olete surmanud	V;ACT;PRS;PRF;POS;IND;2;PL
-surmama	ei olevat surmanudp	V;ACT;PRS;PRF;NEG;QUOT
+surmama	ei olevat surmanud	V;ACT;PRS;PRF;NEG;QUOT
 surmama	oleks surmatud	V;PASS;PRS;PRF;POS;COND
 surmama	surmasin	V;ACT;PST;POS;IND;1;SG
 surmama	surmatakse	V;PASS;PRS;POS;IND
@@ -27574,7 +27574,7 @@ surmama	surmatagu	V;PASS;PRS;POS;IMP
 surmama	ärgu surmaku	V;ACT;PRS;NEG;IMP;3;SG
 surmama	oli surmatud	V;PASS;PST;PRF;POS;IND
 surmama	surmasime	V;ACT;PST;POS;IND;1;PL
-surmama	ei olnud surmanudp	V;ACT;PST;PRF;NEG;IND
+surmama	ei olnud surmanud	V;ACT;PST;PRF;NEG;IND
 surmama	oleksid surmanud	V;ACT;PRS;PRF;POS;COND;2;SG
 surmama	olgu surmanud	V;ACT;PRS;PRF;POS;IMP;PL
 surmama	oli surmanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -27588,9 +27588,9 @@ surmama	ärgu surmaku	V;ACT;PRS;NEG;IMP;3;PL
 surmama	olgu surmanud	V;ACT;PRS;PRF;POS;IMP;SG
 surmama	surmati	V;PASS;PST;POS;IND
 surmama	ei surmavat	V;ACT;PRS;NEG;QUOT
-surmama	ei oleks surmatudp	V;PASS;PRS;PRF;NEG;COND
+surmama	ei oleks surmatud	V;PASS;PRS;PRF;NEG;COND
 surmama	ei surmanud	V;ACT;PST;NEG;IND
-surmama	ei olevat surmatudp	V;PASS;PRS;PRF;NEG;QUOT
+surmama	ei olevat surmatud	V;PASS;PRS;PRF;NEG;QUOT
 surmama	ei surmaks	V;ACT;PRS;PRF;POS;COND;1;SG
 surmama	surmatud	V.PTCP;PASS;PST
 surmama	olid surmanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -27609,7 +27609,7 @@ surmama	olgu surmatud	V;PASS;PRS;PRF;POS;IMP
 surmama	surmaks	V;ACT;PRS;POS;COND;3;SG
 surmama	surmaku	V;ACT;PRS;POS;IMP;3;PL
 surmama	ärgu olgu surmanud	V;ACT;PRS;PRF;NEG;IMP;SG
-surmama	ei ole surmanudp	V;ACT;PST;NEG;IND
+surmama	ei ole surmanud	V;ACT;PST;NEG;IND
 surmama	surmad	V;ACT;PRS;POS;IND;2;SG
 surmama	ära surma	V;ACT;PRS;NEG;IMP;2;SG
 surmama	ei surma	V;ACT;PRS;NEG;IND
@@ -27637,17 +27637,17 @@ surmama	ei surmata	V;PASS;PRS;NEG;IND
 surmama	surmame	V;ACT;PRS;POS;IND;1;PL
 surmama	surman	V;ACT;PRS;POS;IND;1;SG
 surmama	ärgem surmakem	V;ACT;PRS;NEG;IMP;1;PL
-surmama	ei oleks surmanudp	V;ACT;PRS;PRF;NEG;COND
+surmama	ei oleks surmanud	V;ACT;PRS;PRF;NEG;COND
 surmama	oleksid surmanud	V;ACT;PRS;PRF;POS;COND;3;PL
 surmama	surmasite	V;ACT;PST;POS;IND;2;PL
 surmama	oleks surmanud	V;ACT;PRS;PRF;POS;COND;3;SG
 surmama	olin surmanud	V;ACT;PRS;PRF;POS;COND;1;SG
 surmama	oled surmanud	V;ACT;PRS;PRF;POS;IND;2;SG
 surmama	oli surmanud	V;ACT;PRS;PRF;POS;COND;3;SG
-surmama	ei ole surmatudp	V;PASS;PRS;PRF;NEG;IND
+surmama	ei ole surmatud	V;PASS;PRS;PRF;NEG;IND
 surmama	surmaksin	V;ACT;PRS;POS;COND;1;SG
 surmama	olen surmanud	V;ACT;PRS;PRF;POS;IND;1;SG
-surmama	ei olnud surmatudp	V;PASS;PST;PRF;NEG;IND
+surmama	ei olnud surmatud	V;PASS;PST;PRF;NEG;IND
 surmama	ärgu olgu surmatud	V;PASS;PRS;PRF;NEG;IMP
 
 susi	soeni	N;TERM;SG
@@ -27992,7 +27992,7 @@ sõiduk	sõidukitesse	N;IN+ALL;PL
 sõiduk	sõidukitelt	N;AT+ABL;PL
 
 sõitma	olete sõitnud	V;ACT;PRS;PRF;POS;IND;2;PL
-sõitma	ei olevat sõitnudp	V;ACT;PRS;PRF;NEG;QUOT
+sõitma	ei olevat sõitnud	V;ACT;PRS;PRF;NEG;QUOT
 sõitma	oleks sõidetud	V;PASS;PRS;PRF;POS;COND
 sõitma	sõitsin	V;ACT;PST;POS;IND;1;SG
 sõitma	sõidetakse	V;PASS;PRS;POS;IND
@@ -28001,7 +28001,7 @@ sõitma	sõidetagu	V;PASS;PRS;POS;IMP
 sõitma	ärgu sõitku	V;ACT;PRS;NEG;IMP;3;SG
 sõitma	oli sõidetud	V;PASS;PST;PRF;POS;IND
 sõitma	sõitsime	V;ACT;PST;POS;IND;1;PL
-sõitma	ei olnud sõitnudp	V;ACT;PST;PRF;NEG;IND
+sõitma	ei olnud sõitnud	V;ACT;PST;PRF;NEG;IND
 sõitma	oleksid sõitnud	V;ACT;PRS;PRF;POS;COND;2;SG
 sõitma	olgu sõitnud	V;ACT;PRS;PRF;POS;IMP;PL
 sõitma	oli sõitnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -28015,9 +28015,9 @@ sõitma	ärgu sõitku	V;ACT;PRS;NEG;IMP;3;PL
 sõitma	olgu sõitnud	V;ACT;PRS;PRF;POS;IMP;SG
 sõitma	sõideti	V;PASS;PST;POS;IND
 sõitma	ei sõitvat	V;ACT;PRS;NEG;QUOT
-sõitma	ei oleks sõidetudp	V;PASS;PRS;PRF;NEG;COND
+sõitma	ei oleks sõidetud	V;PASS;PRS;PRF;NEG;COND
 sõitma	ei sõitnud	V;ACT;PST;NEG;IND
-sõitma	ei olevat sõidetudp	V;PASS;PRS;PRF;NEG;QUOT
+sõitma	ei olevat sõidetud	V;PASS;PRS;PRF;NEG;QUOT
 sõitma	ei sõidaks	V;ACT;PRS;PRF;POS;COND;1;SG
 sõitma	sõidetud	V.PTCP;PASS;PST
 sõitma	olid sõitnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -28036,7 +28036,7 @@ sõitma	olgu sõidetud	V;PASS;PRS;PRF;POS;IMP
 sõitma	sõidaks	V;ACT;PRS;POS;COND;3;SG
 sõitma	sõitku	V;ACT;PRS;POS;IMP;3;PL
 sõitma	ärgu olgu sõitnud	V;ACT;PRS;PRF;NEG;IMP;SG
-sõitma	ei ole sõitnudp	V;ACT;PST;NEG;IND
+sõitma	ei ole sõitnud	V;ACT;PST;NEG;IND
 sõitma	sõidad	V;ACT;PRS;POS;IND;2;SG
 sõitma	ära sõida	V;ACT;PRS;NEG;IMP;2;SG
 sõitma	ei sõida	V;ACT;PRS;NEG;IND
@@ -28064,17 +28064,17 @@ sõitma	ei sõideta	V;PASS;PRS;NEG;IND
 sõitma	sõidame	V;ACT;PRS;POS;IND;1;PL
 sõitma	sõidan	V;ACT;PRS;POS;IND;1;SG
 sõitma	ärgem sõitkem	V;ACT;PRS;NEG;IMP;1;PL
-sõitma	ei oleks sõitnudp	V;ACT;PRS;PRF;NEG;COND
+sõitma	ei oleks sõitnud	V;ACT;PRS;PRF;NEG;COND
 sõitma	oleksid sõitnud	V;ACT;PRS;PRF;POS;COND;3;PL
 sõitma	sõitsite	V;ACT;PST;POS;IND;2;PL
 sõitma	oleks sõitnud	V;ACT;PRS;PRF;POS;COND;3;SG
 sõitma	olin sõitnud	V;ACT;PRS;PRF;POS;COND;1;SG
 sõitma	oled sõitnud	V;ACT;PRS;PRF;POS;IND;2;SG
 sõitma	oli sõitnud	V;ACT;PRS;PRF;POS;COND;3;SG
-sõitma	ei ole sõidetudp	V;PASS;PRS;PRF;NEG;IND
+sõitma	ei ole sõidetud	V;PASS;PRS;PRF;NEG;IND
 sõitma	sõidaksin	V;ACT;PRS;POS;COND;1;SG
 sõitma	olen sõitnud	V;ACT;PRS;PRF;POS;IND;1;SG
-sõitma	ei olnud sõidetudp	V;PASS;PST;PRF;NEG;IND
+sõitma	ei olnud sõidetud	V;PASS;PST;PRF;NEG;IND
 sõitma	ärgu olgu sõidetud	V;PASS;PRS;PRF;NEG;IMP
 
 sõltlane	sõltlaseni	N;TERM;SG
@@ -28295,7 +28295,7 @@ sõsar	sõsaratesse	N;IN+ALL;PL
 sõsar	sõsaratelt	N;AT+ABL;PL
 
 sõudma	olete sõudnud	V;ACT;PRS;PRF;POS;IND;2;PL
-sõudma	ei olevat sõudnudp	V;ACT;PRS;PRF;NEG;QUOT
+sõudma	ei olevat sõudnud	V;ACT;PRS;PRF;NEG;QUOT
 sõudma	oleks sõuetud	V;PASS;PRS;PRF;POS;COND
 sõudma	sõudsin	V;ACT;PST;POS;IND;1;SG
 sõudma	sõuetakse	V;PASS;PRS;POS;IND
@@ -28304,7 +28304,7 @@ sõudma	sõuetagu	V;PASS;PRS;POS;IMP
 sõudma	ärgu sõudku	V;ACT;PRS;NEG;IMP;3;SG
 sõudma	oli sõuetud	V;PASS;PST;PRF;POS;IND
 sõudma	sõudsime	V;ACT;PST;POS;IND;1;PL
-sõudma	ei olnud sõudnudp	V;ACT;PST;PRF;NEG;IND
+sõudma	ei olnud sõudnud	V;ACT;PST;PRF;NEG;IND
 sõudma	oleksid sõudnud	V;ACT;PRS;PRF;POS;COND;2;SG
 sõudma	olgu sõudnud	V;ACT;PRS;PRF;POS;IMP;PL
 sõudma	oli sõudnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -28318,9 +28318,9 @@ sõudma	ärgu sõudku	V;ACT;PRS;NEG;IMP;3;PL
 sõudma	olgu sõudnud	V;ACT;PRS;PRF;POS;IMP;SG
 sõudma	sõueti	V;PASS;PST;POS;IND
 sõudma	ei sõudvat	V;ACT;PRS;NEG;QUOT
-sõudma	ei oleks sõuetudp	V;PASS;PRS;PRF;NEG;COND
+sõudma	ei oleks sõuetud	V;PASS;PRS;PRF;NEG;COND
 sõudma	ei sõudnud	V;ACT;PST;NEG;IND
-sõudma	ei olevat sõuetudp	V;PASS;PRS;PRF;NEG;QUOT
+sõudma	ei olevat sõuetud	V;PASS;PRS;PRF;NEG;QUOT
 sõudma	ei sõuaks	V;ACT;PRS;PRF;POS;COND;1;SG
 sõudma	sõuetud	V.PTCP;PASS;PST
 sõudma	olid sõudnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -28339,7 +28339,7 @@ sõudma	olgu sõuetud	V;PASS;PRS;PRF;POS;IMP
 sõudma	sõuaks	V;ACT;PRS;POS;COND;3;SG
 sõudma	sõudku	V;ACT;PRS;POS;IMP;3;PL
 sõudma	ärgu olgu sõudnud	V;ACT;PRS;PRF;NEG;IMP;SG
-sõudma	ei ole sõudnudp	V;ACT;PST;NEG;IND
+sõudma	ei ole sõudnud	V;ACT;PST;NEG;IND
 sõudma	sõuad	V;ACT;PRS;POS;IND;2;SG
 sõudma	ära sõua	V;ACT;PRS;NEG;IMP;2;SG
 sõudma	ei sõua	V;ACT;PRS;NEG;IND
@@ -28367,21 +28367,21 @@ sõudma	ei sõueta	V;PASS;PRS;NEG;IND
 sõudma	sõuame	V;ACT;PRS;POS;IND;1;PL
 sõudma	sõuan	V;ACT;PRS;POS;IND;1;SG
 sõudma	ärgem sõudkem	V;ACT;PRS;NEG;IMP;1;PL
-sõudma	ei oleks sõudnudp	V;ACT;PRS;PRF;NEG;COND
+sõudma	ei oleks sõudnud	V;ACT;PRS;PRF;NEG;COND
 sõudma	oleksid sõudnud	V;ACT;PRS;PRF;POS;COND;3;PL
 sõudma	sõudsite	V;ACT;PST;POS;IND;2;PL
 sõudma	oleks sõudnud	V;ACT;PRS;PRF;POS;COND;3;SG
 sõudma	olin sõudnud	V;ACT;PRS;PRF;POS;COND;1;SG
 sõudma	oled sõudnud	V;ACT;PRS;PRF;POS;IND;2;SG
 sõudma	oli sõudnud	V;ACT;PRS;PRF;POS;COND;3;SG
-sõudma	ei ole sõuetudp	V;PASS;PRS;PRF;NEG;IND
+sõudma	ei ole sõuetud	V;PASS;PRS;PRF;NEG;IND
 sõudma	sõuaksin	V;ACT;PRS;POS;COND;1;SG
 sõudma	olen sõudnud	V;ACT;PRS;PRF;POS;IND;1;SG
-sõudma	ei olnud sõuetudp	V;PASS;PST;PRF;NEG;IND
+sõudma	ei olnud sõuetud	V;PASS;PST;PRF;NEG;IND
 sõudma	ärgu olgu sõuetud	V;PASS;PRS;PRF;NEG;IMP
 
 sööma	olete söönud	V;ACT;PRS;PRF;POS;IND;2;PL
-sööma	ei olevat söönudp	V;ACT;PRS;PRF;NEG;QUOT
+sööma	ei olevat söönud	V;ACT;PRS;PRF;NEG;QUOT
 sööma	oleks söödud	V;PASS;PRS;PRF;POS;COND
 sööma	sõin	V;ACT;PST;POS;IND;1;SG
 sööma	süüakse	V;PASS;PRS;POS;IND
@@ -28390,7 +28390,7 @@ sööma	söödagu	V;PASS;PRS;POS;IMP
 sööma	ärgu söögu	V;ACT;PRS;NEG;IMP;3;SG
 sööma	oli söödud	V;PASS;PST;PRF;POS;IND
 sööma	sõime	V;ACT;PST;POS;IND;1;PL
-sööma	ei olnud söönudp	V;ACT;PST;PRF;NEG;IND
+sööma	ei olnud söönud	V;ACT;PST;PRF;NEG;IND
 sööma	oleksid söönud	V;ACT;PRS;PRF;POS;COND;2;SG
 sööma	olgu söönud	V;ACT;PRS;PRF;POS;IMP;PL
 sööma	oli söönud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -28404,9 +28404,9 @@ sööma	ärgu söögu	V;ACT;PRS;NEG;IMP;3;PL
 sööma	olgu söönud	V;ACT;PRS;PRF;POS;IMP;SG
 sööma	söödi	V;PASS;PST;POS;IND
 sööma	ei söövat	V;ACT;PRS;NEG;QUOT
-sööma	ei oleks söödudp	V;PASS;PRS;PRF;NEG;COND
+sööma	ei oleks söödud	V;PASS;PRS;PRF;NEG;COND
 sööma	ei söönud	V;ACT;PST;NEG;IND
-sööma	ei olevat söödudp	V;PASS;PRS;PRF;NEG;QUOT
+sööma	ei olevat söödud	V;PASS;PRS;PRF;NEG;QUOT
 sööma	ei sööks	V;ACT;PRS;PRF;POS;COND;1;SG
 sööma	söödud	V.PTCP;PASS;PST
 sööma	olid söönud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -28425,7 +28425,7 @@ sööma	olgu söödud	V;PASS;PRS;PRF;POS;IMP
 sööma	sööks	V;ACT;PRS;POS;COND;3;SG
 sööma	söögu	V;ACT;PRS;POS;IMP;3;PL
 sööma	ärgu olgu söönud	V;ACT;PRS;PRF;NEG;IMP;SG
-sööma	ei ole söönudp	V;ACT;PST;NEG;IND
+sööma	ei ole söönud	V;ACT;PST;NEG;IND
 sööma	sööd	V;ACT;PRS;POS;IND;2;SG
 sööma	ära söö	V;ACT;PRS;NEG;IMP;2;SG
 sööma	ei söö	V;ACT;PRS;NEG;IND
@@ -28453,17 +28453,17 @@ sööma	ei sööda	V;PASS;PRS;NEG;IND
 sööma	sööme	V;ACT;PRS;POS;IND;1;PL
 sööma	söön	V;ACT;PRS;POS;IND;1;SG
 sööma	ärgem söögem	V;ACT;PRS;NEG;IMP;1;PL
-sööma	ei oleks söönudp	V;ACT;PRS;PRF;NEG;COND
+sööma	ei oleks söönud	V;ACT;PRS;PRF;NEG;COND
 sööma	oleksid söönud	V;ACT;PRS;PRF;POS;COND;3;PL
 sööma	sõite	V;ACT;PST;POS;IND;2;PL
 sööma	oleks söönud	V;ACT;PRS;PRF;POS;COND;3;SG
 sööma	olin söönud	V;ACT;PRS;PRF;POS;COND;1;SG
 sööma	oled söönud	V;ACT;PRS;PRF;POS;IND;2;SG
 sööma	oli söönud	V;ACT;PRS;PRF;POS;COND;3;SG
-sööma	ei ole söödudp	V;PASS;PRS;PRF;NEG;IND
+sööma	ei ole söödud	V;PASS;PRS;PRF;NEG;IND
 sööma	sööksin	V;ACT;PRS;POS;COND;1;SG
 sööma	olen söönud	V;ACT;PRS;PRF;POS;IND;1;SG
-sööma	ei olnud söödudp	V;PASS;PST;PRF;NEG;IND
+sööma	ei olnud söödud	V;PASS;PST;PRF;NEG;IND
 sööma	ärgu olgu söödud	V;PASS;PRS;PRF;NEG;IMP
 
 süda	südameni	N;TERM;SG
@@ -28591,7 +28591,7 @@ sümptom	sümptomitesse	N;IN+ALL;PL
 sümptom	sümptomitelt	N;AT+ABL;PL
 
 sündima	olete sündinud	V;ACT;PRS;PRF;POS;IND;2;PL
-sündima	ei olevat sündinudp	V;ACT;PRS;PRF;NEG;QUOT
+sündima	ei olevat sündinud	V;ACT;PRS;PRF;NEG;QUOT
 sündima	oleks sünnitud	V;PASS;PRS;PRF;POS;COND
 sündima	sündisin	V;ACT;PST;POS;IND;1;SG
 sündima	sünnitakse	V;PASS;PRS;POS;IND
@@ -28600,7 +28600,7 @@ sündima	sünnitagu	V;PASS;PRS;POS;IMP
 sündima	ärgu sündigu	V;ACT;PRS;NEG;IMP;3;SG
 sündima	oli sünnitud	V;PASS;PST;PRF;POS;IND
 sündima	sündisime	V;ACT;PST;POS;IND;1;PL
-sündima	ei olnud sündinudp	V;ACT;PST;PRF;NEG;IND
+sündima	ei olnud sündinud	V;ACT;PST;PRF;NEG;IND
 sündima	oleksid sündinud	V;ACT;PRS;PRF;POS;COND;2;SG
 sündima	olgu sündinud	V;ACT;PRS;PRF;POS;IMP;PL
 sündima	oli sündinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -28614,9 +28614,9 @@ sündima	ärgu sündigu	V;ACT;PRS;NEG;IMP;3;PL
 sündima	olgu sündinud	V;ACT;PRS;PRF;POS;IMP;SG
 sündima	sünniti	V;PASS;PST;POS;IND
 sündima	ei sündivat	V;ACT;PRS;NEG;QUOT
-sündima	ei oleks sünnitudp	V;PASS;PRS;PRF;NEG;COND
+sündima	ei oleks sünnitud	V;PASS;PRS;PRF;NEG;COND
 sündima	ei sündinud	V;ACT;PST;NEG;IND
-sündima	ei olevat sünnitudp	V;PASS;PRS;PRF;NEG;QUOT
+sündima	ei olevat sünnitud	V;PASS;PRS;PRF;NEG;QUOT
 sündima	ei sünniks	V;ACT;PRS;PRF;POS;COND;1;SG
 sündima	sünnitud	V.PTCP;PASS;PST
 sündima	olid sündinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -28635,7 +28635,7 @@ sündima	olgu sünnitud	V;PASS;PRS;PRF;POS;IMP
 sündima	sünniks	V;ACT;PRS;POS;COND;3;SG
 sündima	sündigu	V;ACT;PRS;POS;IMP;3;PL
 sündima	ärgu olgu sündinud	V;ACT;PRS;PRF;NEG;IMP;SG
-sündima	ei ole sündinudp	V;ACT;PST;NEG;IND
+sündima	ei ole sündinud	V;ACT;PST;NEG;IND
 sündima	sünnid	V;ACT;PRS;POS;IND;2;SG
 sündima	ära sünni	V;ACT;PRS;NEG;IMP;2;SG
 sündima	ei sünni	V;ACT;PRS;NEG;IND
@@ -28663,21 +28663,21 @@ sündima	ei sünnita	V;PASS;PRS;NEG;IND
 sündima	sünnime	V;ACT;PRS;POS;IND;1;PL
 sündima	sünnin	V;ACT;PRS;POS;IND;1;SG
 sündima	ärgem sündigem	V;ACT;PRS;NEG;IMP;1;PL
-sündima	ei oleks sündinudp	V;ACT;PRS;PRF;NEG;COND
+sündima	ei oleks sündinud	V;ACT;PRS;PRF;NEG;COND
 sündima	oleksid sündinud	V;ACT;PRS;PRF;POS;COND;3;PL
 sündima	sündisite	V;ACT;PST;POS;IND;2;PL
 sündima	oleks sündinud	V;ACT;PRS;PRF;POS;COND;3;SG
 sündima	olin sündinud	V;ACT;PRS;PRF;POS;COND;1;SG
 sündima	oled sündinud	V;ACT;PRS;PRF;POS;IND;2;SG
 sündima	oli sündinud	V;ACT;PRS;PRF;POS;COND;3;SG
-sündima	ei ole sünnitudp	V;PASS;PRS;PRF;NEG;IND
+sündima	ei ole sünnitud	V;PASS;PRS;PRF;NEG;IND
 sündima	sünniksin	V;ACT;PRS;POS;COND;1;SG
 sündima	olen sündinud	V;ACT;PRS;PRF;POS;IND;1;SG
-sündima	ei olnud sünnitudp	V;PASS;PST;PRF;NEG;IND
+sündima	ei olnud sünnitud	V;PASS;PST;PRF;NEG;IND
 sündima	ärgu olgu sünnitud	V;PASS;PRS;PRF;NEG;IMP
 
 sünnitama	olete sünnitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-sünnitama	ei olevat sünnitanudp	V;ACT;PRS;PRF;NEG;QUOT
+sünnitama	ei olevat sünnitanud	V;ACT;PRS;PRF;NEG;QUOT
 sünnitama	oleks sünnitatud	V;PASS;PRS;PRF;POS;COND
 sünnitama	sünnitasin	V;ACT;PST;POS;IND;1;SG
 sünnitama	sünnitatakse	V;PASS;PRS;POS;IND
@@ -28686,7 +28686,7 @@ sünnitama	sünnitatagu	V;PASS;PRS;POS;IMP
 sünnitama	ärgu sünnitagu	V;ACT;PRS;NEG;IMP;3;SG
 sünnitama	oli sünnitatud	V;PASS;PST;PRF;POS;IND
 sünnitama	sünnitasime	V;ACT;PST;POS;IND;1;PL
-sünnitama	ei olnud sünnitanudp	V;ACT;PST;PRF;NEG;IND
+sünnitama	ei olnud sünnitanud	V;ACT;PST;PRF;NEG;IND
 sünnitama	oleksid sünnitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 sünnitama	olgu sünnitanud	V;ACT;PRS;PRF;POS;IMP;PL
 sünnitama	oli sünnitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -28700,9 +28700,9 @@ sünnitama	ärgu sünnitagu	V;ACT;PRS;NEG;IMP;3;PL
 sünnitama	olgu sünnitanud	V;ACT;PRS;PRF;POS;IMP;SG
 sünnitama	sünnitati	V;PASS;PST;POS;IND
 sünnitama	ei sünnitavat	V;ACT;PRS;NEG;QUOT
-sünnitama	ei oleks sünnitatudp	V;PASS;PRS;PRF;NEG;COND
+sünnitama	ei oleks sünnitatud	V;PASS;PRS;PRF;NEG;COND
 sünnitama	ei sünnitanud	V;ACT;PST;NEG;IND
-sünnitama	ei olevat sünnitatudp	V;PASS;PRS;PRF;NEG;QUOT
+sünnitama	ei olevat sünnitatud	V;PASS;PRS;PRF;NEG;QUOT
 sünnitama	ei sünnitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 sünnitama	sünnitatud	V.PTCP;PASS;PST
 sünnitama	olid sünnitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -28721,7 +28721,7 @@ sünnitama	olgu sünnitatud	V;PASS;PRS;PRF;POS;IMP
 sünnitama	sünnitaks	V;ACT;PRS;POS;COND;3;SG
 sünnitama	sünnitagu	V;ACT;PRS;POS;IMP;3;PL
 sünnitama	ärgu olgu sünnitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-sünnitama	ei ole sünnitanudp	V;ACT;PST;NEG;IND
+sünnitama	ei ole sünnitanud	V;ACT;PST;NEG;IND
 sünnitama	sünnitad	V;ACT;PRS;POS;IND;2;SG
 sünnitama	ära sünnita	V;ACT;PRS;NEG;IMP;2;SG
 sünnitama	ei sünnita	V;ACT;PRS;NEG;IND
@@ -28749,17 +28749,17 @@ sünnitama	ei sünnitata	V;PASS;PRS;NEG;IND
 sünnitama	sünnitame	V;ACT;PRS;POS;IND;1;PL
 sünnitama	sünnitan	V;ACT;PRS;POS;IND;1;SG
 sünnitama	ärgem sünnitagem	V;ACT;PRS;NEG;IMP;1;PL
-sünnitama	ei oleks sünnitanudp	V;ACT;PRS;PRF;NEG;COND
+sünnitama	ei oleks sünnitanud	V;ACT;PRS;PRF;NEG;COND
 sünnitama	oleksid sünnitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 sünnitama	sünnitasite	V;ACT;PST;POS;IND;2;PL
 sünnitama	oleks sünnitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 sünnitama	olin sünnitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 sünnitama	oled sünnitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 sünnitama	oli sünnitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-sünnitama	ei ole sünnitatudp	V;PASS;PRS;PRF;NEG;IND
+sünnitama	ei ole sünnitatud	V;PASS;PRS;PRF;NEG;IND
 sünnitama	sünnitaksin	V;ACT;PRS;POS;COND;1;SG
 sünnitama	olen sünnitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-sünnitama	ei olnud sünnitatudp	V;PASS;PST;PRF;NEG;IND
+sünnitama	ei olnud sünnitatud	V;PASS;PST;PRF;NEG;IND
 sünnitama	ärgu olgu sünnitatud	V;PASS;PRS;PRF;NEG;IMP
 
 sünoptik	sünoptikuni	N;TERM;SG
@@ -28856,7 +28856,7 @@ taanlane	taanlastesse	N;IN+ALL;PL
 taanlane	taanlastelt	N;AT+ABL;PL
 
 tahtma	olete tahtnud	V;ACT;PRS;PRF;POS;IND;2;PL
-tahtma	ei olevat tahtnudp	V;ACT;PRS;PRF;NEG;QUOT
+tahtma	ei olevat tahtnud	V;ACT;PRS;PRF;NEG;QUOT
 tahtma	oleks tahetud	V;PASS;PRS;PRF;POS;COND
 tahtma	tahtsin	V;ACT;PST;POS;IND;1;SG
 tahtma	tahetakse	V;PASS;PRS;POS;IND
@@ -28865,7 +28865,7 @@ tahtma	tahetagu	V;PASS;PRS;POS;IMP
 tahtma	ärgu tahtku	V;ACT;PRS;NEG;IMP;3;SG
 tahtma	oli tahetud	V;PASS;PST;PRF;POS;IND
 tahtma	tahtsime	V;ACT;PST;POS;IND;1;PL
-tahtma	ei olnud tahtnudp	V;ACT;PST;PRF;NEG;IND
+tahtma	ei olnud tahtnud	V;ACT;PST;PRF;NEG;IND
 tahtma	oleksid tahtnud	V;ACT;PRS;PRF;POS;COND;2;SG
 tahtma	olgu tahtnud	V;ACT;PRS;PRF;POS;IMP;PL
 tahtma	oli tahtnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -28879,9 +28879,9 @@ tahtma	ärgu tahtku	V;ACT;PRS;NEG;IMP;3;PL
 tahtma	olgu tahtnud	V;ACT;PRS;PRF;POS;IMP;SG
 tahtma	taheti	V;PASS;PST;POS;IND
 tahtma	ei tahtvat	V;ACT;PRS;NEG;QUOT
-tahtma	ei oleks tahetudp	V;PASS;PRS;PRF;NEG;COND
+tahtma	ei oleks tahetud	V;PASS;PRS;PRF;NEG;COND
 tahtma	ei tahtnud	V;ACT;PST;NEG;IND
-tahtma	ei olevat tahetudp	V;PASS;PRS;PRF;NEG;QUOT
+tahtma	ei olevat tahetud	V;PASS;PRS;PRF;NEG;QUOT
 tahtma	ei tahaks	V;ACT;PRS;PRF;POS;COND;1;SG
 tahtma	tahetud	V.PTCP;PASS;PST
 tahtma	olid tahtnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -28900,7 +28900,7 @@ tahtma	olgu tahetud	V;PASS;PRS;PRF;POS;IMP
 tahtma	tahaks	V;ACT;PRS;POS;COND;3;SG
 tahtma	tahtku	V;ACT;PRS;POS;IMP;3;PL
 tahtma	ärgu olgu tahtnud	V;ACT;PRS;PRF;NEG;IMP;SG
-tahtma	ei ole tahtnudp	V;ACT;PST;NEG;IND
+tahtma	ei ole tahtnud	V;ACT;PST;NEG;IND
 tahtma	tahad	V;ACT;PRS;POS;IND;2;SG
 tahtma	ära taha	V;ACT;PRS;NEG;IMP;2;SG
 tahtma	ei taha	V;ACT;PRS;NEG;IND
@@ -28928,17 +28928,17 @@ tahtma	ei taheta	V;PASS;PRS;NEG;IND
 tahtma	tahame	V;ACT;PRS;POS;IND;1;PL
 tahtma	tahan	V;ACT;PRS;POS;IND;1;SG
 tahtma	ärgem tahtkem	V;ACT;PRS;NEG;IMP;1;PL
-tahtma	ei oleks tahtnudp	V;ACT;PRS;PRF;NEG;COND
+tahtma	ei oleks tahtnud	V;ACT;PRS;PRF;NEG;COND
 tahtma	oleksid tahtnud	V;ACT;PRS;PRF;POS;COND;3;PL
 tahtma	tahtsite	V;ACT;PST;POS;IND;2;PL
 tahtma	oleks tahtnud	V;ACT;PRS;PRF;POS;COND;3;SG
 tahtma	olin tahtnud	V;ACT;PRS;PRF;POS;COND;1;SG
 tahtma	oled tahtnud	V;ACT;PRS;PRF;POS;IND;2;SG
 tahtma	oli tahtnud	V;ACT;PRS;PRF;POS;COND;3;SG
-tahtma	ei ole tahetudp	V;PASS;PRS;PRF;NEG;IND
+tahtma	ei ole tahetud	V;PASS;PRS;PRF;NEG;IND
 tahtma	tahaksin	V;ACT;PRS;POS;COND;1;SG
 tahtma	olen tahtnud	V;ACT;PRS;PRF;POS;IND;1;SG
-tahtma	ei olnud tahetudp	V;PASS;PST;PRF;NEG;IND
+tahtma	ei olnud tahetud	V;PASS;PST;PRF;NEG;IND
 tahtma	ärgu olgu tahetud	V;PASS;PRS;PRF;NEG;IMP
 
 tahvel	tahvlini	N;TERM;SG
@@ -29097,7 +29097,7 @@ tanner	tandritesse	N;IN+ALL;PL
 tanner	tandritelt	N;AT+ABL;PL
 
 tapma	olete tapnud	V;ACT;PRS;PRF;POS;IND;2;PL
-tapma	ei olevat tapnudp	V;ACT;PRS;PRF;NEG;QUOT
+tapma	ei olevat tapnud	V;ACT;PRS;PRF;NEG;QUOT
 tapma	oleks tapetud	V;PASS;PRS;PRF;POS;COND
 tapma	tapsin	V;ACT;PST;POS;IND;1;SG
 tapma	tapetakse	V;PASS;PRS;POS;IND
@@ -29106,7 +29106,7 @@ tapma	tapetagu	V;PASS;PRS;POS;IMP
 tapma	ärgu tapku	V;ACT;PRS;NEG;IMP;3;SG
 tapma	oli tapetud	V;PASS;PST;PRF;POS;IND
 tapma	tapsime	V;ACT;PST;POS;IND;1;PL
-tapma	ei olnud tapnudp	V;ACT;PST;PRF;NEG;IND
+tapma	ei olnud tapnud	V;ACT;PST;PRF;NEG;IND
 tapma	oleksid tapnud	V;ACT;PRS;PRF;POS;COND;2;SG
 tapma	olgu tapnud	V;ACT;PRS;PRF;POS;IMP;PL
 tapma	oli tapnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -29120,9 +29120,9 @@ tapma	ärgu tapku	V;ACT;PRS;NEG;IMP;3;PL
 tapma	olgu tapnud	V;ACT;PRS;PRF;POS;IMP;SG
 tapma	tapeti	V;PASS;PST;POS;IND
 tapma	ei tapvat	V;ACT;PRS;NEG;QUOT
-tapma	ei oleks tapetudp	V;PASS;PRS;PRF;NEG;COND
+tapma	ei oleks tapetud	V;PASS;PRS;PRF;NEG;COND
 tapma	ei tapnud	V;ACT;PST;NEG;IND
-tapma	ei olevat tapetudp	V;PASS;PRS;PRF;NEG;QUOT
+tapma	ei olevat tapetud	V;PASS;PRS;PRF;NEG;QUOT
 tapma	ei tapaks	V;ACT;PRS;PRF;POS;COND;1;SG
 tapma	tapetud	V.PTCP;PASS;PST
 tapma	olid tapnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -29141,7 +29141,7 @@ tapma	olgu tapetud	V;PASS;PRS;PRF;POS;IMP
 tapma	tapaks	V;ACT;PRS;POS;COND;3;SG
 tapma	tapku	V;ACT;PRS;POS;IMP;3;PL
 tapma	ärgu olgu tapnud	V;ACT;PRS;PRF;NEG;IMP;SG
-tapma	ei ole tapnudp	V;ACT;PST;NEG;IND
+tapma	ei ole tapnud	V;ACT;PST;NEG;IND
 tapma	tapad	V;ACT;PRS;POS;IND;2;SG
 tapma	ära tapa	V;ACT;PRS;NEG;IMP;2;SG
 tapma	ei tapa	V;ACT;PRS;NEG;IND
@@ -29169,17 +29169,17 @@ tapma	ei tapeta	V;PASS;PRS;NEG;IND
 tapma	tapame	V;ACT;PRS;POS;IND;1;PL
 tapma	tapan	V;ACT;PRS;POS;IND;1;SG
 tapma	ärgem tapkem	V;ACT;PRS;NEG;IMP;1;PL
-tapma	ei oleks tapnudp	V;ACT;PRS;PRF;NEG;COND
+tapma	ei oleks tapnud	V;ACT;PRS;PRF;NEG;COND
 tapma	oleksid tapnud	V;ACT;PRS;PRF;POS;COND;3;PL
 tapma	tapsite	V;ACT;PST;POS;IND;2;PL
 tapma	oleks tapnud	V;ACT;PRS;PRF;POS;COND;3;SG
 tapma	olin tapnud	V;ACT;PRS;PRF;POS;COND;1;SG
 tapma	oled tapnud	V;ACT;PRS;PRF;POS;IND;2;SG
 tapma	oli tapnud	V;ACT;PRS;PRF;POS;COND;3;SG
-tapma	ei ole tapetudp	V;PASS;PRS;PRF;NEG;IND
+tapma	ei ole tapetud	V;PASS;PRS;PRF;NEG;IND
 tapma	tapaksin	V;ACT;PRS;POS;COND;1;SG
 tapma	olen tapnud	V;ACT;PRS;PRF;POS;IND;1;SG
-tapma	ei olnud tapetudp	V;PASS;PST;PRF;NEG;IND
+tapma	ei olnud tapetud	V;PASS;PST;PRF;NEG;IND
 tapma	ärgu olgu tapetud	V;PASS;PRS;PRF;NEG;IMP
 
 tarkvara	tarkvarani	N;TERM;SG
@@ -29245,7 +29245,7 @@ teadlane	teadlastesse	N;IN+ALL;PL
 teadlane	teadlastelt	N;AT+ABL;PL
 
 teadma	olete teadnud	V;ACT;PRS;PRF;POS;IND;2;PL
-teadma	ei olevat teadnudp	V;ACT;PRS;PRF;NEG;QUOT
+teadma	ei olevat teadnud	V;ACT;PRS;PRF;NEG;QUOT
 teadma	oleks teatud	V;PASS;PRS;PRF;POS;COND
 teadma	teadsin	V;ACT;PST;POS;IND;1;SG
 teadma	teatakse	V;PASS;PRS;POS;IND
@@ -29254,7 +29254,7 @@ teadma	teatagu	V;PASS;PRS;POS;IMP
 teadma	ärgu teadku	V;ACT;PRS;NEG;IMP;3;SG
 teadma	oli teatud	V;PASS;PST;PRF;POS;IND
 teadma	teadsime	V;ACT;PST;POS;IND;1;PL
-teadma	ei olnud teadnudp	V;ACT;PST;PRF;NEG;IND
+teadma	ei olnud teadnud	V;ACT;PST;PRF;NEG;IND
 teadma	oleksid teadnud	V;ACT;PRS;PRF;POS;COND;2;SG
 teadma	olgu teadnud	V;ACT;PRS;PRF;POS;IMP;PL
 teadma	oli teadnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -29268,9 +29268,9 @@ teadma	ärgu teadku	V;ACT;PRS;NEG;IMP;3;PL
 teadma	olgu teadnud	V;ACT;PRS;PRF;POS;IMP;SG
 teadma	teati	V;PASS;PST;POS;IND
 teadma	ei teadvat	V;ACT;PRS;NEG;QUOT
-teadma	ei oleks teatudp	V;PASS;PRS;PRF;NEG;COND
+teadma	ei oleks teatud	V;PASS;PRS;PRF;NEG;COND
 teadma	ei teadnud	V;ACT;PST;NEG;IND
-teadma	ei olevat teatudp	V;PASS;PRS;PRF;NEG;QUOT
+teadma	ei olevat teatud	V;PASS;PRS;PRF;NEG;QUOT
 teadma	ei teaks	V;ACT;PRS;PRF;POS;COND;1;SG
 teadma	teatud	V.PTCP;PASS;PST
 teadma	olid teadnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -29289,7 +29289,7 @@ teadma	olgu teatud	V;PASS;PRS;PRF;POS;IMP
 teadma	teaks	V;ACT;PRS;POS;COND;3;SG
 teadma	teadku	V;ACT;PRS;POS;IMP;3;PL
 teadma	ärgu olgu teadnud	V;ACT;PRS;PRF;NEG;IMP;SG
-teadma	ei ole teadnudp	V;ACT;PST;NEG;IND
+teadma	ei ole teadnud	V;ACT;PST;NEG;IND
 teadma	tead	V;ACT;PRS;POS;IND;2;SG
 teadma	ära tea	V;ACT;PRS;NEG;IMP;2;SG
 teadma	ei tea	V;ACT;PRS;NEG;IND
@@ -29317,17 +29317,17 @@ teadma	ei teata	V;PASS;PRS;NEG;IND
 teadma	teame	V;ACT;PRS;POS;IND;1;PL
 teadma	tean	V;ACT;PRS;POS;IND;1;SG
 teadma	ärgem teadkem	V;ACT;PRS;NEG;IMP;1;PL
-teadma	ei oleks teadnudp	V;ACT;PRS;PRF;NEG;COND
+teadma	ei oleks teadnud	V;ACT;PRS;PRF;NEG;COND
 teadma	oleksid teadnud	V;ACT;PRS;PRF;POS;COND;3;PL
 teadma	teadsite	V;ACT;PST;POS;IND;2;PL
 teadma	oleks teadnud	V;ACT;PRS;PRF;POS;COND;3;SG
 teadma	olin teadnud	V;ACT;PRS;PRF;POS;COND;1;SG
 teadma	oled teadnud	V;ACT;PRS;PRF;POS;IND;2;SG
 teadma	oli teadnud	V;ACT;PRS;PRF;POS;COND;3;SG
-teadma	ei ole teatudp	V;PASS;PRS;PRF;NEG;IND
+teadma	ei ole teatud	V;PASS;PRS;PRF;NEG;IND
 teadma	teaksin	V;ACT;PRS;POS;COND;1;SG
 teadma	olen teadnud	V;ACT;PRS;PRF;POS;IND;1;SG
-teadma	ei olnud teatudp	V;PASS;PST;PRF;NEG;IND
+teadma	ei olnud teatud	V;PASS;PST;PRF;NEG;IND
 teadma	ärgu olgu teatud	V;PASS;PRS;PRF;NEG;IMP
 
 teadmine	teadmiseni	N;TERM;SG
@@ -29424,7 +29424,7 @@ tegelik	tegelikesse	N;IN+ALL;PL
 tegelik	tegelikelt	N;AT+ABL;PL
 
 tegema	olete teinud	V;ACT;PRS;PRF;POS;IND;2;PL
-tegema	ei olevat teinudp	V;ACT;PRS;PRF;NEG;QUOT
+tegema	ei olevat teinud	V;ACT;PRS;PRF;NEG;QUOT
 tegema	oleks tehtud	V;PASS;PRS;PRF;POS;COND
 tegema	tegin	V;ACT;PST;POS;IND;1;SG
 tegema	tehakse	V;PASS;PRS;POS;IND
@@ -29433,7 +29433,7 @@ tegema	tehtagu	V;PASS;PRS;POS;IMP
 tegema	ärgu tehku	V;ACT;PRS;NEG;IMP;3;SG
 tegema	oli tehtud	V;PASS;PST;PRF;POS;IND
 tegema	tegime	V;ACT;PST;POS;IND;1;PL
-tegema	ei olnud teinudp	V;ACT;PST;PRF;NEG;IND
+tegema	ei olnud teinud	V;ACT;PST;PRF;NEG;IND
 tegema	oleksid teinud	V;ACT;PRS;PRF;POS;COND;2;SG
 tegema	olgu teinud	V;ACT;PRS;PRF;POS;IMP;PL
 tegema	oli teinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -29447,9 +29447,9 @@ tegema	ärgu tehku	V;ACT;PRS;NEG;IMP;3;PL
 tegema	olgu teinud	V;ACT;PRS;PRF;POS;IMP;SG
 tegema	tehti	V;PASS;PST;POS;IND
 tegema	ei tegevat	V;ACT;PRS;NEG;QUOT
-tegema	ei oleks tehtudp	V;PASS;PRS;PRF;NEG;COND
+tegema	ei oleks tehtud	V;PASS;PRS;PRF;NEG;COND
 tegema	ei teinud	V;ACT;PST;NEG;IND
-tegema	ei olevat tehtudp	V;PASS;PRS;PRF;NEG;QUOT
+tegema	ei olevat tehtud	V;PASS;PRS;PRF;NEG;QUOT
 tegema	ei teeks	V;ACT;PRS;PRF;POS;COND;1;SG
 tegema	tehtud	V.PTCP;PASS;PST
 tegema	olid teinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -29468,7 +29468,7 @@ tegema	olgu tehtud	V;PASS;PRS;PRF;POS;IMP
 tegema	teeks	V;ACT;PRS;POS;COND;3;SG
 tegema	tehku	V;ACT;PRS;POS;IMP;3;PL
 tegema	ärgu olgu teinud	V;ACT;PRS;PRF;NEG;IMP;SG
-tegema	ei ole teinudp	V;ACT;PST;NEG;IND
+tegema	ei ole teinud	V;ACT;PST;NEG;IND
 tegema	teed	V;ACT;PRS;POS;IND;2;SG
 tegema	ära tee	V;ACT;PRS;NEG;IMP;2;SG
 tegema	ei tee	V;ACT;PRS;NEG;IND
@@ -29496,17 +29496,17 @@ tegema	ei tehta	V;PASS;PRS;NEG;IND
 tegema	teeme	V;ACT;PRS;POS;IND;1;PL
 tegema	teen	V;ACT;PRS;POS;IND;1;SG
 tegema	ärgem tehkem	V;ACT;PRS;NEG;IMP;1;PL
-tegema	ei oleks teinudp	V;ACT;PRS;PRF;NEG;COND
+tegema	ei oleks teinud	V;ACT;PRS;PRF;NEG;COND
 tegema	oleksid teinud	V;ACT;PRS;PRF;POS;COND;3;PL
 tegema	tegite	V;ACT;PST;POS;IND;2;PL
 tegema	oleks teinud	V;ACT;PRS;PRF;POS;COND;3;SG
 tegema	olin teinud	V;ACT;PRS;PRF;POS;COND;1;SG
 tegema	oled teinud	V;ACT;PRS;PRF;POS;IND;2;SG
 tegema	oli teinud	V;ACT;PRS;PRF;POS;COND;3;SG
-tegema	ei ole tehtudp	V;PASS;PRS;PRF;NEG;IND
+tegema	ei ole tehtud	V;PASS;PRS;PRF;NEG;IND
 tegema	teeksin	V;ACT;PRS;POS;COND;1;SG
 tegema	olen teinud	V;ACT;PRS;PRF;POS;IND;1;SG
-tegema	ei olnud tehtudp	V;PASS;PST;PRF;NEG;IND
+tegema	ei olnud tehtud	V;PASS;PST;PRF;NEG;IND
 tegema	ärgu olgu tehtud	V;PASS;PRS;PRF;NEG;IMP
 
 tehneetsium	tehneetsiumini	N;TERM;SG
@@ -29541,7 +29541,7 @@ tehneetsium	tehneetsiumdesse	N;IN+ALL;PL
 tehneetsium	tehneetsiumdelt	N;AT+ABL;PL
 
 teietama	olete teietanud	V;ACT;PRS;PRF;POS;IND;2;PL
-teietama	ei olevat teietanudp	V;ACT;PRS;PRF;NEG;QUOT
+teietama	ei olevat teietanud	V;ACT;PRS;PRF;NEG;QUOT
 teietama	oleks teietatud	V;PASS;PRS;PRF;POS;COND
 teietama	teietasin	V;ACT;PST;POS;IND;1;SG
 teietama	teietatakse	V;PASS;PRS;POS;IND
@@ -29550,7 +29550,7 @@ teietama	teietatagu	V;PASS;PRS;POS;IMP
 teietama	ärgu teietagu	V;ACT;PRS;NEG;IMP;3;SG
 teietama	oli teietatud	V;PASS;PST;PRF;POS;IND
 teietama	teietasime	V;ACT;PST;POS;IND;1;PL
-teietama	ei olnud teietanudp	V;ACT;PST;PRF;NEG;IND
+teietama	ei olnud teietanud	V;ACT;PST;PRF;NEG;IND
 teietama	oleksid teietanud	V;ACT;PRS;PRF;POS;COND;2;SG
 teietama	olgu teietanud	V;ACT;PRS;PRF;POS;IMP;PL
 teietama	oli teietanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -29564,9 +29564,9 @@ teietama	ärgu teietagu	V;ACT;PRS;NEG;IMP;3;PL
 teietama	olgu teietanud	V;ACT;PRS;PRF;POS;IMP;SG
 teietama	teietati	V;PASS;PST;POS;IND
 teietama	ei teietavat	V;ACT;PRS;NEG;QUOT
-teietama	ei oleks teietatudp	V;PASS;PRS;PRF;NEG;COND
+teietama	ei oleks teietatud	V;PASS;PRS;PRF;NEG;COND
 teietama	ei teietanud	V;ACT;PST;NEG;IND
-teietama	ei olevat teietatudp	V;PASS;PRS;PRF;NEG;QUOT
+teietama	ei olevat teietatud	V;PASS;PRS;PRF;NEG;QUOT
 teietama	ei teietaks	V;ACT;PRS;PRF;POS;COND;1;SG
 teietama	teietatud	V.PTCP;PASS;PST
 teietama	olid teietanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -29585,7 +29585,7 @@ teietama	olgu teietatud	V;PASS;PRS;PRF;POS;IMP
 teietama	teietaks	V;ACT;PRS;POS;COND;3;SG
 teietama	teietagu	V;ACT;PRS;POS;IMP;3;PL
 teietama	ärgu olgu teietanud	V;ACT;PRS;PRF;NEG;IMP;SG
-teietama	ei ole teietanudp	V;ACT;PST;NEG;IND
+teietama	ei ole teietanud	V;ACT;PST;NEG;IND
 teietama	teietad	V;ACT;PRS;POS;IND;2;SG
 teietama	ära teieta	V;ACT;PRS;NEG;IMP;2;SG
 teietama	ei teieta	V;ACT;PRS;NEG;IND
@@ -29613,17 +29613,17 @@ teietama	ei teietata	V;PASS;PRS;NEG;IND
 teietama	teietame	V;ACT;PRS;POS;IND;1;PL
 teietama	teietan	V;ACT;PRS;POS;IND;1;SG
 teietama	ärgem teietagem	V;ACT;PRS;NEG;IMP;1;PL
-teietama	ei oleks teietanudp	V;ACT;PRS;PRF;NEG;COND
+teietama	ei oleks teietanud	V;ACT;PRS;PRF;NEG;COND
 teietama	oleksid teietanud	V;ACT;PRS;PRF;POS;COND;3;PL
 teietama	teietasite	V;ACT;PST;POS;IND;2;PL
 teietama	oleks teietanud	V;ACT;PRS;PRF;POS;COND;3;SG
 teietama	olin teietanud	V;ACT;PRS;PRF;POS;COND;1;SG
 teietama	oled teietanud	V;ACT;PRS;PRF;POS;IND;2;SG
 teietama	oli teietanud	V;ACT;PRS;PRF;POS;COND;3;SG
-teietama	ei ole teietatudp	V;PASS;PRS;PRF;NEG;IND
+teietama	ei ole teietatud	V;PASS;PRS;PRF;NEG;IND
 teietama	teietaksin	V;ACT;PRS;POS;COND;1;SG
 teietama	olen teietanud	V;ACT;PRS;PRF;POS;IND;1;SG
-teietama	ei olnud teietatudp	V;PASS;PST;PRF;NEG;IND
+teietama	ei olnud teietatud	V;PASS;PST;PRF;NEG;IND
 teietama	ärgu olgu teietatud	V;PASS;PRS;PRF;NEG;IMP
 
 telefon	telefonini	N;TERM;SG
@@ -29813,7 +29813,7 @@ toimetaja	toimetajatesse	N;IN+ALL;PL
 toimetaja	toimetajatelt	N;AT+ABL;PL
 
 toitma	olete toitnud	V;ACT;PRS;PRF;POS;IND;2;PL
-toitma	ei olevat toitnudp	V;ACT;PRS;PRF;NEG;QUOT
+toitma	ei olevat toitnud	V;ACT;PRS;PRF;NEG;QUOT
 toitma	oleks toidetud	V;PASS;PRS;PRF;POS;COND
 toitma	toitsin	V;ACT;PST;POS;IND;1;SG
 toitma	toidetakse	V;PASS;PRS;POS;IND
@@ -29822,7 +29822,7 @@ toitma	toidetagu	V;PASS;PRS;POS;IMP
 toitma	ärgu toitku	V;ACT;PRS;NEG;IMP;3;SG
 toitma	oli toidetud	V;PASS;PST;PRF;POS;IND
 toitma	toitsime	V;ACT;PST;POS;IND;1;PL
-toitma	ei olnud toitnudp	V;ACT;PST;PRF;NEG;IND
+toitma	ei olnud toitnud	V;ACT;PST;PRF;NEG;IND
 toitma	oleksid toitnud	V;ACT;PRS;PRF;POS;COND;2;SG
 toitma	olgu toitnud	V;ACT;PRS;PRF;POS;IMP;PL
 toitma	oli toitnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -29836,9 +29836,9 @@ toitma	ärgu toitku	V;ACT;PRS;NEG;IMP;3;PL
 toitma	olgu toitnud	V;ACT;PRS;PRF;POS;IMP;SG
 toitma	toideti	V;PASS;PST;POS;IND
 toitma	ei toitvat	V;ACT;PRS;NEG;QUOT
-toitma	ei oleks toidetudp	V;PASS;PRS;PRF;NEG;COND
+toitma	ei oleks toidetud	V;PASS;PRS;PRF;NEG;COND
 toitma	ei toitnud	V;ACT;PST;NEG;IND
-toitma	ei olevat toidetudp	V;PASS;PRS;PRF;NEG;QUOT
+toitma	ei olevat toidetud	V;PASS;PRS;PRF;NEG;QUOT
 toitma	ei toidaks	V;ACT;PRS;PRF;POS;COND;1;SG
 toitma	toidetud	V.PTCP;PASS;PST
 toitma	olid toitnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -29857,7 +29857,7 @@ toitma	olgu toidetud	V;PASS;PRS;PRF;POS;IMP
 toitma	toidaks	V;ACT;PRS;POS;COND;3;SG
 toitma	toitku	V;ACT;PRS;POS;IMP;3;PL
 toitma	ärgu olgu toitnud	V;ACT;PRS;PRF;NEG;IMP;SG
-toitma	ei ole toitnudp	V;ACT;PST;NEG;IND
+toitma	ei ole toitnud	V;ACT;PST;NEG;IND
 toitma	toidad	V;ACT;PRS;POS;IND;2;SG
 toitma	ära toida	V;ACT;PRS;NEG;IMP;2;SG
 toitma	ei toida	V;ACT;PRS;NEG;IND
@@ -29885,17 +29885,17 @@ toitma	ei toideta	V;PASS;PRS;NEG;IND
 toitma	toidame	V;ACT;PRS;POS;IND;1;PL
 toitma	toidan	V;ACT;PRS;POS;IND;1;SG
 toitma	ärgem toitkem	V;ACT;PRS;NEG;IMP;1;PL
-toitma	ei oleks toitnudp	V;ACT;PRS;PRF;NEG;COND
+toitma	ei oleks toitnud	V;ACT;PRS;PRF;NEG;COND
 toitma	oleksid toitnud	V;ACT;PRS;PRF;POS;COND;3;PL
 toitma	toitsite	V;ACT;PST;POS;IND;2;PL
 toitma	oleks toitnud	V;ACT;PRS;PRF;POS;COND;3;SG
 toitma	olin toitnud	V;ACT;PRS;PRF;POS;COND;1;SG
 toitma	oled toitnud	V;ACT;PRS;PRF;POS;IND;2;SG
 toitma	oli toitnud	V;ACT;PRS;PRF;POS;COND;3;SG
-toitma	ei ole toidetudp	V;PASS;PRS;PRF;NEG;IND
+toitma	ei ole toidetud	V;PASS;PRS;PRF;NEG;IND
 toitma	toidaksin	V;ACT;PRS;POS;COND;1;SG
 toitma	olen toitnud	V;ACT;PRS;PRF;POS;IND;1;SG
-toitma	ei olnud toidetudp	V;PASS;PST;PRF;NEG;IND
+toitma	ei olnud toidetud	V;PASS;PST;PRF;NEG;IND
 toitma	ärgu olgu toidetud	V;PASS;PRS;PRF;NEG;IMP
 
 tolmuimeja	tolmuimejani	N;TERM;SG
@@ -29930,7 +29930,7 @@ tolmuimeja	tolmuimejatesse	N;IN+ALL;PL
 tolmuimeja	tolmuimejatelt	N;AT+ABL;PL
 
 tooma	olete toonud	V;ACT;PRS;PRF;POS;IND;2;PL
-tooma	ei olevat toonudp	V;ACT;PRS;PRF;NEG;QUOT
+tooma	ei olevat toonud	V;ACT;PRS;PRF;NEG;QUOT
 tooma	oleks toodud	V;PASS;PRS;PRF;POS;COND
 tooma	tõin	V;ACT;PST;POS;IND;1;SG
 tooma	tuuakse	V;PASS;PRS;POS;IND
@@ -29939,7 +29939,7 @@ tooma	toodagu	V;PASS;PRS;POS;IMP
 tooma	ärgu toogu	V;ACT;PRS;NEG;IMP;3;SG
 tooma	oli toodud	V;PASS;PST;PRF;POS;IND
 tooma	tõime	V;ACT;PST;POS;IND;1;PL
-tooma	ei olnud toonudp	V;ACT;PST;PRF;NEG;IND
+tooma	ei olnud toonud	V;ACT;PST;PRF;NEG;IND
 tooma	oleksid toonud	V;ACT;PRS;PRF;POS;COND;2;SG
 tooma	olgu toonud	V;ACT;PRS;PRF;POS;IMP;PL
 tooma	oli toonud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -29953,9 +29953,9 @@ tooma	ärgu toogu	V;ACT;PRS;NEG;IMP;3;PL
 tooma	olgu toonud	V;ACT;PRS;PRF;POS;IMP;SG
 tooma	toodi	V;PASS;PST;POS;IND
 tooma	ei toovat	V;ACT;PRS;NEG;QUOT
-tooma	ei oleks toodudp	V;PASS;PRS;PRF;NEG;COND
+tooma	ei oleks toodud	V;PASS;PRS;PRF;NEG;COND
 tooma	ei toonud	V;ACT;PST;NEG;IND
-tooma	ei olevat toodudp	V;PASS;PRS;PRF;NEG;QUOT
+tooma	ei olevat toodud	V;PASS;PRS;PRF;NEG;QUOT
 tooma	ei tooks	V;ACT;PRS;PRF;POS;COND;1;SG
 tooma	toodud	V.PTCP;PASS;PST
 tooma	olid toonud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -29974,7 +29974,7 @@ tooma	olgu toodud	V;PASS;PRS;PRF;POS;IMP
 tooma	tooks	V;ACT;PRS;POS;COND;3;SG
 tooma	toogu	V;ACT;PRS;POS;IMP;3;PL
 tooma	ärgu olgu toonud	V;ACT;PRS;PRF;NEG;IMP;SG
-tooma	ei ole toonudp	V;ACT;PST;NEG;IND
+tooma	ei ole toonud	V;ACT;PST;NEG;IND
 tooma	tood	V;ACT;PRS;POS;IND;2;SG
 tooma	ära too	V;ACT;PRS;NEG;IMP;2;SG
 tooma	ei too	V;ACT;PRS;NEG;IND
@@ -30002,17 +30002,17 @@ tooma	ei tooda	V;PASS;PRS;NEG;IND
 tooma	toome	V;ACT;PRS;POS;IND;1;PL
 tooma	toon	V;ACT;PRS;POS;IND;1;SG
 tooma	ärgem toogem	V;ACT;PRS;NEG;IMP;1;PL
-tooma	ei oleks toonudp	V;ACT;PRS;PRF;NEG;COND
+tooma	ei oleks toonud	V;ACT;PRS;PRF;NEG;COND
 tooma	oleksid toonud	V;ACT;PRS;PRF;POS;COND;3;PL
 tooma	tõite	V;ACT;PST;POS;IND;2;PL
 tooma	oleks toonud	V;ACT;PRS;PRF;POS;COND;3;SG
 tooma	olin toonud	V;ACT;PRS;PRF;POS;COND;1;SG
 tooma	oled toonud	V;ACT;PRS;PRF;POS;IND;2;SG
 tooma	oli toonud	V;ACT;PRS;PRF;POS;COND;3;SG
-tooma	ei ole toodudp	V;PASS;PRS;PRF;NEG;IND
+tooma	ei ole toodud	V;PASS;PRS;PRF;NEG;IND
 tooma	tooksin	V;ACT;PRS;POS;COND;1;SG
 tooma	olen toonud	V;ACT;PRS;PRF;POS;IND;1;SG
-tooma	ei olnud toodudp	V;PASS;PST;PRF;NEG;IND
+tooma	ei olnud toodud	V;PASS;PST;PRF;NEG;IND
 tooma	ärgu olgu toodud	V;PASS;PRS;PRF;NEG;IMP
 
 toomingas	toomingani	N;TERM;SG
@@ -30481,7 +30481,7 @@ tulekahju	tulekahjudesse	N;IN+ALL;PL
 tulekahju	tulekahjudelt	N;AT+ABL;PL
 
 tulema	olete tulnud	V;ACT;PRS;PRF;POS;IND;2;PL
-tulema	ei olevat tulnudp	V;ACT;PRS;PRF;NEG;QUOT
+tulema	ei olevat tulnud	V;ACT;PRS;PRF;NEG;QUOT
 tulema	oleks tuldud	V;PASS;PRS;PRF;POS;COND
 tulema	tulin	V;ACT;PST;POS;IND;1;SG
 tulema	tullakse	V;PASS;PRS;POS;IND
@@ -30490,7 +30490,7 @@ tulema	tuldagu	V;PASS;PRS;POS;IMP
 tulema	ärgu tulgu	V;ACT;PRS;NEG;IMP;3;SG
 tulema	oli tuldud	V;PASS;PST;PRF;POS;IND
 tulema	tulime	V;ACT;PST;POS;IND;1;PL
-tulema	ei olnud tulnudp	V;ACT;PST;PRF;NEG;IND
+tulema	ei olnud tulnud	V;ACT;PST;PRF;NEG;IND
 tulema	oleksid tulnud	V;ACT;PRS;PRF;POS;COND;2;SG
 tulema	olgu tulnud	V;ACT;PRS;PRF;POS;IMP;PL
 tulema	oli tulnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -30504,9 +30504,9 @@ tulema	ärgu tulgu	V;ACT;PRS;NEG;IMP;3;PL
 tulema	olgu tulnud	V;ACT;PRS;PRF;POS;IMP;SG
 tulema	tuldi	V;PASS;PST;POS;IND
 tulema	ei tulevat	V;ACT;PRS;NEG;QUOT
-tulema	ei oleks tuldudp	V;PASS;PRS;PRF;NEG;COND
+tulema	ei oleks tuldud	V;PASS;PRS;PRF;NEG;COND
 tulema	ei tulnud	V;ACT;PST;NEG;IND
-tulema	ei olevat tuldudp	V;PASS;PRS;PRF;NEG;QUOT
+tulema	ei olevat tuldud	V;PASS;PRS;PRF;NEG;QUOT
 tulema	ei tuleks	V;ACT;PRS;PRF;POS;COND;1;SG
 tulema	tuldud	V.PTCP;PASS;PST
 tulema	olid tulnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -30525,7 +30525,7 @@ tulema	olgu tuldud	V;PASS;PRS;PRF;POS;IMP
 tulema	tuleks	V;ACT;PRS;POS;COND;3;SG
 tulema	tulgu	V;ACT;PRS;POS;IMP;3;PL
 tulema	ärgu olgu tulnud	V;ACT;PRS;PRF;NEG;IMP;SG
-tulema	ei ole tulnudp	V;ACT;PST;NEG;IND
+tulema	ei ole tulnud	V;ACT;PST;NEG;IND
 tulema	tuled	V;ACT;PRS;POS;IND;2;SG
 tulema	ära tule	V;ACT;PRS;NEG;IMP;2;SG
 tulema	ei tule	V;ACT;PRS;NEG;IND
@@ -30553,17 +30553,17 @@ tulema	ei tulda	V;PASS;PRS;NEG;IND
 tulema	tuleme	V;ACT;PRS;POS;IND;1;PL
 tulema	tulen	V;ACT;PRS;POS;IND;1;SG
 tulema	ärgem tulgem	V;ACT;PRS;NEG;IMP;1;PL
-tulema	ei oleks tulnudp	V;ACT;PRS;PRF;NEG;COND
+tulema	ei oleks tulnud	V;ACT;PRS;PRF;NEG;COND
 tulema	oleksid tulnud	V;ACT;PRS;PRF;POS;COND;3;PL
 tulema	tulite	V;ACT;PST;POS;IND;2;PL
 tulema	oleks tulnud	V;ACT;PRS;PRF;POS;COND;3;SG
 tulema	olin tulnud	V;ACT;PRS;PRF;POS;COND;1;SG
 tulema	oled tulnud	V;ACT;PRS;PRF;POS;IND;2;SG
 tulema	oli tulnud	V;ACT;PRS;PRF;POS;COND;3;SG
-tulema	ei ole tuldudp	V;PASS;PRS;PRF;NEG;IND
+tulema	ei ole tuldud	V;PASS;PRS;PRF;NEG;IND
 tulema	tuleksin	V;ACT;PRS;POS;COND;1;SG
 tulema	olen tulnud	V;ACT;PRS;PRF;POS;IND;1;SG
-tulema	ei olnud tuldudp	V;PASS;PST;PRF;NEG;IND
+tulema	ei olnud tuldud	V;PASS;PST;PRF;NEG;IND
 tulema	ärgu olgu tuldud	V;PASS;PRS;PRF;NEG;IMP
 
 tuletis	tuletiseni	N;TERM;SG
@@ -30629,7 +30629,7 @@ tuletõrjuja	tuletõrjujatesse	N;IN+ALL;PL
 tuletõrjuja	tuletõrjujatelt	N;AT+ABL;PL
 
 tundma	olete tundnud	V;ACT;PRS;PRF;POS;IND;2;PL
-tundma	ei olevat tundnudp	V;ACT;PRS;PRF;NEG;QUOT
+tundma	ei olevat tundnud	V;ACT;PRS;PRF;NEG;QUOT
 tundma	oleks tunnetud	V;PASS;PRS;PRF;POS;COND
 tundma	tundsin	V;ACT;PST;POS;IND;1;SG
 tundma	tunnetakse	V;PASS;PRS;POS;IND
@@ -30638,7 +30638,7 @@ tundma	tunnetagu	V;PASS;PRS;POS;IMP
 tundma	ärgu tundku	V;ACT;PRS;NEG;IMP;3;SG
 tundma	oli tunnetud	V;PASS;PST;PRF;POS;IND
 tundma	tundsime	V;ACT;PST;POS;IND;1;PL
-tundma	ei olnud tundnudp	V;ACT;PST;PRF;NEG;IND
+tundma	ei olnud tundnud	V;ACT;PST;PRF;NEG;IND
 tundma	oleksid tundnud	V;ACT;PRS;PRF;POS;COND;2;SG
 tundma	olgu tundnud	V;ACT;PRS;PRF;POS;IMP;PL
 tundma	oli tundnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -30652,9 +30652,9 @@ tundma	ärgu tundku	V;ACT;PRS;NEG;IMP;3;PL
 tundma	olgu tundnud	V;ACT;PRS;PRF;POS;IMP;SG
 tundma	tunneti	V;PASS;PST;POS;IND
 tundma	ei tundvat	V;ACT;PRS;NEG;QUOT
-tundma	ei oleks tunnetudp	V;PASS;PRS;PRF;NEG;COND
+tundma	ei oleks tunnetud	V;PASS;PRS;PRF;NEG;COND
 tundma	ei tundnud	V;ACT;PST;NEG;IND
-tundma	ei olevat tunnetudp	V;PASS;PRS;PRF;NEG;QUOT
+tundma	ei olevat tunnetud	V;PASS;PRS;PRF;NEG;QUOT
 tundma	ei tunneks	V;ACT;PRS;PRF;POS;COND;1;SG
 tundma	tunnetud	V.PTCP;PASS;PST
 tundma	olid tundnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -30673,7 +30673,7 @@ tundma	olgu tunnetud	V;PASS;PRS;PRF;POS;IMP
 tundma	tunneks	V;ACT;PRS;POS;COND;3;SG
 tundma	tundku	V;ACT;PRS;POS;IMP;3;PL
 tundma	ärgu olgu tundnud	V;ACT;PRS;PRF;NEG;IMP;SG
-tundma	ei ole tundnudp	V;ACT;PST;NEG;IND
+tundma	ei ole tundnud	V;ACT;PST;NEG;IND
 tundma	tunned	V;ACT;PRS;POS;IND;2;SG
 tundma	ära tunne	V;ACT;PRS;NEG;IMP;2;SG
 tundma	ei tunne	V;ACT;PRS;NEG;IND
@@ -30701,17 +30701,17 @@ tundma	ei tunneta	V;PASS;PRS;NEG;IND
 tundma	tunneme	V;ACT;PRS;POS;IND;1;PL
 tundma	tunnen	V;ACT;PRS;POS;IND;1;SG
 tundma	ärgem tundkem	V;ACT;PRS;NEG;IMP;1;PL
-tundma	ei oleks tundnudp	V;ACT;PRS;PRF;NEG;COND
+tundma	ei oleks tundnud	V;ACT;PRS;PRF;NEG;COND
 tundma	oleksid tundnud	V;ACT;PRS;PRF;POS;COND;3;PL
 tundma	tundsite	V;ACT;PST;POS;IND;2;PL
 tundma	oleks tundnud	V;ACT;PRS;PRF;POS;COND;3;SG
 tundma	olin tundnud	V;ACT;PRS;PRF;POS;COND;1;SG
 tundma	oled tundnud	V;ACT;PRS;PRF;POS;IND;2;SG
 tundma	oli tundnud	V;ACT;PRS;PRF;POS;COND;3;SG
-tundma	ei ole tunnetudp	V;PASS;PRS;PRF;NEG;IND
+tundma	ei ole tunnetud	V;PASS;PRS;PRF;NEG;IND
 tundma	tunneksin	V;ACT;PRS;POS;COND;1;SG
 tundma	olen tundnud	V;ACT;PRS;PRF;POS;IND;1;SG
-tundma	ei olnud tunnetudp	V;PASS;PST;PRF;NEG;IND
+tundma	ei olnud tunnetud	V;PASS;PST;PRF;NEG;IND
 tundma	ärgu olgu tunnetud	V;PASS;PRS;PRF;NEG;IMP
 
 tuulium	tuuliumini	N;TERM;SG
@@ -30808,7 +30808,7 @@ ameeriklane	ameeriklastesse	N;IN+ALL;PL
 ameeriklane	ameeriklastelt	N;AT+ABL;PL
 
 tähendama	olete tähendanud	V;ACT;PRS;PRF;POS;IND;2;PL
-tähendama	ei olevat tähendanudp	V;ACT;PRS;PRF;NEG;QUOT
+tähendama	ei olevat tähendanud	V;ACT;PRS;PRF;NEG;QUOT
 tähendama	oleks tähendatud	V;PASS;PRS;PRF;POS;COND
 tähendama	tähendasin	V;ACT;PST;POS;IND;1;SG
 tähendama	tähendatakse	V;PASS;PRS;POS;IND
@@ -30817,7 +30817,7 @@ tähendama	tähendatagu	V;PASS;PRS;POS;IMP
 tähendama	ärgu tähendagu	V;ACT;PRS;NEG;IMP;3;SG
 tähendama	oli tähendatud	V;PASS;PST;PRF;POS;IND
 tähendama	tähendasime	V;ACT;PST;POS;IND;1;PL
-tähendama	ei olnud tähendanudp	V;ACT;PST;PRF;NEG;IND
+tähendama	ei olnud tähendanud	V;ACT;PST;PRF;NEG;IND
 tähendama	oleksid tähendanud	V;ACT;PRS;PRF;POS;COND;2;SG
 tähendama	olgu tähendanud	V;ACT;PRS;PRF;POS;IMP;PL
 tähendama	oli tähendanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -30831,9 +30831,9 @@ tähendama	ärgu tähendagu	V;ACT;PRS;NEG;IMP;3;PL
 tähendama	olgu tähendanud	V;ACT;PRS;PRF;POS;IMP;SG
 tähendama	tähendati	V;PASS;PST;POS;IND
 tähendama	ei tähendavat	V;ACT;PRS;NEG;QUOT
-tähendama	ei oleks tähendatudp	V;PASS;PRS;PRF;NEG;COND
+tähendama	ei oleks tähendatud	V;PASS;PRS;PRF;NEG;COND
 tähendama	ei tähendanud	V;ACT;PST;NEG;IND
-tähendama	ei olevat tähendatudp	V;PASS;PRS;PRF;NEG;QUOT
+tähendama	ei olevat tähendatud	V;PASS;PRS;PRF;NEG;QUOT
 tähendama	ei tähendaks	V;ACT;PRS;PRF;POS;COND;1;SG
 tähendama	tähendatud	V.PTCP;PASS;PST
 tähendama	olid tähendanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -30852,7 +30852,7 @@ tähendama	olgu tähendatud	V;PASS;PRS;PRF;POS;IMP
 tähendama	tähendaks	V;ACT;PRS;POS;COND;3;SG
 tähendama	tähendagu	V;ACT;PRS;POS;IMP;3;PL
 tähendama	ärgu olgu tähendanud	V;ACT;PRS;PRF;NEG;IMP;SG
-tähendama	ei ole tähendanudp	V;ACT;PST;NEG;IND
+tähendama	ei ole tähendanud	V;ACT;PST;NEG;IND
 tähendama	tähendad	V;ACT;PRS;POS;IND;2;SG
 tähendama	ära tähenda	V;ACT;PRS;NEG;IMP;2;SG
 tähendama	ei tähenda	V;ACT;PRS;NEG;IND
@@ -30880,17 +30880,17 @@ tähendama	ei tähendata	V;PASS;PRS;NEG;IND
 tähendama	tähendame	V;ACT;PRS;POS;IND;1;PL
 tähendama	tähendan	V;ACT;PRS;POS;IND;1;SG
 tähendama	ärgem tähendagem	V;ACT;PRS;NEG;IMP;1;PL
-tähendama	ei oleks tähendanudp	V;ACT;PRS;PRF;NEG;COND
+tähendama	ei oleks tähendanud	V;ACT;PRS;PRF;NEG;COND
 tähendama	oleksid tähendanud	V;ACT;PRS;PRF;POS;COND;3;PL
 tähendama	tähendasite	V;ACT;PST;POS;IND;2;PL
 tähendama	oleks tähendanud	V;ACT;PRS;PRF;POS;COND;3;SG
 tähendama	olin tähendanud	V;ACT;PRS;PRF;POS;COND;1;SG
 tähendama	oled tähendanud	V;ACT;PRS;PRF;POS;IND;2;SG
 tähendama	oli tähendanud	V;ACT;PRS;PRF;POS;COND;3;SG
-tähendama	ei ole tähendatudp	V;PASS;PRS;PRF;NEG;IND
+tähendama	ei ole tähendatud	V;PASS;PRS;PRF;NEG;IND
 tähendama	tähendaksin	V;ACT;PRS;POS;COND;1;SG
 tähendama	olen tähendanud	V;ACT;PRS;PRF;POS;IND;1;SG
-tähendama	ei olnud tähendatudp	V;PASS;PST;PRF;NEG;IND
+tähendama	ei olnud tähendatud	V;PASS;PST;PRF;NEG;IND
 tähendama	ärgu olgu tähendatud	V;PASS;PRS;PRF;NEG;IMP
 
 täi	täini	N;TERM;SG
@@ -30925,7 +30925,7 @@ täi	täidesse	N;IN+ALL;PL
 täi	täidelt	N;AT+ABL;PL
 
 täitma	olete täitnud	V;ACT;PRS;PRF;POS;IND;2;PL
-täitma	ei olevat täitnudp	V;ACT;PRS;PRF;NEG;QUOT
+täitma	ei olevat täitnud	V;ACT;PRS;PRF;NEG;QUOT
 täitma	oleks täidetud	V;PASS;PRS;PRF;POS;COND
 täitma	täitsin	V;ACT;PST;POS;IND;1;SG
 täitma	täidetakse	V;PASS;PRS;POS;IND
@@ -30934,7 +30934,7 @@ täitma	täidetagu	V;PASS;PRS;POS;IMP
 täitma	ärgu täitku	V;ACT;PRS;NEG;IMP;3;SG
 täitma	oli täidetud	V;PASS;PST;PRF;POS;IND
 täitma	täitsime	V;ACT;PST;POS;IND;1;PL
-täitma	ei olnud täitnudp	V;ACT;PST;PRF;NEG;IND
+täitma	ei olnud täitnud	V;ACT;PST;PRF;NEG;IND
 täitma	oleksid täitnud	V;ACT;PRS;PRF;POS;COND;2;SG
 täitma	olgu täitnud	V;ACT;PRS;PRF;POS;IMP;PL
 täitma	oli täitnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -30948,9 +30948,9 @@ täitma	ärgu täitku	V;ACT;PRS;NEG;IMP;3;PL
 täitma	olgu täitnud	V;ACT;PRS;PRF;POS;IMP;SG
 täitma	täideti	V;PASS;PST;POS;IND
 täitma	ei täitvat	V;ACT;PRS;NEG;QUOT
-täitma	ei oleks täidetudp	V;PASS;PRS;PRF;NEG;COND
+täitma	ei oleks täidetud	V;PASS;PRS;PRF;NEG;COND
 täitma	ei täitnud	V;ACT;PST;NEG;IND
-täitma	ei olevat täidetudp	V;PASS;PRS;PRF;NEG;QUOT
+täitma	ei olevat täidetud	V;PASS;PRS;PRF;NEG;QUOT
 täitma	ei täidaks	V;ACT;PRS;PRF;POS;COND;1;SG
 täitma	täidetud	V.PTCP;PASS;PST
 täitma	olid täitnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -30969,7 +30969,7 @@ täitma	olgu täidetud	V;PASS;PRS;PRF;POS;IMP
 täitma	täidaks	V;ACT;PRS;POS;COND;3;SG
 täitma	täitku	V;ACT;PRS;POS;IMP;3;PL
 täitma	ärgu olgu täitnud	V;ACT;PRS;PRF;NEG;IMP;SG
-täitma	ei ole täitnudp	V;ACT;PST;NEG;IND
+täitma	ei ole täitnud	V;ACT;PST;NEG;IND
 täitma	täidad	V;ACT;PRS;POS;IND;2;SG
 täitma	ära täida	V;ACT;PRS;NEG;IMP;2;SG
 täitma	ei täida	V;ACT;PRS;NEG;IND
@@ -30997,21 +30997,21 @@ täitma	ei täideta	V;PASS;PRS;NEG;IND
 täitma	täidame	V;ACT;PRS;POS;IND;1;PL
 täitma	täidan	V;ACT;PRS;POS;IND;1;SG
 täitma	ärgem täitkem	V;ACT;PRS;NEG;IMP;1;PL
-täitma	ei oleks täitnudp	V;ACT;PRS;PRF;NEG;COND
+täitma	ei oleks täitnud	V;ACT;PRS;PRF;NEG;COND
 täitma	oleksid täitnud	V;ACT;PRS;PRF;POS;COND;3;PL
 täitma	täitsite	V;ACT;PST;POS;IND;2;PL
 täitma	oleks täitnud	V;ACT;PRS;PRF;POS;COND;3;SG
 täitma	olin täitnud	V;ACT;PRS;PRF;POS;COND;1;SG
 täitma	oled täitnud	V;ACT;PRS;PRF;POS;IND;2;SG
 täitma	oli täitnud	V;ACT;PRS;PRF;POS;COND;3;SG
-täitma	ei ole täidetudp	V;PASS;PRS;PRF;NEG;IND
+täitma	ei ole täidetud	V;PASS;PRS;PRF;NEG;IND
 täitma	täidaksin	V;ACT;PRS;POS;COND;1;SG
 täitma	olen täitnud	V;ACT;PRS;PRF;POS;IND;1;SG
-täitma	ei olnud täidetudp	V;PASS;PST;PRF;NEG;IND
+täitma	ei olnud täidetud	V;PASS;PST;PRF;NEG;IND
 täitma	ärgu olgu täidetud	V;PASS;PRS;PRF;NEG;IMP
 
 tänama	olete tänanud	V;ACT;PRS;PRF;POS;IND;2;PL
-tänama	ei olevat tänanudp	V;ACT;PRS;PRF;NEG;QUOT
+tänama	ei olevat tänanud	V;ACT;PRS;PRF;NEG;QUOT
 tänama	oleks tänatud	V;PASS;PRS;PRF;POS;COND
 tänama	tänasin	V;ACT;PST;POS;IND;1;SG
 tänama	tänatakse	V;PASS;PRS;POS;IND
@@ -31020,7 +31020,7 @@ tänama	tänatagu	V;PASS;PRS;POS;IMP
 tänama	ärgu tänagu	V;ACT;PRS;NEG;IMP;3;SG
 tänama	oli tänatud	V;PASS;PST;PRF;POS;IND
 tänama	tänasime	V;ACT;PST;POS;IND;1;PL
-tänama	ei olnud tänanudp	V;ACT;PST;PRF;NEG;IND
+tänama	ei olnud tänanud	V;ACT;PST;PRF;NEG;IND
 tänama	oleksid tänanud	V;ACT;PRS;PRF;POS;COND;2;SG
 tänama	olgu tänanud	V;ACT;PRS;PRF;POS;IMP;PL
 tänama	oli tänanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -31034,9 +31034,9 @@ tänama	ärgu tänagu	V;ACT;PRS;NEG;IMP;3;PL
 tänama	olgu tänanud	V;ACT;PRS;PRF;POS;IMP;SG
 tänama	tänati	V;PASS;PST;POS;IND
 tänama	ei tänavat	V;ACT;PRS;NEG;QUOT
-tänama	ei oleks tänatudp	V;PASS;PRS;PRF;NEG;COND
+tänama	ei oleks tänatud	V;PASS;PRS;PRF;NEG;COND
 tänama	ei tänanud	V;ACT;PST;NEG;IND
-tänama	ei olevat tänatudp	V;PASS;PRS;PRF;NEG;QUOT
+tänama	ei olevat tänatud	V;PASS;PRS;PRF;NEG;QUOT
 tänama	ei tänaks	V;ACT;PRS;PRF;POS;COND;1;SG
 tänama	tänatud	V.PTCP;PASS;PST
 tänama	olid tänanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -31055,7 +31055,7 @@ tänama	olgu tänatud	V;PASS;PRS;PRF;POS;IMP
 tänama	tänaks	V;ACT;PRS;POS;COND;3;SG
 tänama	tänagu	V;ACT;PRS;POS;IMP;3;PL
 tänama	ärgu olgu tänanud	V;ACT;PRS;PRF;NEG;IMP;SG
-tänama	ei ole tänanudp	V;ACT;PST;NEG;IND
+tänama	ei ole tänanud	V;ACT;PST;NEG;IND
 tänama	tänad	V;ACT;PRS;POS;IND;2;SG
 tänama	ära täna	V;ACT;PRS;NEG;IMP;2;SG
 tänama	ei täna	V;ACT;PRS;NEG;IND
@@ -31083,17 +31083,17 @@ tänama	ei tänata	V;PASS;PRS;NEG;IND
 tänama	täname	V;ACT;PRS;POS;IND;1;PL
 tänama	tänan	V;ACT;PRS;POS;IND;1;SG
 tänama	ärgem tänagem	V;ACT;PRS;NEG;IMP;1;PL
-tänama	ei oleks tänanudp	V;ACT;PRS;PRF;NEG;COND
+tänama	ei oleks tänanud	V;ACT;PRS;PRF;NEG;COND
 tänama	oleksid tänanud	V;ACT;PRS;PRF;POS;COND;3;PL
 tänama	tänasite	V;ACT;PST;POS;IND;2;PL
 tänama	oleks tänanud	V;ACT;PRS;PRF;POS;COND;3;SG
 tänama	olin tänanud	V;ACT;PRS;PRF;POS;COND;1;SG
 tänama	oled tänanud	V;ACT;PRS;PRF;POS;IND;2;SG
 tänama	oli tänanud	V;ACT;PRS;PRF;POS;COND;3;SG
-tänama	ei ole tänatudp	V;PASS;PRS;PRF;NEG;IND
+tänama	ei ole tänatud	V;PASS;PRS;PRF;NEG;IND
 tänama	tänaksin	V;ACT;PRS;POS;COND;1;SG
 tänama	olen tänanud	V;ACT;PRS;PRF;POS;IND;1;SG
-tänama	ei olnud tänatudp	V;PASS;PST;PRF;NEG;IND
+tänama	ei olnud tänatud	V;PASS;PST;PRF;NEG;IND
 tänama	ärgu olgu tänatud	V;PASS;PRS;PRF;NEG;IMP
 
 tänav	tänavani	N;TERM;SG
@@ -31159,7 +31159,7 @@ tätoveerija	tätoveerijatesse	N;IN+ALL;PL
 tätoveerija	tätoveerijatelt	N;AT+ABL;PL
 
 tätoveerima	olete tätoveerinud	V;ACT;PRS;PRF;POS;IND;2;PL
-tätoveerima	ei olevat tätoveerinudp	V;ACT;PRS;PRF;NEG;QUOT
+tätoveerima	ei olevat tätoveerinud	V;ACT;PRS;PRF;NEG;QUOT
 tätoveerima	oleks tätoveeritud	V;PASS;PRS;PRF;POS;COND
 tätoveerima	tätoveerisin	V;ACT;PST;POS;IND;1;SG
 tätoveerima	tätoveeritakse	V;PASS;PRS;POS;IND
@@ -31168,7 +31168,7 @@ tätoveerima	tätoveeritagu	V;PASS;PRS;POS;IMP
 tätoveerima	ärgu tätoveerigu	V;ACT;PRS;NEG;IMP;3;SG
 tätoveerima	oli tätoveeritud	V;PASS;PST;PRF;POS;IND
 tätoveerima	tätoveerisime	V;ACT;PST;POS;IND;1;PL
-tätoveerima	ei olnud tätoveerinudp	V;ACT;PST;PRF;NEG;IND
+tätoveerima	ei olnud tätoveerinud	V;ACT;PST;PRF;NEG;IND
 tätoveerima	oleksid tätoveerinud	V;ACT;PRS;PRF;POS;COND;2;SG
 tätoveerima	olgu tätoveerinud	V;ACT;PRS;PRF;POS;IMP;PL
 tätoveerima	oli tätoveerinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -31182,9 +31182,9 @@ tätoveerima	ärgu tätoveerigu	V;ACT;PRS;NEG;IMP;3;PL
 tätoveerima	olgu tätoveerinud	V;ACT;PRS;PRF;POS;IMP;SG
 tätoveerima	tätoveeriti	V;PASS;PST;POS;IND
 tätoveerima	ei tätoveerivat	V;ACT;PRS;NEG;QUOT
-tätoveerima	ei oleks tätoveeritudp	V;PASS;PRS;PRF;NEG;COND
+tätoveerima	ei oleks tätoveeritud	V;PASS;PRS;PRF;NEG;COND
 tätoveerima	ei tätoveerinud	V;ACT;PST;NEG;IND
-tätoveerima	ei olevat tätoveeritudp	V;PASS;PRS;PRF;NEG;QUOT
+tätoveerima	ei olevat tätoveeritud	V;PASS;PRS;PRF;NEG;QUOT
 tätoveerima	ei tätoveeriks	V;ACT;PRS;PRF;POS;COND;1;SG
 tätoveerima	tätoveeritud	V.PTCP;PASS;PST
 tätoveerima	olid tätoveerinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -31203,7 +31203,7 @@ tätoveerima	olgu tätoveeritud	V;PASS;PRS;PRF;POS;IMP
 tätoveerima	tätoveeriks	V;ACT;PRS;POS;COND;3;SG
 tätoveerima	tätoveerigu	V;ACT;PRS;POS;IMP;3;PL
 tätoveerima	ärgu olgu tätoveerinud	V;ACT;PRS;PRF;NEG;IMP;SG
-tätoveerima	ei ole tätoveerinudp	V;ACT;PST;NEG;IND
+tätoveerima	ei ole tätoveerinud	V;ACT;PST;NEG;IND
 tätoveerima	tätoveerid	V;ACT;PRS;POS;IND;2;SG
 tätoveerima	ära tätoveeri	V;ACT;PRS;NEG;IMP;2;SG
 tätoveerima	ei tätoveeri	V;ACT;PRS;NEG;IND
@@ -31231,17 +31231,17 @@ tätoveerima	ei tätoveerita	V;PASS;PRS;NEG;IND
 tätoveerima	tätoveerime	V;ACT;PRS;POS;IND;1;PL
 tätoveerima	tätoveerin	V;ACT;PRS;POS;IND;1;SG
 tätoveerima	ärgem tätoveerigem	V;ACT;PRS;NEG;IMP;1;PL
-tätoveerima	ei oleks tätoveerinudp	V;ACT;PRS;PRF;NEG;COND
+tätoveerima	ei oleks tätoveerinud	V;ACT;PRS;PRF;NEG;COND
 tätoveerima	oleksid tätoveerinud	V;ACT;PRS;PRF;POS;COND;3;PL
 tätoveerima	tätoveerisite	V;ACT;PST;POS;IND;2;PL
 tätoveerima	oleks tätoveerinud	V;ACT;PRS;PRF;POS;COND;3;SG
 tätoveerima	olin tätoveerinud	V;ACT;PRS;PRF;POS;COND;1;SG
 tätoveerima	oled tätoveerinud	V;ACT;PRS;PRF;POS;IND;2;SG
 tätoveerima	oli tätoveerinud	V;ACT;PRS;PRF;POS;COND;3;SG
-tätoveerima	ei ole tätoveeritudp	V;PASS;PRS;PRF;NEG;IND
+tätoveerima	ei ole tätoveeritud	V;PASS;PRS;PRF;NEG;IND
 tätoveerima	tätoveeriksin	V;ACT;PRS;POS;COND;1;SG
 tätoveerima	olen tätoveerinud	V;ACT;PRS;PRF;POS;IND;1;SG
-tätoveerima	ei olnud tätoveeritudp	V;PASS;PST;PRF;NEG;IND
+tätoveerima	ei olnud tätoveeritud	V;PASS;PST;PRF;NEG;IND
 tätoveerima	ärgu olgu tätoveeritud	V;PASS;PRS;PRF;NEG;IMP
 
 ameriitsium	ameriitsiumini	N;TERM;SG
@@ -31276,7 +31276,7 @@ ameriitsium	ameriitsiumdesse	N;IN+ALL;PL
 ameriitsium	ameriitsiumdelt	N;AT+ABL;PL
 
 tõlkima	olete tõlkinud	V;ACT;PRS;PRF;POS;IND;2;PL
-tõlkima	ei olevat tõlkinudp	V;ACT;PRS;PRF;NEG;QUOT
+tõlkima	ei olevat tõlkinud	V;ACT;PRS;PRF;NEG;QUOT
 tõlkima	oleks tõlgitud	V;PASS;PRS;PRF;POS;COND
 tõlkima	tõlkisin	V;ACT;PST;POS;IND;1;SG
 tõlkima	tõlgitakse	V;PASS;PRS;POS;IND
@@ -31285,7 +31285,7 @@ tõlkima	tõlgitagu	V;PASS;PRS;POS;IMP
 tõlkima	ärgu tõlkigu	V;ACT;PRS;NEG;IMP;3;SG
 tõlkima	oli tõlgitud	V;PASS;PST;PRF;POS;IND
 tõlkima	tõlkisime	V;ACT;PST;POS;IND;1;PL
-tõlkima	ei olnud tõlkinudp	V;ACT;PST;PRF;NEG;IND
+tõlkima	ei olnud tõlkinud	V;ACT;PST;PRF;NEG;IND
 tõlkima	oleksid tõlkinud	V;ACT;PRS;PRF;POS;COND;2;SG
 tõlkima	olgu tõlkinud	V;ACT;PRS;PRF;POS;IMP;PL
 tõlkima	oli tõlkinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -31299,9 +31299,9 @@ tõlkima	ärgu tõlkigu	V;ACT;PRS;NEG;IMP;3;PL
 tõlkima	olgu tõlkinud	V;ACT;PRS;PRF;POS;IMP;SG
 tõlkima	tõlgiti	V;PASS;PST;POS;IND
 tõlkima	ei tõlkivat	V;ACT;PRS;NEG;QUOT
-tõlkima	ei oleks tõlgitudp	V;PASS;PRS;PRF;NEG;COND
+tõlkima	ei oleks tõlgitud	V;PASS;PRS;PRF;NEG;COND
 tõlkima	ei tõlkinud	V;ACT;PST;NEG;IND
-tõlkima	ei olevat tõlgitudp	V;PASS;PRS;PRF;NEG;QUOT
+tõlkima	ei olevat tõlgitud	V;PASS;PRS;PRF;NEG;QUOT
 tõlkima	ei tõlgiks	V;ACT;PRS;PRF;POS;COND;1;SG
 tõlkima	tõlgitud	V.PTCP;PASS;PST
 tõlkima	olid tõlkinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -31320,7 +31320,7 @@ tõlkima	olgu tõlgitud	V;PASS;PRS;PRF;POS;IMP
 tõlkima	tõlgiks	V;ACT;PRS;POS;COND;3;SG
 tõlkima	tõlkigu	V;ACT;PRS;POS;IMP;3;PL
 tõlkima	ärgu olgu tõlkinud	V;ACT;PRS;PRF;NEG;IMP;SG
-tõlkima	ei ole tõlkinudp	V;ACT;PST;NEG;IND
+tõlkima	ei ole tõlkinud	V;ACT;PST;NEG;IND
 tõlkima	tõlgid	V;ACT;PRS;POS;IND;2;SG
 tõlkima	ära tõlgi	V;ACT;PRS;NEG;IMP;2;SG
 tõlkima	ei tõlgi	V;ACT;PRS;NEG;IND
@@ -31348,17 +31348,17 @@ tõlkima	ei tõlgita	V;PASS;PRS;NEG;IND
 tõlkima	tõlgime	V;ACT;PRS;POS;IND;1;PL
 tõlkima	tõlgin	V;ACT;PRS;POS;IND;1;SG
 tõlkima	ärgem tõlkigem	V;ACT;PRS;NEG;IMP;1;PL
-tõlkima	ei oleks tõlkinudp	V;ACT;PRS;PRF;NEG;COND
+tõlkima	ei oleks tõlkinud	V;ACT;PRS;PRF;NEG;COND
 tõlkima	oleksid tõlkinud	V;ACT;PRS;PRF;POS;COND;3;PL
 tõlkima	tõlkisite	V;ACT;PST;POS;IND;2;PL
 tõlkima	oleks tõlkinud	V;ACT;PRS;PRF;POS;COND;3;SG
 tõlkima	olin tõlkinud	V;ACT;PRS;PRF;POS;COND;1;SG
 tõlkima	oled tõlkinud	V;ACT;PRS;PRF;POS;IND;2;SG
 tõlkima	oli tõlkinud	V;ACT;PRS;PRF;POS;COND;3;SG
-tõlkima	ei ole tõlgitudp	V;PASS;PRS;PRF;NEG;IND
+tõlkima	ei ole tõlgitud	V;PASS;PRS;PRF;NEG;IND
 tõlkima	tõlgiksin	V;ACT;PRS;POS;COND;1;SG
 tõlkima	olen tõlkinud	V;ACT;PRS;PRF;POS;IND;1;SG
-tõlkima	ei olnud tõlgitudp	V;PASS;PST;PRF;NEG;IND
+tõlkima	ei olnud tõlgitud	V;PASS;PST;PRF;NEG;IND
 tõlkima	ärgu olgu tõlgitud	V;PASS;PRS;PRF;NEG;IMP
 
 tõsi	tõeni	N;TERM;SG
@@ -31548,7 +31548,7 @@ uba	ubadesse	N;IN+ALL;PL
 uba	ubadelt	N;AT+ABL;PL
 
 ujuma	olete ujunud	V;ACT;PRS;PRF;POS;IND;2;PL
-ujuma	ei olevat ujunudp	V;ACT;PRS;PRF;NEG;QUOT
+ujuma	ei olevat ujunud	V;ACT;PRS;PRF;NEG;QUOT
 ujuma	oleks ujutud	V;PASS;PRS;PRF;POS;COND
 ujuma	ujusin	V;ACT;PST;POS;IND;1;SG
 ujuma	ujutakse	V;PASS;PRS;POS;IND
@@ -31557,7 +31557,7 @@ ujuma	ujutagu	V;PASS;PRS;POS;IMP
 ujuma	ärgu ujugu	V;ACT;PRS;NEG;IMP;3;SG
 ujuma	oli ujutud	V;PASS;PST;PRF;POS;IND
 ujuma	ujusime	V;ACT;PST;POS;IND;1;PL
-ujuma	ei olnud ujunudp	V;ACT;PST;PRF;NEG;IND
+ujuma	ei olnud ujunud	V;ACT;PST;PRF;NEG;IND
 ujuma	oleksid ujunud	V;ACT;PRS;PRF;POS;COND;2;SG
 ujuma	olgu ujunud	V;ACT;PRS;PRF;POS;IMP;PL
 ujuma	oli ujunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -31571,9 +31571,9 @@ ujuma	ärgu ujugu	V;ACT;PRS;NEG;IMP;3;PL
 ujuma	olgu ujunud	V;ACT;PRS;PRF;POS;IMP;SG
 ujuma	ujuti	V;PASS;PST;POS;IND
 ujuma	ei ujuvat	V;ACT;PRS;NEG;QUOT
-ujuma	ei oleks ujutudp	V;PASS;PRS;PRF;NEG;COND
+ujuma	ei oleks ujutud	V;PASS;PRS;PRF;NEG;COND
 ujuma	ei ujunud	V;ACT;PST;NEG;IND
-ujuma	ei olevat ujutudp	V;PASS;PRS;PRF;NEG;QUOT
+ujuma	ei olevat ujutud	V;PASS;PRS;PRF;NEG;QUOT
 ujuma	ei ujuks	V;ACT;PRS;PRF;POS;COND;1;SG
 ujuma	ujutud	V.PTCP;PASS;PST
 ujuma	olid ujunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -31592,7 +31592,7 @@ ujuma	olgu ujutud	V;PASS;PRS;PRF;POS;IMP
 ujuma	ujuks	V;ACT;PRS;POS;COND;3;SG
 ujuma	ujugu	V;ACT;PRS;POS;IMP;3;PL
 ujuma	ärgu olgu ujunud	V;ACT;PRS;PRF;NEG;IMP;SG
-ujuma	ei ole ujunudp	V;ACT;PST;NEG;IND
+ujuma	ei ole ujunud	V;ACT;PST;NEG;IND
 ujuma	ujud	V;ACT;PRS;POS;IND;2;SG
 ujuma	ära uju	V;ACT;PRS;NEG;IMP;2;SG
 ujuma	ei uju	V;ACT;PRS;NEG;IND
@@ -31620,17 +31620,17 @@ ujuma	ei ujuta	V;PASS;PRS;NEG;IND
 ujuma	ujume	V;ACT;PRS;POS;IND;1;PL
 ujuma	ujun	V;ACT;PRS;POS;IND;1;SG
 ujuma	ärgem ujugem	V;ACT;PRS;NEG;IMP;1;PL
-ujuma	ei oleks ujunudp	V;ACT;PRS;PRF;NEG;COND
+ujuma	ei oleks ujunud	V;ACT;PRS;PRF;NEG;COND
 ujuma	oleksid ujunud	V;ACT;PRS;PRF;POS;COND;3;PL
 ujuma	ujusite	V;ACT;PST;POS;IND;2;PL
 ujuma	oleks ujunud	V;ACT;PRS;PRF;POS;COND;3;SG
 ujuma	olin ujunud	V;ACT;PRS;PRF;POS;COND;1;SG
 ujuma	oled ujunud	V;ACT;PRS;PRF;POS;IND;2;SG
 ujuma	oli ujunud	V;ACT;PRS;PRF;POS;COND;3;SG
-ujuma	ei ole ujutudp	V;PASS;PRS;PRF;NEG;IND
+ujuma	ei ole ujutud	V;PASS;PRS;PRF;NEG;IND
 ujuma	ujuksin	V;ACT;PRS;POS;COND;1;SG
 ujuma	olen ujunud	V;ACT;PRS;PRF;POS;IND;1;SG
-ujuma	ei olnud ujutudp	V;PASS;PST;PRF;NEG;IND
+ujuma	ei olnud ujutud	V;PASS;PST;PRF;NEG;IND
 ujuma	ärgu olgu ujutud	V;PASS;PRS;PRF;NEG;IMP
 
 ukrainlane	ukrainlaseni	N;TERM;SG
@@ -31913,7 +31913,7 @@ ununtrium	ununtriumdesse	N;IN+ALL;PL
 ununtrium	ununtriumdelt	N;AT+ABL;PL
 
 unustama	olete unustanud	V;ACT;PRS;PRF;POS;IND;2;PL
-unustama	ei olevat unustanudp	V;ACT;PRS;PRF;NEG;QUOT
+unustama	ei olevat unustanud	V;ACT;PRS;PRF;NEG;QUOT
 unustama	oleks unustatud	V;PASS;PRS;PRF;POS;COND
 unustama	unustasin	V;ACT;PST;POS;IND;1;SG
 unustama	unustatakse	V;PASS;PRS;POS;IND
@@ -31922,7 +31922,7 @@ unustama	unustatagu	V;PASS;PRS;POS;IMP
 unustama	ärgu unustagu	V;ACT;PRS;NEG;IMP;3;SG
 unustama	oli unustatud	V;PASS;PST;PRF;POS;IND
 unustama	unustasime	V;ACT;PST;POS;IND;1;PL
-unustama	ei olnud unustanudp	V;ACT;PST;PRF;NEG;IND
+unustama	ei olnud unustanud	V;ACT;PST;PRF;NEG;IND
 unustama	oleksid unustanud	V;ACT;PRS;PRF;POS;COND;2;SG
 unustama	olgu unustanud	V;ACT;PRS;PRF;POS;IMP;PL
 unustama	oli unustanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -31936,9 +31936,9 @@ unustama	ärgu unustagu	V;ACT;PRS;NEG;IMP;3;PL
 unustama	olgu unustanud	V;ACT;PRS;PRF;POS;IMP;SG
 unustama	unustati	V;PASS;PST;POS;IND
 unustama	ei unustavat	V;ACT;PRS;NEG;QUOT
-unustama	ei oleks unustatudp	V;PASS;PRS;PRF;NEG;COND
+unustama	ei oleks unustatud	V;PASS;PRS;PRF;NEG;COND
 unustama	ei unustanud	V;ACT;PST;NEG;IND
-unustama	ei olevat unustatudp	V;PASS;PRS;PRF;NEG;QUOT
+unustama	ei olevat unustatud	V;PASS;PRS;PRF;NEG;QUOT
 unustama	ei unustaks	V;ACT;PRS;PRF;POS;COND;1;SG
 unustama	unustatud	V.PTCP;PASS;PST
 unustama	olid unustanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -31957,7 +31957,7 @@ unustama	olgu unustatud	V;PASS;PRS;PRF;POS;IMP
 unustama	unustaks	V;ACT;PRS;POS;COND;3;SG
 unustama	unustagu	V;ACT;PRS;POS;IMP;3;PL
 unustama	ärgu olgu unustanud	V;ACT;PRS;PRF;NEG;IMP;SG
-unustama	ei ole unustanudp	V;ACT;PST;NEG;IND
+unustama	ei ole unustanud	V;ACT;PST;NEG;IND
 unustama	unustad	V;ACT;PRS;POS;IND;2;SG
 unustama	ära unusta	V;ACT;PRS;NEG;IMP;2;SG
 unustama	ei unusta	V;ACT;PRS;NEG;IND
@@ -31985,17 +31985,17 @@ unustama	ei unustata	V;PASS;PRS;NEG;IND
 unustama	unustame	V;ACT;PRS;POS;IND;1;PL
 unustama	unustan	V;ACT;PRS;POS;IND;1;SG
 unustama	ärgem unustagem	V;ACT;PRS;NEG;IMP;1;PL
-unustama	ei oleks unustanudp	V;ACT;PRS;PRF;NEG;COND
+unustama	ei oleks unustanud	V;ACT;PRS;PRF;NEG;COND
 unustama	oleksid unustanud	V;ACT;PRS;PRF;POS;COND;3;PL
 unustama	unustasite	V;ACT;PST;POS;IND;2;PL
 unustama	oleks unustanud	V;ACT;PRS;PRF;POS;COND;3;SG
 unustama	olin unustanud	V;ACT;PRS;PRF;POS;COND;1;SG
 unustama	oled unustanud	V;ACT;PRS;PRF;POS;IND;2;SG
 unustama	oli unustanud	V;ACT;PRS;PRF;POS;COND;3;SG
-unustama	ei ole unustatudp	V;PASS;PRS;PRF;NEG;IND
+unustama	ei ole unustatud	V;PASS;PRS;PRF;NEG;IND
 unustama	unustaksin	V;ACT;PRS;POS;COND;1;SG
 unustama	olen unustanud	V;ACT;PRS;PRF;POS;IND;1;SG
-unustama	ei olnud unustatudp	V;PASS;PST;PRF;NEG;IND
+unustama	ei olnud unustatud	V;PASS;PST;PRF;NEG;IND
 unustama	ärgu olgu unustatud	V;PASS;PRS;PRF;NEG;IMP
 
 uus	uueni	N;TERM;SG
@@ -32061,7 +32061,7 @@ vaarikas	vaarikatesse	N;IN+ALL;PL
 vaarikas	vaarikatelt	N;AT+ABL;PL
 
 vaatama	olete vaadanud	V;ACT;PRS;PRF;POS;IND;2;PL
-vaatama	ei olevat vaadanudp	V;ACT;PRS;PRF;NEG;QUOT
+vaatama	ei olevat vaadanud	V;ACT;PRS;PRF;NEG;QUOT
 vaatama	oleks vaadatud	V;PASS;PRS;PRF;POS;COND
 vaatama	vaatasin	V;ACT;PST;POS;IND;1;SG
 vaatama	vaadatakse	V;PASS;PRS;POS;IND
@@ -32070,7 +32070,7 @@ vaatama	vaadatagu	V;PASS;PRS;POS;IMP
 vaatama	ärgu vaadaku	V;ACT;PRS;NEG;IMP;3;SG
 vaatama	oli vaadatud	V;PASS;PST;PRF;POS;IND
 vaatama	vaatasime	V;ACT;PST;POS;IND;1;PL
-vaatama	ei olnud vaadanudp	V;ACT;PST;PRF;NEG;IND
+vaatama	ei olnud vaadanud	V;ACT;PST;PRF;NEG;IND
 vaatama	oleksid vaadanud	V;ACT;PRS;PRF;POS;COND;2;SG
 vaatama	olgu vaadanud	V;ACT;PRS;PRF;POS;IMP;PL
 vaatama	oli vaadanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -32084,9 +32084,9 @@ vaatama	ärgu vaadaku	V;ACT;PRS;NEG;IMP;3;PL
 vaatama	olgu vaadanud	V;ACT;PRS;PRF;POS;IMP;SG
 vaatama	vaadati	V;PASS;PST;POS;IND
 vaatama	ei vaatavat	V;ACT;PRS;NEG;QUOT
-vaatama	ei oleks vaadatudp	V;PASS;PRS;PRF;NEG;COND
+vaatama	ei oleks vaadatud	V;PASS;PRS;PRF;NEG;COND
 vaatama	ei vaadanud	V;ACT;PST;NEG;IND
-vaatama	ei olevat vaadatudp	V;PASS;PRS;PRF;NEG;QUOT
+vaatama	ei olevat vaadatud	V;PASS;PRS;PRF;NEG;QUOT
 vaatama	ei vaataks	V;ACT;PRS;PRF;POS;COND;1;SG
 vaatama	vaadatud	V.PTCP;PASS;PST
 vaatama	olid vaadanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -32105,7 +32105,7 @@ vaatama	olgu vaadatud	V;PASS;PRS;PRF;POS;IMP
 vaatama	vaataks	V;ACT;PRS;POS;COND;3;SG
 vaatama	vaadaku	V;ACT;PRS;POS;IMP;3;PL
 vaatama	ärgu olgu vaadanud	V;ACT;PRS;PRF;NEG;IMP;SG
-vaatama	ei ole vaadanudp	V;ACT;PST;NEG;IND
+vaatama	ei ole vaadanud	V;ACT;PST;NEG;IND
 vaatama	vaatad	V;ACT;PRS;POS;IND;2;SG
 vaatama	ära vaata	V;ACT;PRS;NEG;IMP;2;SG
 vaatama	ei vaata	V;ACT;PRS;NEG;IND
@@ -32133,17 +32133,17 @@ vaatama	ei vaadata	V;PASS;PRS;NEG;IND
 vaatama	vaatame	V;ACT;PRS;POS;IND;1;PL
 vaatama	vaatan	V;ACT;PRS;POS;IND;1;SG
 vaatama	ärgem vaadakem	V;ACT;PRS;NEG;IMP;1;PL
-vaatama	ei oleks vaadanudp	V;ACT;PRS;PRF;NEG;COND
+vaatama	ei oleks vaadanud	V;ACT;PRS;PRF;NEG;COND
 vaatama	oleksid vaadanud	V;ACT;PRS;PRF;POS;COND;3;PL
 vaatama	vaatasite	V;ACT;PST;POS;IND;2;PL
 vaatama	oleks vaadanud	V;ACT;PRS;PRF;POS;COND;3;SG
 vaatama	olin vaadanud	V;ACT;PRS;PRF;POS;COND;1;SG
 vaatama	oled vaadanud	V;ACT;PRS;PRF;POS;IND;2;SG
 vaatama	oli vaadanud	V;ACT;PRS;PRF;POS;COND;3;SG
-vaatama	ei ole vaadatudp	V;PASS;PRS;PRF;NEG;IND
+vaatama	ei ole vaadatud	V;PASS;PRS;PRF;NEG;IND
 vaatama	vaataksin	V;ACT;PRS;POS;COND;1;SG
 vaatama	olen vaadanud	V;ACT;PRS;PRF;POS;IND;1;SG
-vaatama	ei olnud vaadatudp	V;PASS;PST;PRF;NEG;IND
+vaatama	ei olnud vaadatud	V;PASS;PST;PRF;NEG;IND
 vaatama	ärgu olgu vaadatud	V;PASS;PRS;PRF;NEG;IMP
 
 vaba	vabani	N;TERM;SG
@@ -32209,7 +32209,7 @@ vabadus	vabadustesse	N;IN+ALL;PL
 vabadus	vabadustelt	N;AT+ABL;PL
 
 vabastama	olete vabastanud	V;ACT;PRS;PRF;POS;IND;2;PL
-vabastama	ei olevat vabastanudp	V;ACT;PRS;PRF;NEG;QUOT
+vabastama	ei olevat vabastanud	V;ACT;PRS;PRF;NEG;QUOT
 vabastama	oleks vabastatud	V;PASS;PRS;PRF;POS;COND
 vabastama	vabastasin	V;ACT;PST;POS;IND;1;SG
 vabastama	vabastatakse	V;PASS;PRS;POS;IND
@@ -32218,7 +32218,7 @@ vabastama	vabastatagu	V;PASS;PRS;POS;IMP
 vabastama	ärgu vabastagu	V;ACT;PRS;NEG;IMP;3;SG
 vabastama	oli vabastatud	V;PASS;PST;PRF;POS;IND
 vabastama	vabastasime	V;ACT;PST;POS;IND;1;PL
-vabastama	ei olnud vabastanudp	V;ACT;PST;PRF;NEG;IND
+vabastama	ei olnud vabastanud	V;ACT;PST;PRF;NEG;IND
 vabastama	oleksid vabastanud	V;ACT;PRS;PRF;POS;COND;2;SG
 vabastama	olgu vabastanud	V;ACT;PRS;PRF;POS;IMP;PL
 vabastama	oli vabastanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -32232,9 +32232,9 @@ vabastama	ärgu vabastagu	V;ACT;PRS;NEG;IMP;3;PL
 vabastama	olgu vabastanud	V;ACT;PRS;PRF;POS;IMP;SG
 vabastama	vabastati	V;PASS;PST;POS;IND
 vabastama	ei vabastavat	V;ACT;PRS;NEG;QUOT
-vabastama	ei oleks vabastatudp	V;PASS;PRS;PRF;NEG;COND
+vabastama	ei oleks vabastatud	V;PASS;PRS;PRF;NEG;COND
 vabastama	ei vabastanud	V;ACT;PST;NEG;IND
-vabastama	ei olevat vabastatudp	V;PASS;PRS;PRF;NEG;QUOT
+vabastama	ei olevat vabastatud	V;PASS;PRS;PRF;NEG;QUOT
 vabastama	ei vabastaks	V;ACT;PRS;PRF;POS;COND;1;SG
 vabastama	vabastatud	V.PTCP;PASS;PST
 vabastama	olid vabastanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -32253,7 +32253,7 @@ vabastama	olgu vabastatud	V;PASS;PRS;PRF;POS;IMP
 vabastama	vabastaks	V;ACT;PRS;POS;COND;3;SG
 vabastama	vabastagu	V;ACT;PRS;POS;IMP;3;PL
 vabastama	ärgu olgu vabastanud	V;ACT;PRS;PRF;NEG;IMP;SG
-vabastama	ei ole vabastanudp	V;ACT;PST;NEG;IND
+vabastama	ei ole vabastanud	V;ACT;PST;NEG;IND
 vabastama	vabastad	V;ACT;PRS;POS;IND;2;SG
 vabastama	ära vabasta	V;ACT;PRS;NEG;IMP;2;SG
 vabastama	ei vabasta	V;ACT;PRS;NEG;IND
@@ -32281,17 +32281,17 @@ vabastama	ei vabastata	V;PASS;PRS;NEG;IND
 vabastama	vabastame	V;ACT;PRS;POS;IND;1;PL
 vabastama	vabastan	V;ACT;PRS;POS;IND;1;SG
 vabastama	ärgem vabastagem	V;ACT;PRS;NEG;IMP;1;PL
-vabastama	ei oleks vabastanudp	V;ACT;PRS;PRF;NEG;COND
+vabastama	ei oleks vabastanud	V;ACT;PRS;PRF;NEG;COND
 vabastama	oleksid vabastanud	V;ACT;PRS;PRF;POS;COND;3;PL
 vabastama	vabastasite	V;ACT;PST;POS;IND;2;PL
 vabastama	oleks vabastanud	V;ACT;PRS;PRF;POS;COND;3;SG
 vabastama	olin vabastanud	V;ACT;PRS;PRF;POS;COND;1;SG
 vabastama	oled vabastanud	V;ACT;PRS;PRF;POS;IND;2;SG
 vabastama	oli vabastanud	V;ACT;PRS;PRF;POS;COND;3;SG
-vabastama	ei ole vabastatudp	V;PASS;PRS;PRF;NEG;IND
+vabastama	ei ole vabastatud	V;PASS;PRS;PRF;NEG;IND
 vabastama	vabastaksin	V;ACT;PRS;POS;COND;1;SG
 vabastama	olen vabastanud	V;ACT;PRS;PRF;POS;IND;1;SG
-vabastama	ei olnud vabastatudp	V;PASS;PST;PRF;NEG;IND
+vabastama	ei olnud vabastatud	V;PASS;PST;PRF;NEG;IND
 vabastama	ärgu olgu vabastatud	V;PASS;PRS;PRF;NEG;IMP
 
 vadjalane	vadjalaseni	N;TERM;SG
@@ -32357,7 +32357,7 @@ vaenlane	vaenlastesse	N;IN+ALL;PL
 vaenlane	vaenlastelt	N;AT+ABL;PL
 
 vaheldama	olete vaheldanud	V;ACT;PRS;PRF;POS;IND;2;PL
-vaheldama	ei olevat vaheldanudp	V;ACT;PRS;PRF;NEG;QUOT
+vaheldama	ei olevat vaheldanud	V;ACT;PRS;PRF;NEG;QUOT
 vaheldama	oleks vaheldatud	V;PASS;PRS;PRF;POS;COND
 vaheldama	vaheldasin	V;ACT;PST;POS;IND;1;SG
 vaheldama	vaheldatakse	V;PASS;PRS;POS;IND
@@ -32366,7 +32366,7 @@ vaheldama	vaheldatagu	V;PASS;PRS;POS;IMP
 vaheldama	ärgu vaheldagu	V;ACT;PRS;NEG;IMP;3;SG
 vaheldama	oli vaheldatud	V;PASS;PST;PRF;POS;IND
 vaheldama	vaheldasime	V;ACT;PST;POS;IND;1;PL
-vaheldama	ei olnud vaheldanudp	V;ACT;PST;PRF;NEG;IND
+vaheldama	ei olnud vaheldanud	V;ACT;PST;PRF;NEG;IND
 vaheldama	oleksid vaheldanud	V;ACT;PRS;PRF;POS;COND;2;SG
 vaheldama	olgu vaheldanud	V;ACT;PRS;PRF;POS;IMP;PL
 vaheldama	oli vaheldanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -32380,9 +32380,9 @@ vaheldama	ärgu vaheldagu	V;ACT;PRS;NEG;IMP;3;PL
 vaheldama	olgu vaheldanud	V;ACT;PRS;PRF;POS;IMP;SG
 vaheldama	vaheldati	V;PASS;PST;POS;IND
 vaheldama	ei vaheldavat	V;ACT;PRS;NEG;QUOT
-vaheldama	ei oleks vaheldatudp	V;PASS;PRS;PRF;NEG;COND
+vaheldama	ei oleks vaheldatud	V;PASS;PRS;PRF;NEG;COND
 vaheldama	ei vaheldanud	V;ACT;PST;NEG;IND
-vaheldama	ei olevat vaheldatudp	V;PASS;PRS;PRF;NEG;QUOT
+vaheldama	ei olevat vaheldatud	V;PASS;PRS;PRF;NEG;QUOT
 vaheldama	ei vaheldaks	V;ACT;PRS;PRF;POS;COND;1;SG
 vaheldama	vaheldatud	V.PTCP;PASS;PST
 vaheldama	olid vaheldanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -32401,7 +32401,7 @@ vaheldama	olgu vaheldatud	V;PASS;PRS;PRF;POS;IMP
 vaheldama	vaheldaks	V;ACT;PRS;POS;COND;3;SG
 vaheldama	vaheldagu	V;ACT;PRS;POS;IMP;3;PL
 vaheldama	ärgu olgu vaheldanud	V;ACT;PRS;PRF;NEG;IMP;SG
-vaheldama	ei ole vaheldanudp	V;ACT;PST;NEG;IND
+vaheldama	ei ole vaheldanud	V;ACT;PST;NEG;IND
 vaheldama	vaheldad	V;ACT;PRS;POS;IND;2;SG
 vaheldama	ära vahelda	V;ACT;PRS;NEG;IMP;2;SG
 vaheldama	ei vahelda	V;ACT;PRS;NEG;IND
@@ -32429,17 +32429,17 @@ vaheldama	ei vaheldata	V;PASS;PRS;NEG;IND
 vaheldama	vaheldame	V;ACT;PRS;POS;IND;1;PL
 vaheldama	vaheldan	V;ACT;PRS;POS;IND;1;SG
 vaheldama	ärgem vaheldagem	V;ACT;PRS;NEG;IMP;1;PL
-vaheldama	ei oleks vaheldanudp	V;ACT;PRS;PRF;NEG;COND
+vaheldama	ei oleks vaheldanud	V;ACT;PRS;PRF;NEG;COND
 vaheldama	oleksid vaheldanud	V;ACT;PRS;PRF;POS;COND;3;PL
 vaheldama	vaheldasite	V;ACT;PST;POS;IND;2;PL
 vaheldama	oleks vaheldanud	V;ACT;PRS;PRF;POS;COND;3;SG
 vaheldama	olin vaheldanud	V;ACT;PRS;PRF;POS;COND;1;SG
 vaheldama	oled vaheldanud	V;ACT;PRS;PRF;POS;IND;2;SG
 vaheldama	oli vaheldanud	V;ACT;PRS;PRF;POS;COND;3;SG
-vaheldama	ei ole vaheldatudp	V;PASS;PRS;PRF;NEG;IND
+vaheldama	ei ole vaheldatud	V;PASS;PRS;PRF;NEG;IND
 vaheldama	vaheldaksin	V;ACT;PRS;POS;COND;1;SG
 vaheldama	olen vaheldanud	V;ACT;PRS;PRF;POS;IND;1;SG
-vaheldama	ei olnud vaheldatudp	V;PASS;PST;PRF;NEG;IND
+vaheldama	ei olnud vaheldatud	V;PASS;PST;PRF;NEG;IND
 vaheldama	ärgu olgu vaheldatud	V;PASS;PRS;PRF;NEG;IMP
 
 vaher	vahtrani	N;TERM;SG
@@ -32536,7 +32536,7 @@ vahvel	vahvlitesse	N;IN+ALL;PL
 vahvel	vahvlitelt	N;AT+ABL;PL
 
 vaidlema	olete vaielnud	V;ACT;PRS;PRF;POS;IND;2;PL
-vaidlema	ei olevat vaielnudp	V;ACT;PRS;PRF;NEG;QUOT
+vaidlema	ei olevat vaielnud	V;ACT;PRS;PRF;NEG;QUOT
 vaidlema	oleks vaieldud	V;PASS;PRS;PRF;POS;COND
 vaidlema	vaidlesin	V;ACT;PST;POS;IND;1;SG
 vaidlema	vaieldakse	V;PASS;PRS;POS;IND
@@ -32545,7 +32545,7 @@ vaidlema	vaieldagu	V;PASS;PRS;POS;IMP
 vaidlema	ärgu vaielgu	V;ACT;PRS;NEG;IMP;3;SG
 vaidlema	oli vaieldud	V;PASS;PST;PRF;POS;IND
 vaidlema	vaidlesime	V;ACT;PST;POS;IND;1;PL
-vaidlema	ei olnud vaielnudp	V;ACT;PST;PRF;NEG;IND
+vaidlema	ei olnud vaielnud	V;ACT;PST;PRF;NEG;IND
 vaidlema	oleksid vaielnud	V;ACT;PRS;PRF;POS;COND;2;SG
 vaidlema	olgu vaielnud	V;ACT;PRS;PRF;POS;IMP;PL
 vaidlema	oli vaielnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -32559,9 +32559,9 @@ vaidlema	ärgu vaielgu	V;ACT;PRS;NEG;IMP;3;PL
 vaidlema	olgu vaielnud	V;ACT;PRS;PRF;POS;IMP;SG
 vaidlema	vaieldi	V;PASS;PST;POS;IND
 vaidlema	ei vaidlevat	V;ACT;PRS;NEG;QUOT
-vaidlema	ei oleks vaieldudp	V;PASS;PRS;PRF;NEG;COND
+vaidlema	ei oleks vaieldud	V;PASS;PRS;PRF;NEG;COND
 vaidlema	ei vaielnud	V;ACT;PST;NEG;IND
-vaidlema	ei olevat vaieldudp	V;PASS;PRS;PRF;NEG;QUOT
+vaidlema	ei olevat vaieldud	V;PASS;PRS;PRF;NEG;QUOT
 vaidlema	ei vaidleks	V;ACT;PRS;PRF;POS;COND;1;SG
 vaidlema	vaieldud	V.PTCP;PASS;PST
 vaidlema	olid vaielnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -32580,7 +32580,7 @@ vaidlema	olgu vaieldud	V;PASS;PRS;PRF;POS;IMP
 vaidlema	vaidleks	V;ACT;PRS;POS;COND;3;SG
 vaidlema	vaielgu	V;ACT;PRS;POS;IMP;3;PL
 vaidlema	ärgu olgu vaielnud	V;ACT;PRS;PRF;NEG;IMP;SG
-vaidlema	ei ole vaielnudp	V;ACT;PST;NEG;IND
+vaidlema	ei ole vaielnud	V;ACT;PST;NEG;IND
 vaidlema	vaidled	V;ACT;PRS;POS;IND;2;SG
 vaidlema	ära vaidle	V;ACT;PRS;NEG;IMP;2;SG
 vaidlema	ei vaidle	V;ACT;PRS;NEG;IND
@@ -32608,21 +32608,21 @@ vaidlema	ei vaielda	V;PASS;PRS;NEG;IND
 vaidlema	vaidleme	V;ACT;PRS;POS;IND;1;PL
 vaidlema	vaidlen	V;ACT;PRS;POS;IND;1;SG
 vaidlema	ärgem vaielgem	V;ACT;PRS;NEG;IMP;1;PL
-vaidlema	ei oleks vaielnudp	V;ACT;PRS;PRF;NEG;COND
+vaidlema	ei oleks vaielnud	V;ACT;PRS;PRF;NEG;COND
 vaidlema	oleksid vaielnud	V;ACT;PRS;PRF;POS;COND;3;PL
 vaidlema	vaidlesite	V;ACT;PST;POS;IND;2;PL
 vaidlema	oleks vaielnud	V;ACT;PRS;PRF;POS;COND;3;SG
 vaidlema	olin vaielnud	V;ACT;PRS;PRF;POS;COND;1;SG
 vaidlema	oled vaielnud	V;ACT;PRS;PRF;POS;IND;2;SG
 vaidlema	oli vaielnud	V;ACT;PRS;PRF;POS;COND;3;SG
-vaidlema	ei ole vaieldudp	V;PASS;PRS;PRF;NEG;IND
+vaidlema	ei ole vaieldud	V;PASS;PRS;PRF;NEG;IND
 vaidlema	vaidleksin	V;ACT;PRS;POS;COND;1;SG
 vaidlema	olen vaielnud	V;ACT;PRS;PRF;POS;IND;1;SG
-vaidlema	ei olnud vaieldudp	V;PASS;PST;PRF;NEG;IND
+vaidlema	ei olnud vaieldud	V;PASS;PST;PRF;NEG;IND
 vaidlema	ärgu olgu vaieldud	V;PASS;PRS;PRF;NEG;IMP
 
 vaikima	olete vaikinud	V;ACT;PRS;PRF;POS;IND;2;PL
-vaikima	ei olevat vaikinudp	V;ACT;PRS;PRF;NEG;QUOT
+vaikima	ei olevat vaikinud	V;ACT;PRS;PRF;NEG;QUOT
 vaikima	oleks vaikitud	V;PASS;PRS;PRF;POS;COND
 vaikima	vaikisin	V;ACT;PST;POS;IND;1;SG
 vaikima	vaikitakse	V;PASS;PRS;POS;IND
@@ -32631,7 +32631,7 @@ vaikima	vaikitagu	V;PASS;PRS;POS;IMP
 vaikima	ärgu vaikigu	V;ACT;PRS;NEG;IMP;3;SG
 vaikima	oli vaikitud	V;PASS;PST;PRF;POS;IND
 vaikima	vaikisime	V;ACT;PST;POS;IND;1;PL
-vaikima	ei olnud vaikinudp	V;ACT;PST;PRF;NEG;IND
+vaikima	ei olnud vaikinud	V;ACT;PST;PRF;NEG;IND
 vaikima	oleksid vaikinud	V;ACT;PRS;PRF;POS;COND;2;SG
 vaikima	olgu vaikinud	V;ACT;PRS;PRF;POS;IMP;PL
 vaikima	oli vaikinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -32645,9 +32645,9 @@ vaikima	ärgu vaikigu	V;ACT;PRS;NEG;IMP;3;PL
 vaikima	olgu vaikinud	V;ACT;PRS;PRF;POS;IMP;SG
 vaikima	vaikiti	V;PASS;PST;POS;IND
 vaikima	ei vaikivat	V;ACT;PRS;NEG;QUOT
-vaikima	ei oleks vaikitudp	V;PASS;PRS;PRF;NEG;COND
+vaikima	ei oleks vaikitud	V;PASS;PRS;PRF;NEG;COND
 vaikima	ei vaikinud	V;ACT;PST;NEG;IND
-vaikima	ei olevat vaikitudp	V;PASS;PRS;PRF;NEG;QUOT
+vaikima	ei olevat vaikitud	V;PASS;PRS;PRF;NEG;QUOT
 vaikima	ei vaikiks	V;ACT;PRS;PRF;POS;COND;1;SG
 vaikima	vaikitud	V.PTCP;PASS;PST
 vaikima	olid vaikinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -32666,7 +32666,7 @@ vaikima	olgu vaikitud	V;PASS;PRS;PRF;POS;IMP
 vaikima	vaikiks	V;ACT;PRS;POS;COND;3;SG
 vaikima	vaikigu	V;ACT;PRS;POS;IMP;3;PL
 vaikima	ärgu olgu vaikinud	V;ACT;PRS;PRF;NEG;IMP;SG
-vaikima	ei ole vaikinudp	V;ACT;PST;NEG;IND
+vaikima	ei ole vaikinud	V;ACT;PST;NEG;IND
 vaikima	vaikid	V;ACT;PRS;POS;IND;2;SG
 vaikima	ära vaiki	V;ACT;PRS;NEG;IMP;2;SG
 vaikima	ei vaiki	V;ACT;PRS;NEG;IND
@@ -32694,17 +32694,17 @@ vaikima	ei vaikita	V;PASS;PRS;NEG;IND
 vaikima	vaikime	V;ACT;PRS;POS;IND;1;PL
 vaikima	vaikin	V;ACT;PRS;POS;IND;1;SG
 vaikima	ärgem vaikigem	V;ACT;PRS;NEG;IMP;1;PL
-vaikima	ei oleks vaikinudp	V;ACT;PRS;PRF;NEG;COND
+vaikima	ei oleks vaikinud	V;ACT;PRS;PRF;NEG;COND
 vaikima	oleksid vaikinud	V;ACT;PRS;PRF;POS;COND;3;PL
 vaikima	vaikisite	V;ACT;PST;POS;IND;2;PL
 vaikima	oleks vaikinud	V;ACT;PRS;PRF;POS;COND;3;SG
 vaikima	olin vaikinud	V;ACT;PRS;PRF;POS;COND;1;SG
 vaikima	oled vaikinud	V;ACT;PRS;PRF;POS;IND;2;SG
 vaikima	oli vaikinud	V;ACT;PRS;PRF;POS;COND;3;SG
-vaikima	ei ole vaikitudp	V;PASS;PRS;PRF;NEG;IND
+vaikima	ei ole vaikitud	V;PASS;PRS;PRF;NEG;IND
 vaikima	vaikiksin	V;ACT;PRS;POS;COND;1;SG
 vaikima	olen vaikinud	V;ACT;PRS;PRF;POS;IND;1;SG
-vaikima	ei olnud vaikitudp	V;PASS;PST;PRF;NEG;IND
+vaikima	ei olnud vaikitud	V;PASS;PST;PRF;NEG;IND
 vaikima	ärgu olgu vaikitud	V;PASS;PRS;PRF;NEG;IMP
 
 vaikus	vaikuseni	N;TERM;SG
@@ -33049,7 +33049,7 @@ vara	varadesse	N;IN+ALL;PL
 vara	varadelt	N;AT+ABL;PL
 
 varastama	olete varastanud	V;ACT;PRS;PRF;POS;IND;2;PL
-varastama	ei olevat varastanudp	V;ACT;PRS;PRF;NEG;QUOT
+varastama	ei olevat varastanud	V;ACT;PRS;PRF;NEG;QUOT
 varastama	oleks varastatud	V;PASS;PRS;PRF;POS;COND
 varastama	varastasin	V;ACT;PST;POS;IND;1;SG
 varastama	varastatakse	V;PASS;PRS;POS;IND
@@ -33058,7 +33058,7 @@ varastama	varastatagu	V;PASS;PRS;POS;IMP
 varastama	ärgu varastagu	V;ACT;PRS;NEG;IMP;3;SG
 varastama	oli varastatud	V;PASS;PST;PRF;POS;IND
 varastama	varastasime	V;ACT;PST;POS;IND;1;PL
-varastama	ei olnud varastanudp	V;ACT;PST;PRF;NEG;IND
+varastama	ei olnud varastanud	V;ACT;PST;PRF;NEG;IND
 varastama	oleksid varastanud	V;ACT;PRS;PRF;POS;COND;2;SG
 varastama	olgu varastanud	V;ACT;PRS;PRF;POS;IMP;PL
 varastama	oli varastanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -33072,9 +33072,9 @@ varastama	ärgu varastagu	V;ACT;PRS;NEG;IMP;3;PL
 varastama	olgu varastanud	V;ACT;PRS;PRF;POS;IMP;SG
 varastama	varastati	V;PASS;PST;POS;IND
 varastama	ei varastavat	V;ACT;PRS;NEG;QUOT
-varastama	ei oleks varastatudp	V;PASS;PRS;PRF;NEG;COND
+varastama	ei oleks varastatud	V;PASS;PRS;PRF;NEG;COND
 varastama	ei varastanud	V;ACT;PST;NEG;IND
-varastama	ei olevat varastatudp	V;PASS;PRS;PRF;NEG;QUOT
+varastama	ei olevat varastatud	V;PASS;PRS;PRF;NEG;QUOT
 varastama	ei varastaks	V;ACT;PRS;PRF;POS;COND;1;SG
 varastama	varastatud	V.PTCP;PASS;PST
 varastama	olid varastanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -33093,7 +33093,7 @@ varastama	olgu varastatud	V;PASS;PRS;PRF;POS;IMP
 varastama	varastaks	V;ACT;PRS;POS;COND;3;SG
 varastama	varastagu	V;ACT;PRS;POS;IMP;3;PL
 varastama	ärgu olgu varastanud	V;ACT;PRS;PRF;NEG;IMP;SG
-varastama	ei ole varastanudp	V;ACT;PST;NEG;IND
+varastama	ei ole varastanud	V;ACT;PST;NEG;IND
 varastama	varastad	V;ACT;PRS;POS;IND;2;SG
 varastama	ära varasta	V;ACT;PRS;NEG;IMP;2;SG
 varastama	ei varasta	V;ACT;PRS;NEG;IND
@@ -33121,17 +33121,17 @@ varastama	ei varastata	V;PASS;PRS;NEG;IND
 varastama	varastame	V;ACT;PRS;POS;IND;1;PL
 varastama	varastan	V;ACT;PRS;POS;IND;1;SG
 varastama	ärgem varastagem	V;ACT;PRS;NEG;IMP;1;PL
-varastama	ei oleks varastanudp	V;ACT;PRS;PRF;NEG;COND
+varastama	ei oleks varastanud	V;ACT;PRS;PRF;NEG;COND
 varastama	oleksid varastanud	V;ACT;PRS;PRF;POS;COND;3;PL
 varastama	varastasite	V;ACT;PST;POS;IND;2;PL
 varastama	oleks varastanud	V;ACT;PRS;PRF;POS;COND;3;SG
 varastama	olin varastanud	V;ACT;PRS;PRF;POS;COND;1;SG
 varastama	oled varastanud	V;ACT;PRS;PRF;POS;IND;2;SG
 varastama	oli varastanud	V;ACT;PRS;PRF;POS;COND;3;SG
-varastama	ei ole varastatudp	V;PASS;PRS;PRF;NEG;IND
+varastama	ei ole varastatud	V;PASS;PRS;PRF;NEG;IND
 varastama	varastaksin	V;ACT;PRS;POS;COND;1;SG
 varastama	olen varastanud	V;ACT;PRS;PRF;POS;IND;1;SG
-varastama	ei olnud varastatudp	V;PASS;PST;PRF;NEG;IND
+varastama	ei olnud varastatud	V;PASS;PST;PRF;NEG;IND
 varastama	ärgu olgu varastatud	V;PASS;PRS;PRF;NEG;IMP
 
 varblane	varblaseni	N;TERM;SG
@@ -33352,7 +33352,7 @@ veebruar	veebruardesse	N;IN+ALL;PL
 veebruar	veebruardelt	N;AT+ABL;PL
 
 veenma	olete veennud	V;ACT;PRS;PRF;POS;IND;2;PL
-veenma	ei olevat veennudp	V;ACT;PRS;PRF;NEG;QUOT
+veenma	ei olevat veennud	V;ACT;PRS;PRF;NEG;QUOT
 veenma	oleks veendud	V;PASS;PRS;PRF;POS;COND
 veenma	veensin	V;ACT;PST;POS;IND;1;SG
 veenma	veendakse	V;PASS;PRS;POS;IND
@@ -33361,7 +33361,7 @@ veenma	veendagu	V;PASS;PRS;POS;IMP
 veenma	ärgu veengu	V;ACT;PRS;NEG;IMP;3;SG
 veenma	oli veendud	V;PASS;PST;PRF;POS;IND
 veenma	veensime	V;ACT;PST;POS;IND;1;PL
-veenma	ei olnud veennudp	V;ACT;PST;PRF;NEG;IND
+veenma	ei olnud veennud	V;ACT;PST;PRF;NEG;IND
 veenma	oleksid veennud	V;ACT;PRS;PRF;POS;COND;2;SG
 veenma	olgu veennud	V;ACT;PRS;PRF;POS;IMP;PL
 veenma	oli veennud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -33375,9 +33375,9 @@ veenma	ärgu veengu	V;ACT;PRS;NEG;IMP;3;PL
 veenma	olgu veennud	V;ACT;PRS;PRF;POS;IMP;SG
 veenma	veendi	V;PASS;PST;POS;IND
 veenma	ei veenvat	V;ACT;PRS;NEG;QUOT
-veenma	ei oleks veendudp	V;PASS;PRS;PRF;NEG;COND
+veenma	ei oleks veendud	V;PASS;PRS;PRF;NEG;COND
 veenma	ei veennud	V;ACT;PST;NEG;IND
-veenma	ei olevat veendudp	V;PASS;PRS;PRF;NEG;QUOT
+veenma	ei olevat veendud	V;PASS;PRS;PRF;NEG;QUOT
 veenma	ei veenaks	V;ACT;PRS;PRF;POS;COND;1;SG
 veenma	veendud	V.PTCP;PASS;PST
 veenma	olid veennud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -33396,7 +33396,7 @@ veenma	olgu veendud	V;PASS;PRS;PRF;POS;IMP
 veenma	veenaks	V;ACT;PRS;POS;COND;3;SG
 veenma	veengu	V;ACT;PRS;POS;IMP;3;PL
 veenma	ärgu olgu veennud	V;ACT;PRS;PRF;NEG;IMP;SG
-veenma	ei ole veennudp	V;ACT;PST;NEG;IND
+veenma	ei ole veennud	V;ACT;PST;NEG;IND
 veenma	veenad	V;ACT;PRS;POS;IND;2;SG
 veenma	ära veena	V;ACT;PRS;NEG;IMP;2;SG
 veenma	ei veena	V;ACT;PRS;NEG;IND
@@ -33424,17 +33424,17 @@ veenma	ei veenda	V;PASS;PRS;NEG;IND
 veenma	veename	V;ACT;PRS;POS;IND;1;PL
 veenma	veenan	V;ACT;PRS;POS;IND;1;SG
 veenma	ärgem veengem	V;ACT;PRS;NEG;IMP;1;PL
-veenma	ei oleks veennudp	V;ACT;PRS;PRF;NEG;COND
+veenma	ei oleks veennud	V;ACT;PRS;PRF;NEG;COND
 veenma	oleksid veennud	V;ACT;PRS;PRF;POS;COND;3;PL
 veenma	veensite	V;ACT;PST;POS;IND;2;PL
 veenma	oleks veennud	V;ACT;PRS;PRF;POS;COND;3;SG
 veenma	olin veennud	V;ACT;PRS;PRF;POS;COND;1;SG
 veenma	oled veennud	V;ACT;PRS;PRF;POS;IND;2;SG
 veenma	oli veennud	V;ACT;PRS;PRF;POS;COND;3;SG
-veenma	ei ole veendudp	V;PASS;PRS;PRF;NEG;IND
+veenma	ei ole veendud	V;PASS;PRS;PRF;NEG;IND
 veenma	veenaksin	V;ACT;PRS;POS;COND;1;SG
 veenma	olen veennud	V;ACT;PRS;PRF;POS;IND;1;SG
-veenma	ei olnud veendudp	V;PASS;PST;PRF;NEG;IND
+veenma	ei olnud veendud	V;PASS;PST;PRF;NEG;IND
 veenma	ärgu olgu veendud	V;PASS;PRS;PRF;NEG;IMP
 
 venelane	venelaseni	N;TERM;SG
@@ -33593,7 +33593,7 @@ veski	veskidesse	N;IN+ALL;PL
 veski	veskidelt	N;AT+ABL;PL
 
 vibutama	olete vibutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-vibutama	ei olevat vibutanudp	V;ACT;PRS;PRF;NEG;QUOT
+vibutama	ei olevat vibutanud	V;ACT;PRS;PRF;NEG;QUOT
 vibutama	oleks vibutatud	V;PASS;PRS;PRF;POS;COND
 vibutama	vibutasin	V;ACT;PST;POS;IND;1;SG
 vibutama	vibutatakse	V;PASS;PRS;POS;IND
@@ -33602,7 +33602,7 @@ vibutama	vibutatagu	V;PASS;PRS;POS;IMP
 vibutama	ärgu vibutagu	V;ACT;PRS;NEG;IMP;3;SG
 vibutama	oli vibutatud	V;PASS;PST;PRF;POS;IND
 vibutama	vibutasime	V;ACT;PST;POS;IND;1;PL
-vibutama	ei olnud vibutanudp	V;ACT;PST;PRF;NEG;IND
+vibutama	ei olnud vibutanud	V;ACT;PST;PRF;NEG;IND
 vibutama	oleksid vibutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 vibutama	olgu vibutanud	V;ACT;PRS;PRF;POS;IMP;PL
 vibutama	oli vibutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -33616,9 +33616,9 @@ vibutama	ärgu vibutagu	V;ACT;PRS;NEG;IMP;3;PL
 vibutama	olgu vibutanud	V;ACT;PRS;PRF;POS;IMP;SG
 vibutama	vibutati	V;PASS;PST;POS;IND
 vibutama	ei vibutavat	V;ACT;PRS;NEG;QUOT
-vibutama	ei oleks vibutatudp	V;PASS;PRS;PRF;NEG;COND
+vibutama	ei oleks vibutatud	V;PASS;PRS;PRF;NEG;COND
 vibutama	ei vibutanud	V;ACT;PST;NEG;IND
-vibutama	ei olevat vibutatudp	V;PASS;PRS;PRF;NEG;QUOT
+vibutama	ei olevat vibutatud	V;PASS;PRS;PRF;NEG;QUOT
 vibutama	ei vibutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 vibutama	vibutatud	V.PTCP;PASS;PST
 vibutama	olid vibutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -33637,7 +33637,7 @@ vibutama	olgu vibutatud	V;PASS;PRS;PRF;POS;IMP
 vibutama	vibutaks	V;ACT;PRS;POS;COND;3;SG
 vibutama	vibutagu	V;ACT;PRS;POS;IMP;3;PL
 vibutama	ärgu olgu vibutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-vibutama	ei ole vibutanudp	V;ACT;PST;NEG;IND
+vibutama	ei ole vibutanud	V;ACT;PST;NEG;IND
 vibutama	vibutad	V;ACT;PRS;POS;IND;2;SG
 vibutama	ära vibuta	V;ACT;PRS;NEG;IMP;2;SG
 vibutama	ei vibuta	V;ACT;PRS;NEG;IND
@@ -33665,17 +33665,17 @@ vibutama	ei vibutata	V;PASS;PRS;NEG;IND
 vibutama	vibutame	V;ACT;PRS;POS;IND;1;PL
 vibutama	vibutan	V;ACT;PRS;POS;IND;1;SG
 vibutama	ärgem vibutagem	V;ACT;PRS;NEG;IMP;1;PL
-vibutama	ei oleks vibutanudp	V;ACT;PRS;PRF;NEG;COND
+vibutama	ei oleks vibutanud	V;ACT;PRS;PRF;NEG;COND
 vibutama	oleksid vibutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 vibutama	vibutasite	V;ACT;PST;POS;IND;2;PL
 vibutama	oleks vibutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 vibutama	olin vibutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 vibutama	oled vibutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 vibutama	oli vibutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-vibutama	ei ole vibutatudp	V;PASS;PRS;PRF;NEG;IND
+vibutama	ei ole vibutatud	V;PASS;PRS;PRF;NEG;IND
 vibutama	vibutaksin	V;ACT;PRS;POS;COND;1;SG
 vibutama	olen vibutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-vibutama	ei olnud vibutatudp	V;PASS;PST;PRF;NEG;IND
+vibutama	ei olnud vibutatud	V;PASS;PST;PRF;NEG;IND
 vibutama	ärgu olgu vibutatud	V;PASS;PRS;PRF;NEG;IMP
 
 vihik	vihikuni	N;TERM;SG
@@ -33710,7 +33710,7 @@ vihik	vihikutesse	N;IN+ALL;PL
 vihik	vihikutelt	N;AT+ABL;PL
 
 vihkama	olete vihanud	V;ACT;PRS;PRF;POS;IND;2;PL
-vihkama	ei olevat vihanudp	V;ACT;PRS;PRF;NEG;QUOT
+vihkama	ei olevat vihanud	V;ACT;PRS;PRF;NEG;QUOT
 vihkama	oleks vihatud	V;PASS;PRS;PRF;POS;COND
 vihkama	vihkasin	V;ACT;PST;POS;IND;1;SG
 vihkama	vihatakse	V;PASS;PRS;POS;IND
@@ -33719,7 +33719,7 @@ vihkama	vihatagu	V;PASS;PRS;POS;IMP
 vihkama	ärgu vihaku	V;ACT;PRS;NEG;IMP;3;SG
 vihkama	oli vihatud	V;PASS;PST;PRF;POS;IND
 vihkama	vihkasime	V;ACT;PST;POS;IND;1;PL
-vihkama	ei olnud vihanudp	V;ACT;PST;PRF;NEG;IND
+vihkama	ei olnud vihanud	V;ACT;PST;PRF;NEG;IND
 vihkama	oleksid vihanud	V;ACT;PRS;PRF;POS;COND;2;SG
 vihkama	olgu vihanud	V;ACT;PRS;PRF;POS;IMP;PL
 vihkama	oli vihanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -33733,9 +33733,9 @@ vihkama	ärgu vihaku	V;ACT;PRS;NEG;IMP;3;PL
 vihkama	olgu vihanud	V;ACT;PRS;PRF;POS;IMP;SG
 vihkama	vihati	V;PASS;PST;POS;IND
 vihkama	ei vihkavat	V;ACT;PRS;NEG;QUOT
-vihkama	ei oleks vihatudp	V;PASS;PRS;PRF;NEG;COND
+vihkama	ei oleks vihatud	V;PASS;PRS;PRF;NEG;COND
 vihkama	ei vihanud	V;ACT;PST;NEG;IND
-vihkama	ei olevat vihatudp	V;PASS;PRS;PRF;NEG;QUOT
+vihkama	ei olevat vihatud	V;PASS;PRS;PRF;NEG;QUOT
 vihkama	ei vihkaks	V;ACT;PRS;PRF;POS;COND;1;SG
 vihkama	vihatud	V.PTCP;PASS;PST
 vihkama	olid vihanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -33754,7 +33754,7 @@ vihkama	olgu vihatud	V;PASS;PRS;PRF;POS;IMP
 vihkama	vihkaks	V;ACT;PRS;POS;COND;3;SG
 vihkama	vihaku	V;ACT;PRS;POS;IMP;3;PL
 vihkama	ärgu olgu vihanud	V;ACT;PRS;PRF;NEG;IMP;SG
-vihkama	ei ole vihanudp	V;ACT;PST;NEG;IND
+vihkama	ei ole vihanud	V;ACT;PST;NEG;IND
 vihkama	vihkad	V;ACT;PRS;POS;IND;2;SG
 vihkama	ära vihka	V;ACT;PRS;NEG;IMP;2;SG
 vihkama	ei vihka	V;ACT;PRS;NEG;IND
@@ -33782,17 +33782,17 @@ vihkama	ei vihata	V;PASS;PRS;NEG;IND
 vihkama	vihkame	V;ACT;PRS;POS;IND;1;PL
 vihkama	vihkan	V;ACT;PRS;POS;IND;1;SG
 vihkama	ärgem vihakem	V;ACT;PRS;NEG;IMP;1;PL
-vihkama	ei oleks vihanudp	V;ACT;PRS;PRF;NEG;COND
+vihkama	ei oleks vihanud	V;ACT;PRS;PRF;NEG;COND
 vihkama	oleksid vihanud	V;ACT;PRS;PRF;POS;COND;3;PL
 vihkama	vihkasite	V;ACT;PST;POS;IND;2;PL
 vihkama	oleks vihanud	V;ACT;PRS;PRF;POS;COND;3;SG
 vihkama	olin vihanud	V;ACT;PRS;PRF;POS;COND;1;SG
 vihkama	oled vihanud	V;ACT;PRS;PRF;POS;IND;2;SG
 vihkama	oli vihanud	V;ACT;PRS;PRF;POS;COND;3;SG
-vihkama	ei ole vihatudp	V;PASS;PRS;PRF;NEG;IND
+vihkama	ei ole vihatud	V;PASS;PRS;PRF;NEG;IND
 vihkama	vihkaksin	V;ACT;PRS;POS;COND;1;SG
 vihkama	olen vihanud	V;ACT;PRS;PRF;POS;IND;1;SG
-vihkama	ei olnud vihatudp	V;PASS;PST;PRF;NEG;IND
+vihkama	ei olnud vihatud	V;PASS;PST;PRF;NEG;IND
 vihkama	ärgu olgu vihatud	V;PASS;PRS;PRF;NEG;IMP
 
 viinakuu	viinakuuni	N;TERM;SG
@@ -33827,7 +33827,7 @@ viinakuu	viinakuudesse	N;IN+ALL;PL
 viinakuu	viinakuudelt	N;AT+ABL;PL
 
 viitsima	olete viitsinud	V;ACT;PRS;PRF;POS;IND;2;PL
-viitsima	ei olevat viitsinudp	V;ACT;PRS;PRF;NEG;QUOT
+viitsima	ei olevat viitsinud	V;ACT;PRS;PRF;NEG;QUOT
 viitsima	oleks viitsitud	V;PASS;PRS;PRF;POS;COND
 viitsima	viitsisin	V;ACT;PST;POS;IND;1;SG
 viitsima	viitsitakse	V;PASS;PRS;POS;IND
@@ -33836,7 +33836,7 @@ viitsima	viitsitagu	V;PASS;PRS;POS;IMP
 viitsima	ärgu viitsigu	V;ACT;PRS;NEG;IMP;3;SG
 viitsima	oli viitsitud	V;PASS;PST;PRF;POS;IND
 viitsima	viitsisime	V;ACT;PST;POS;IND;1;PL
-viitsima	ei olnud viitsinudp	V;ACT;PST;PRF;NEG;IND
+viitsima	ei olnud viitsinud	V;ACT;PST;PRF;NEG;IND
 viitsima	oleksid viitsinud	V;ACT;PRS;PRF;POS;COND;2;SG
 viitsima	olgu viitsinud	V;ACT;PRS;PRF;POS;IMP;PL
 viitsima	oli viitsinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -33850,9 +33850,9 @@ viitsima	ärgu viitsigu	V;ACT;PRS;NEG;IMP;3;PL
 viitsima	olgu viitsinud	V;ACT;PRS;PRF;POS;IMP;SG
 viitsima	viitsiti	V;PASS;PST;POS;IND
 viitsima	ei viitsivat	V;ACT;PRS;NEG;QUOT
-viitsima	ei oleks viitsitudp	V;PASS;PRS;PRF;NEG;COND
+viitsima	ei oleks viitsitud	V;PASS;PRS;PRF;NEG;COND
 viitsima	ei viitsinud	V;ACT;PST;NEG;IND
-viitsima	ei olevat viitsitudp	V;PASS;PRS;PRF;NEG;QUOT
+viitsima	ei olevat viitsitud	V;PASS;PRS;PRF;NEG;QUOT
 viitsima	ei viitsiks	V;ACT;PRS;PRF;POS;COND;1;SG
 viitsima	viitsitud	V.PTCP;PASS;PST
 viitsima	olid viitsinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -33871,7 +33871,7 @@ viitsima	olgu viitsitud	V;PASS;PRS;PRF;POS;IMP
 viitsima	viitsiks	V;ACT;PRS;POS;COND;3;SG
 viitsima	viitsigu	V;ACT;PRS;POS;IMP;3;PL
 viitsima	ärgu olgu viitsinud	V;ACT;PRS;PRF;NEG;IMP;SG
-viitsima	ei ole viitsinudp	V;ACT;PST;NEG;IND
+viitsima	ei ole viitsinud	V;ACT;PST;NEG;IND
 viitsima	viitsid	V;ACT;PRS;POS;IND;2;SG
 viitsima	ära viitsi	V;ACT;PRS;NEG;IMP;2;SG
 viitsima	ei viitsi	V;ACT;PRS;NEG;IND
@@ -33899,21 +33899,21 @@ viitsima	ei viitsita	V;PASS;PRS;NEG;IND
 viitsima	viitsime	V;ACT;PRS;POS;IND;1;PL
 viitsima	viitsin	V;ACT;PRS;POS;IND;1;SG
 viitsima	ärgem viitsigem	V;ACT;PRS;NEG;IMP;1;PL
-viitsima	ei oleks viitsinudp	V;ACT;PRS;PRF;NEG;COND
+viitsima	ei oleks viitsinud	V;ACT;PRS;PRF;NEG;COND
 viitsima	oleksid viitsinud	V;ACT;PRS;PRF;POS;COND;3;PL
 viitsima	viitsisite	V;ACT;PST;POS;IND;2;PL
 viitsima	oleks viitsinud	V;ACT;PRS;PRF;POS;COND;3;SG
 viitsima	olin viitsinud	V;ACT;PRS;PRF;POS;COND;1;SG
 viitsima	oled viitsinud	V;ACT;PRS;PRF;POS;IND;2;SG
 viitsima	oli viitsinud	V;ACT;PRS;PRF;POS;COND;3;SG
-viitsima	ei ole viitsitudp	V;PASS;PRS;PRF;NEG;IND
+viitsima	ei ole viitsitud	V;PASS;PRS;PRF;NEG;IND
 viitsima	viitsiksin	V;ACT;PRS;POS;COND;1;SG
 viitsima	olen viitsinud	V;ACT;PRS;PRF;POS;IND;1;SG
-viitsima	ei olnud viitsitudp	V;PASS;PST;PRF;NEG;IND
+viitsima	ei olnud viitsitud	V;PASS;PST;PRF;NEG;IND
 viitsima	ärgu olgu viitsitud	V;PASS;PRS;PRF;NEG;IMP
 
 andma	olete andnud	V;ACT;PRS;PRF;POS;IND;2;PL
-andma	ei olevat andnudp	V;ACT;PRS;PRF;NEG;QUOT
+andma	ei olevat andnud	V;ACT;PRS;PRF;NEG;QUOT
 andma	oleks annetud	V;PASS;PRS;PRF;POS;COND
 andma	andsin	V;ACT;PST;POS;IND;1;SG
 andma	annetakse	V;PASS;PRS;POS;IND
@@ -33922,7 +33922,7 @@ andma	annetagu	V;PASS;PRS;POS;IMP
 andma	ärgu andku	V;ACT;PRS;NEG;IMP;3;SG
 andma	oli annetud	V;PASS;PST;PRF;POS;IND
 andma	andsime	V;ACT;PST;POS;IND;1;PL
-andma	ei olnud andnudp	V;ACT;PST;PRF;NEG;IND
+andma	ei olnud andnud	V;ACT;PST;PRF;NEG;IND
 andma	oleksid andnud	V;ACT;PRS;PRF;POS;COND;2;SG
 andma	olgu andnud	V;ACT;PRS;PRF;POS;IMP;PL
 andma	oli andnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -33936,9 +33936,9 @@ andma	ärgu andku	V;ACT;PRS;NEG;IMP;3;PL
 andma	olgu andnud	V;ACT;PRS;PRF;POS;IMP;SG
 andma	anneti	V;PASS;PST;POS;IND
 andma	ei andvat	V;ACT;PRS;NEG;QUOT
-andma	ei oleks annetudp	V;PASS;PRS;PRF;NEG;COND
+andma	ei oleks annetud	V;PASS;PRS;PRF;NEG;COND
 andma	ei andnud	V;ACT;PST;NEG;IND
-andma	ei olevat annetudp	V;PASS;PRS;PRF;NEG;QUOT
+andma	ei olevat annetud	V;PASS;PRS;PRF;NEG;QUOT
 andma	ei annaks	V;ACT;PRS;PRF;POS;COND;1;SG
 andma	annetud	V.PTCP;PASS;PST
 andma	olid andnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -33957,7 +33957,7 @@ andma	olgu annetud	V;PASS;PRS;PRF;POS;IMP
 andma	annaks	V;ACT;PRS;POS;COND;3;SG
 andma	andku	V;ACT;PRS;POS;IMP;3;PL
 andma	ärgu olgu andnud	V;ACT;PRS;PRF;NEG;IMP;SG
-andma	ei ole andnudp	V;ACT;PST;NEG;IND
+andma	ei ole andnud	V;ACT;PST;NEG;IND
 andma	annad	V;ACT;PRS;POS;IND;2;SG
 andma	ära anna	V;ACT;PRS;NEG;IMP;2;SG
 andma	ei anna	V;ACT;PRS;NEG;IND
@@ -33985,17 +33985,17 @@ andma	ei anneta	V;PASS;PRS;NEG;IND
 andma	anname	V;ACT;PRS;POS;IND;1;PL
 andma	annan	V;ACT;PRS;POS;IND;1;SG
 andma	ärgem andkem	V;ACT;PRS;NEG;IMP;1;PL
-andma	ei oleks andnudp	V;ACT;PRS;PRF;NEG;COND
+andma	ei oleks andnud	V;ACT;PRS;PRF;NEG;COND
 andma	oleksid andnud	V;ACT;PRS;PRF;POS;COND;3;PL
 andma	andsite	V;ACT;PST;POS;IND;2;PL
 andma	oleks andnud	V;ACT;PRS;PRF;POS;COND;3;SG
 andma	olin andnud	V;ACT;PRS;PRF;POS;COND;1;SG
 andma	oled andnud	V;ACT;PRS;PRF;POS;IND;2;SG
 andma	oli andnud	V;ACT;PRS;PRF;POS;COND;3;SG
-andma	ei ole annetudp	V;PASS;PRS;PRF;NEG;IND
+andma	ei ole annetud	V;PASS;PRS;PRF;NEG;IND
 andma	annaksin	V;ACT;PRS;POS;COND;1;SG
 andma	olen andnud	V;ACT;PRS;PRF;POS;IND;1;SG
-andma	ei olnud annetudp	V;PASS;PST;PRF;NEG;IND
+andma	ei olnud annetud	V;PASS;PST;PRF;NEG;IND
 andma	ärgu olgu annetud	V;PASS;PRS;PRF;NEG;IMP
 
 voodi	voodini	N;TERM;SG
@@ -34278,7 +34278,7 @@ väävel	väävlitesse	N;IN+ALL;PL
 väävel	väävlitelt	N;AT+ABL;PL
 
 võima	olete võinud	V;ACT;PRS;PRF;POS;IND;2;PL
-võima	ei olevat võinudp	V;ACT;PRS;PRF;NEG;QUOT
+võima	ei olevat võinud	V;ACT;PRS;PRF;NEG;QUOT
 võima	oleks võidud	V;PASS;PRS;PRF;POS;COND
 võima	võisin	V;ACT;PST;POS;IND;1;SG
 võima	võidakse	V;PASS;PRS;POS;IND
@@ -34287,7 +34287,7 @@ võima	võidagu	V;PASS;PRS;POS;IMP
 võima	ärgu võigu	V;ACT;PRS;NEG;IMP;3;SG
 võima	oli võidud	V;PASS;PST;PRF;POS;IND
 võima	võisime	V;ACT;PST;POS;IND;1;PL
-võima	ei olnud võinudp	V;ACT;PST;PRF;NEG;IND
+võima	ei olnud võinud	V;ACT;PST;PRF;NEG;IND
 võima	oleksid võinud	V;ACT;PRS;PRF;POS;COND;2;SG
 võima	olgu võinud	V;ACT;PRS;PRF;POS;IMP;PL
 võima	oli võinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -34301,9 +34301,9 @@ võima	ärgu võigu	V;ACT;PRS;NEG;IMP;3;PL
 võima	olgu võinud	V;ACT;PRS;PRF;POS;IMP;SG
 võima	võidi	V;PASS;PST;POS;IND
 võima	ei võivat	V;ACT;PRS;NEG;QUOT
-võima	ei oleks võidudp	V;PASS;PRS;PRF;NEG;COND
+võima	ei oleks võidud	V;PASS;PRS;PRF;NEG;COND
 võima	ei võinud	V;ACT;PST;NEG;IND
-võima	ei olevat võidudp	V;PASS;PRS;PRF;NEG;QUOT
+võima	ei olevat võidud	V;PASS;PRS;PRF;NEG;QUOT
 võima	ei võiks	V;ACT;PRS;PRF;POS;COND;1;SG
 võima	võidud	V.PTCP;PASS;PST
 võima	olid võinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -34322,7 +34322,7 @@ võima	olgu võidud	V;PASS;PRS;PRF;POS;IMP
 võima	võiks	V;ACT;PRS;POS;COND;3;SG
 võima	võigu	V;ACT;PRS;POS;IMP;3;PL
 võima	ärgu olgu võinud	V;ACT;PRS;PRF;NEG;IMP;SG
-võima	ei ole võinudp	V;ACT;PST;NEG;IND
+võima	ei ole võinud	V;ACT;PST;NEG;IND
 võima	võid	V;ACT;PRS;POS;IND;2;SG
 võima	ära või	V;ACT;PRS;NEG;IMP;2;SG
 võima	ei või	V;ACT;PRS;NEG;IND
@@ -34350,17 +34350,17 @@ võima	ei võida	V;PASS;PRS;NEG;IND
 võima	võime	V;ACT;PRS;POS;IND;1;PL
 võima	võin	V;ACT;PRS;POS;IND;1;SG
 võima	ärgem võigem	V;ACT;PRS;NEG;IMP;1;PL
-võima	ei oleks võinudp	V;ACT;PRS;PRF;NEG;COND
+võima	ei oleks võinud	V;ACT;PRS;PRF;NEG;COND
 võima	oleksid võinud	V;ACT;PRS;PRF;POS;COND;3;PL
 võima	võisite	V;ACT;PST;POS;IND;2;PL
 võima	oleks võinud	V;ACT;PRS;PRF;POS;COND;3;SG
 võima	olin võinud	V;ACT;PRS;PRF;POS;COND;1;SG
 võima	oled võinud	V;ACT;PRS;PRF;POS;IND;2;SG
 võima	oli võinud	V;ACT;PRS;PRF;POS;COND;3;SG
-võima	ei ole võidudp	V;PASS;PRS;PRF;NEG;IND
+võima	ei ole võidud	V;PASS;PRS;PRF;NEG;IND
 võima	võiksin	V;ACT;PRS;POS;COND;1;SG
 võima	olen võinud	V;ACT;PRS;PRF;POS;IND;1;SG
-võima	ei olnud võidudp	V;PASS;PST;PRF;NEG;IND
+võima	ei olnud võidud	V;PASS;PST;PRF;NEG;IND
 võima	ärgu olgu võidud	V;PASS;PRS;PRF;NEG;IMP
 
 võimalus	võimalusseni	N;TERM;SG
@@ -34426,7 +34426,7 @@ võitja	võitjatesse	N;IN+ALL;PL
 võitja	võitjatelt	N;AT+ABL;PL
 
 võitma	olete võitnud	V;ACT;PRS;PRF;POS;IND;2;PL
-võitma	ei olevat võitnudp	V;ACT;PRS;PRF;NEG;QUOT
+võitma	ei olevat võitnud	V;ACT;PRS;PRF;NEG;QUOT
 võitma	oleks võidetud	V;PASS;PRS;PRF;POS;COND
 võitma	võitsin	V;ACT;PST;POS;IND;1;SG
 võitma	võidetakse	V;PASS;PRS;POS;IND
@@ -34435,7 +34435,7 @@ võitma	võidetagu	V;PASS;PRS;POS;IMP
 võitma	ärgu võitku	V;ACT;PRS;NEG;IMP;3;SG
 võitma	oli võidetud	V;PASS;PST;PRF;POS;IND
 võitma	võitsime	V;ACT;PST;POS;IND;1;PL
-võitma	ei olnud võitnudp	V;ACT;PST;PRF;NEG;IND
+võitma	ei olnud võitnud	V;ACT;PST;PRF;NEG;IND
 võitma	oleksid võitnud	V;ACT;PRS;PRF;POS;COND;2;SG
 võitma	olgu võitnud	V;ACT;PRS;PRF;POS;IMP;PL
 võitma	oli võitnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -34449,9 +34449,9 @@ võitma	ärgu võitku	V;ACT;PRS;NEG;IMP;3;PL
 võitma	olgu võitnud	V;ACT;PRS;PRF;POS;IMP;SG
 võitma	võideti	V;PASS;PST;POS;IND
 võitma	ei võitvat	V;ACT;PRS;NEG;QUOT
-võitma	ei oleks võidetudp	V;PASS;PRS;PRF;NEG;COND
+võitma	ei oleks võidetud	V;PASS;PRS;PRF;NEG;COND
 võitma	ei võitnud	V;ACT;PST;NEG;IND
-võitma	ei olevat võidetudp	V;PASS;PRS;PRF;NEG;QUOT
+võitma	ei olevat võidetud	V;PASS;PRS;PRF;NEG;QUOT
 võitma	ei võidaks	V;ACT;PRS;PRF;POS;COND;1;SG
 võitma	võidetud	V.PTCP;PASS;PST
 võitma	olid võitnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -34470,7 +34470,7 @@ võitma	olgu võidetud	V;PASS;PRS;PRF;POS;IMP
 võitma	võidaks	V;ACT;PRS;POS;COND;3;SG
 võitma	võitku	V;ACT;PRS;POS;IMP;3;PL
 võitma	ärgu olgu võitnud	V;ACT;PRS;PRF;NEG;IMP;SG
-võitma	ei ole võitnudp	V;ACT;PST;NEG;IND
+võitma	ei ole võitnud	V;ACT;PST;NEG;IND
 võitma	võidad	V;ACT;PRS;POS;IND;2;SG
 võitma	ära võida	V;ACT;PRS;NEG;IMP;2;SG
 võitma	ei võida	V;ACT;PRS;NEG;IND
@@ -34498,17 +34498,17 @@ võitma	ei võideta	V;PASS;PRS;NEG;IND
 võitma	võidame	V;ACT;PRS;POS;IND;1;PL
 võitma	võidan	V;ACT;PRS;POS;IND;1;SG
 võitma	ärgem võitkem	V;ACT;PRS;NEG;IMP;1;PL
-võitma	ei oleks võitnudp	V;ACT;PRS;PRF;NEG;COND
+võitma	ei oleks võitnud	V;ACT;PRS;PRF;NEG;COND
 võitma	oleksid võitnud	V;ACT;PRS;PRF;POS;COND;3;PL
 võitma	võitsite	V;ACT;PST;POS;IND;2;PL
 võitma	oleks võitnud	V;ACT;PRS;PRF;POS;COND;3;SG
 võitma	olin võitnud	V;ACT;PRS;PRF;POS;COND;1;SG
 võitma	oled võitnud	V;ACT;PRS;PRF;POS;IND;2;SG
 võitma	oli võitnud	V;ACT;PRS;PRF;POS;COND;3;SG
-võitma	ei ole võidetudp	V;PASS;PRS;PRF;NEG;IND
+võitma	ei ole võidetud	V;PASS;PRS;PRF;NEG;IND
 võitma	võidaksin	V;ACT;PRS;POS;COND;1;SG
 võitma	olen võitnud	V;ACT;PRS;PRF;POS;IND;1;SG
-võitma	ei olnud võidetudp	V;PASS;PST;PRF;NEG;IND
+võitma	ei olnud võidetud	V;PASS;PST;PRF;NEG;IND
 võitma	ärgu olgu võidetud	V;PASS;PRS;PRF;NEG;IMP
 
 võlur	võlurini	N;TERM;SG
@@ -34543,7 +34543,7 @@ võlur	võluritesse	N;IN+ALL;PL
 võlur	võluritelt	N;AT+ABL;PL
 
 võrduma	olete võrdunud	V;ACT;PRS;PRF;POS;IND;2;PL
-võrduma	ei olevat võrdunudp	V;ACT;PRS;PRF;NEG;QUOT
+võrduma	ei olevat võrdunud	V;ACT;PRS;PRF;NEG;QUOT
 võrduma	oleks võrdutud	V;PASS;PRS;PRF;POS;COND
 võrduma	võrdusin	V;ACT;PST;POS;IND;1;SG
 võrduma	võrdutakse	V;PASS;PRS;POS;IND
@@ -34552,7 +34552,7 @@ võrduma	võrdutagu	V;PASS;PRS;POS;IMP
 võrduma	ärgu võrdugu	V;ACT;PRS;NEG;IMP;3;SG
 võrduma	oli võrdutud	V;PASS;PST;PRF;POS;IND
 võrduma	võrdusime	V;ACT;PST;POS;IND;1;PL
-võrduma	ei olnud võrdunudp	V;ACT;PST;PRF;NEG;IND
+võrduma	ei olnud võrdunud	V;ACT;PST;PRF;NEG;IND
 võrduma	oleksid võrdunud	V;ACT;PRS;PRF;POS;COND;2;SG
 võrduma	olgu võrdunud	V;ACT;PRS;PRF;POS;IMP;PL
 võrduma	oli võrdunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -34566,9 +34566,9 @@ võrduma	ärgu võrdugu	V;ACT;PRS;NEG;IMP;3;PL
 võrduma	olgu võrdunud	V;ACT;PRS;PRF;POS;IMP;SG
 võrduma	võrduti	V;PASS;PST;POS;IND
 võrduma	ei võrduvat	V;ACT;PRS;NEG;QUOT
-võrduma	ei oleks võrdutudp	V;PASS;PRS;PRF;NEG;COND
+võrduma	ei oleks võrdutud	V;PASS;PRS;PRF;NEG;COND
 võrduma	ei võrdunud	V;ACT;PST;NEG;IND
-võrduma	ei olevat võrdutudp	V;PASS;PRS;PRF;NEG;QUOT
+võrduma	ei olevat võrdutud	V;PASS;PRS;PRF;NEG;QUOT
 võrduma	ei võrduks	V;ACT;PRS;PRF;POS;COND;1;SG
 võrduma	võrdutud	V.PTCP;PASS;PST
 võrduma	olid võrdunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -34587,7 +34587,7 @@ võrduma	olgu võrdutud	V;PASS;PRS;PRF;POS;IMP
 võrduma	võrduks	V;ACT;PRS;POS;COND;3;SG
 võrduma	võrdugu	V;ACT;PRS;POS;IMP;3;PL
 võrduma	ärgu olgu võrdunud	V;ACT;PRS;PRF;NEG;IMP;SG
-võrduma	ei ole võrdunudp	V;ACT;PST;NEG;IND
+võrduma	ei ole võrdunud	V;ACT;PST;NEG;IND
 võrduma	võrdud	V;ACT;PRS;POS;IND;2;SG
 võrduma	ära võrdu	V;ACT;PRS;NEG;IMP;2;SG
 võrduma	ei võrdu	V;ACT;PRS;NEG;IND
@@ -34615,21 +34615,21 @@ võrduma	ei võrduta	V;PASS;PRS;NEG;IND
 võrduma	võrdume	V;ACT;PRS;POS;IND;1;PL
 võrduma	võrdun	V;ACT;PRS;POS;IND;1;SG
 võrduma	ärgem võrdugem	V;ACT;PRS;NEG;IMP;1;PL
-võrduma	ei oleks võrdunudp	V;ACT;PRS;PRF;NEG;COND
+võrduma	ei oleks võrdunud	V;ACT;PRS;PRF;NEG;COND
 võrduma	oleksid võrdunud	V;ACT;PRS;PRF;POS;COND;3;PL
 võrduma	võrdusite	V;ACT;PST;POS;IND;2;PL
 võrduma	oleks võrdunud	V;ACT;PRS;PRF;POS;COND;3;SG
 võrduma	olin võrdunud	V;ACT;PRS;PRF;POS;COND;1;SG
 võrduma	oled võrdunud	V;ACT;PRS;PRF;POS;IND;2;SG
 võrduma	oli võrdunud	V;ACT;PRS;PRF;POS;COND;3;SG
-võrduma	ei ole võrdutudp	V;PASS;PRS;PRF;NEG;IND
+võrduma	ei ole võrdutud	V;PASS;PRS;PRF;NEG;IND
 võrduma	võrduksin	V;ACT;PRS;POS;COND;1;SG
 võrduma	olen võrdunud	V;ACT;PRS;PRF;POS;IND;1;SG
-võrduma	ei olnud võrdutudp	V;PASS;PST;PRF;NEG;IND
+võrduma	ei olnud võrdutud	V;PASS;PST;PRF;NEG;IND
 võrduma	ärgu olgu võrdutud	V;PASS;PRS;PRF;NEG;IMP
 
 võtma	olete võtnud	V;ACT;PRS;PRF;POS;IND;2;PL
-võtma	ei olevat võtnudp	V;ACT;PRS;PRF;NEG;QUOT
+võtma	ei olevat võtnud	V;ACT;PRS;PRF;NEG;QUOT
 võtma	oleks võtetud	V;PASS;PRS;PRF;POS;COND
 võtma	võtsin	V;ACT;PST;POS;IND;1;SG
 võtma	võtetakse	V;PASS;PRS;POS;IND
@@ -34638,7 +34638,7 @@ võtma	võtetagu	V;PASS;PRS;POS;IMP
 võtma	ärgu võtku	V;ACT;PRS;NEG;IMP;3;SG
 võtma	oli võtetud	V;PASS;PST;PRF;POS;IND
 võtma	võtsime	V;ACT;PST;POS;IND;1;PL
-võtma	ei olnud võtnudp	V;ACT;PST;PRF;NEG;IND
+võtma	ei olnud võtnud	V;ACT;PST;PRF;NEG;IND
 võtma	oleksid võtnud	V;ACT;PRS;PRF;POS;COND;2;SG
 võtma	olgu võtnud	V;ACT;PRS;PRF;POS;IMP;PL
 võtma	oli võtnud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -34652,9 +34652,9 @@ võtma	ärgu võtku	V;ACT;PRS;NEG;IMP;3;PL
 võtma	olgu võtnud	V;ACT;PRS;PRF;POS;IMP;SG
 võtma	võteti	V;PASS;PST;POS;IND
 võtma	ei võtvat	V;ACT;PRS;NEG;QUOT
-võtma	ei oleks võtetudp	V;PASS;PRS;PRF;NEG;COND
+võtma	ei oleks võtetud	V;PASS;PRS;PRF;NEG;COND
 võtma	ei võtnud	V;ACT;PST;NEG;IND
-võtma	ei olevat võtetudp	V;PASS;PRS;PRF;NEG;QUOT
+võtma	ei olevat võtetud	V;PASS;PRS;PRF;NEG;QUOT
 võtma	ei võtaks	V;ACT;PRS;PRF;POS;COND;1;SG
 võtma	võtetud	V.PTCP;PASS;PST
 võtma	olid võtnud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -34673,7 +34673,7 @@ võtma	olgu võtetud	V;PASS;PRS;PRF;POS;IMP
 võtma	võtaks	V;ACT;PRS;POS;COND;3;SG
 võtma	võtku	V;ACT;PRS;POS;IMP;3;PL
 võtma	ärgu olgu võtnud	V;ACT;PRS;PRF;NEG;IMP;SG
-võtma	ei ole võtnudp	V;ACT;PST;NEG;IND
+võtma	ei ole võtnud	V;ACT;PST;NEG;IND
 võtma	võtad	V;ACT;PRS;POS;IND;2;SG
 võtma	ära võta	V;ACT;PRS;NEG;IMP;2;SG
 võtma	ei võta	V;ACT;PRS;NEG;IND
@@ -34701,17 +34701,17 @@ võtma	ei võteta	V;PASS;PRS;NEG;IND
 võtma	võtame	V;ACT;PRS;POS;IND;1;PL
 võtma	võtan	V;ACT;PRS;POS;IND;1;SG
 võtma	ärgem võtkem	V;ACT;PRS;NEG;IMP;1;PL
-võtma	ei oleks võtnudp	V;ACT;PRS;PRF;NEG;COND
+võtma	ei oleks võtnud	V;ACT;PRS;PRF;NEG;COND
 võtma	oleksid võtnud	V;ACT;PRS;PRF;POS;COND;3;PL
 võtma	võtsite	V;ACT;PST;POS;IND;2;PL
 võtma	oleks võtnud	V;ACT;PRS;PRF;POS;COND;3;SG
 võtma	olin võtnud	V;ACT;PRS;PRF;POS;COND;1;SG
 võtma	oled võtnud	V;ACT;PRS;PRF;POS;IND;2;SG
 võtma	oli võtnud	V;ACT;PRS;PRF;POS;COND;3;SG
-võtma	ei ole võtetudp	V;PASS;PRS;PRF;NEG;IND
+võtma	ei ole võtetud	V;PASS;PRS;PRF;NEG;IND
 võtma	võtaksin	V;ACT;PRS;POS;COND;1;SG
 võtma	olen võtnud	V;ACT;PRS;PRF;POS;IND;1;SG
-võtma	ei olnud võtetudp	V;PASS;PST;PRF;NEG;IND
+võtma	ei olnud võtetud	V;PASS;PST;PRF;NEG;IND
 võtma	ärgu olgu võtetud	V;PASS;PRS;PRF;NEG;IMP
 
 vöö	vööni	N;TERM;SG
@@ -35149,7 +35149,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 õpetaja	õpetajatelt	N;AT+ABL;PL
 
 õpetama	olete õpetanud	V;ACT;PRS;PRF;POS;IND;2;PL
-õpetama	ei olevat õpetanudp	V;ACT;PRS;PRF;NEG;QUOT
+õpetama	ei olevat õpetanud	V;ACT;PRS;PRF;NEG;QUOT
 õpetama	oleks õpetatud	V;PASS;PRS;PRF;POS;COND
 õpetama	õpetasin	V;ACT;PST;POS;IND;1;SG
 õpetama	õpetatakse	V;PASS;PRS;POS;IND
@@ -35158,7 +35158,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 õpetama	ärgu õpetagu	V;ACT;PRS;NEG;IMP;3;SG
 õpetama	oli õpetatud	V;PASS;PST;PRF;POS;IND
 õpetama	õpetasime	V;ACT;PST;POS;IND;1;PL
-õpetama	ei olnud õpetanudp	V;ACT;PST;PRF;NEG;IND
+õpetama	ei olnud õpetanud	V;ACT;PST;PRF;NEG;IND
 õpetama	oleksid õpetanud	V;ACT;PRS;PRF;POS;COND;2;SG
 õpetama	olgu õpetanud	V;ACT;PRS;PRF;POS;IMP;PL
 õpetama	oli õpetanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -35172,9 +35172,9 @@ ankur	ankrutelt	N;AT+ABL;PL
 õpetama	olgu õpetanud	V;ACT;PRS;PRF;POS;IMP;SG
 õpetama	õpetati	V;PASS;PST;POS;IND
 õpetama	ei õpetavat	V;ACT;PRS;NEG;QUOT
-õpetama	ei oleks õpetatudp	V;PASS;PRS;PRF;NEG;COND
+õpetama	ei oleks õpetatud	V;PASS;PRS;PRF;NEG;COND
 õpetama	ei õpetanud	V;ACT;PST;NEG;IND
-õpetama	ei olevat õpetatudp	V;PASS;PRS;PRF;NEG;QUOT
+õpetama	ei olevat õpetatud	V;PASS;PRS;PRF;NEG;QUOT
 õpetama	ei õpetaks	V;ACT;PRS;PRF;POS;COND;1;SG
 õpetama	õpetatud	V.PTCP;PASS;PST
 õpetama	olid õpetanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -35193,7 +35193,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 õpetama	õpetaks	V;ACT;PRS;POS;COND;3;SG
 õpetama	õpetagu	V;ACT;PRS;POS;IMP;3;PL
 õpetama	ärgu olgu õpetanud	V;ACT;PRS;PRF;NEG;IMP;SG
-õpetama	ei ole õpetanudp	V;ACT;PST;NEG;IND
+õpetama	ei ole õpetanud	V;ACT;PST;NEG;IND
 õpetama	õpetad	V;ACT;PRS;POS;IND;2;SG
 õpetama	ära õpeta	V;ACT;PRS;NEG;IMP;2;SG
 õpetama	ei õpeta	V;ACT;PRS;NEG;IND
@@ -35221,17 +35221,17 @@ ankur	ankrutelt	N;AT+ABL;PL
 õpetama	õpetame	V;ACT;PRS;POS;IND;1;PL
 õpetama	õpetan	V;ACT;PRS;POS;IND;1;SG
 õpetama	ärgem õpetagem	V;ACT;PRS;NEG;IMP;1;PL
-õpetama	ei oleks õpetanudp	V;ACT;PRS;PRF;NEG;COND
+õpetama	ei oleks õpetanud	V;ACT;PRS;PRF;NEG;COND
 õpetama	oleksid õpetanud	V;ACT;PRS;PRF;POS;COND;3;PL
 õpetama	õpetasite	V;ACT;PST;POS;IND;2;PL
 õpetama	oleks õpetanud	V;ACT;PRS;PRF;POS;COND;3;SG
 õpetama	olin õpetanud	V;ACT;PRS;PRF;POS;COND;1;SG
 õpetama	oled õpetanud	V;ACT;PRS;PRF;POS;IND;2;SG
 õpetama	oli õpetanud	V;ACT;PRS;PRF;POS;COND;3;SG
-õpetama	ei ole õpetatudp	V;PASS;PRS;PRF;NEG;IND
+õpetama	ei ole õpetatud	V;PASS;PRS;PRF;NEG;IND
 õpetama	õpetaksin	V;ACT;PRS;POS;COND;1;SG
 õpetama	olen õpetanud	V;ACT;PRS;PRF;POS;IND;1;SG
-õpetama	ei olnud õpetatudp	V;PASS;PST;PRF;NEG;IND
+õpetama	ei olnud õpetatud	V;PASS;PST;PRF;NEG;IND
 õpetama	ärgu olgu õpetatud	V;PASS;PRS;PRF;NEG;IMP
 
 õpetamine	õpetamiseni	N;TERM;SG
@@ -35328,7 +35328,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 õpilane	õpilastelt	N;AT+ABL;PL
 
 õppima	olete õppinud	V;ACT;PRS;PRF;POS;IND;2;PL
-õppima	ei olevat õppinudp	V;ACT;PRS;PRF;NEG;QUOT
+õppima	ei olevat õppinud	V;ACT;PRS;PRF;NEG;QUOT
 õppima	oleks õpitud	V;PASS;PRS;PRF;POS;COND
 õppima	õppisin	V;ACT;PST;POS;IND;1;SG
 õppima	õpitakse	V;PASS;PRS;POS;IND
@@ -35337,7 +35337,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 õppima	ärgu õppigu	V;ACT;PRS;NEG;IMP;3;SG
 õppima	oli õpitud	V;PASS;PST;PRF;POS;IND
 õppima	õppisime	V;ACT;PST;POS;IND;1;PL
-õppima	ei olnud õppinudp	V;ACT;PST;PRF;NEG;IND
+õppima	ei olnud õppinud	V;ACT;PST;PRF;NEG;IND
 õppima	oleksid õppinud	V;ACT;PRS;PRF;POS;COND;2;SG
 õppima	olgu õppinud	V;ACT;PRS;PRF;POS;IMP;PL
 õppima	oli õppinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -35351,9 +35351,9 @@ ankur	ankrutelt	N;AT+ABL;PL
 õppima	olgu õppinud	V;ACT;PRS;PRF;POS;IMP;SG
 õppima	õpiti	V;PASS;PST;POS;IND
 õppima	ei õppivat	V;ACT;PRS;NEG;QUOT
-õppima	ei oleks õpitudp	V;PASS;PRS;PRF;NEG;COND
+õppima	ei oleks õpitud	V;PASS;PRS;PRF;NEG;COND
 õppima	ei õppinud	V;ACT;PST;NEG;IND
-õppima	ei olevat õpitudp	V;PASS;PRS;PRF;NEG;QUOT
+õppima	ei olevat õpitud	V;PASS;PRS;PRF;NEG;QUOT
 õppima	ei õpiks	V;ACT;PRS;PRF;POS;COND;1;SG
 õppima	õpitud	V.PTCP;PASS;PST
 õppima	olid õppinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -35372,7 +35372,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 õppima	õpiks	V;ACT;PRS;POS;COND;3;SG
 õppima	õppigu	V;ACT;PRS;POS;IMP;3;PL
 õppima	ärgu olgu õppinud	V;ACT;PRS;PRF;NEG;IMP;SG
-õppima	ei ole õppinudp	V;ACT;PST;NEG;IND
+õppima	ei ole õppinud	V;ACT;PST;NEG;IND
 õppima	õpid	V;ACT;PRS;POS;IND;2;SG
 õppima	ära õpi	V;ACT;PRS;NEG;IMP;2;SG
 õppima	ei õpi	V;ACT;PRS;NEG;IND
@@ -35400,17 +35400,17 @@ ankur	ankrutelt	N;AT+ABL;PL
 õppima	õpime	V;ACT;PRS;POS;IND;1;PL
 õppima	õpin	V;ACT;PRS;POS;IND;1;SG
 õppima	ärgem õppigem	V;ACT;PRS;NEG;IMP;1;PL
-õppima	ei oleks õppinudp	V;ACT;PRS;PRF;NEG;COND
+õppima	ei oleks õppinud	V;ACT;PRS;PRF;NEG;COND
 õppima	oleksid õppinud	V;ACT;PRS;PRF;POS;COND;3;PL
 õppima	õppisite	V;ACT;PST;POS;IND;2;PL
 õppima	oleks õppinud	V;ACT;PRS;PRF;POS;COND;3;SG
 õppima	olin õppinud	V;ACT;PRS;PRF;POS;COND;1;SG
 õppima	oled õppinud	V;ACT;PRS;PRF;POS;IND;2;SG
 õppima	oli õppinud	V;ACT;PRS;PRF;POS;COND;3;SG
-õppima	ei ole õpitudp	V;PASS;PRS;PRF;NEG;IND
+õppima	ei ole õpitud	V;PASS;PRS;PRF;NEG;IND
 õppima	õpiksin	V;ACT;PRS;POS;COND;1;SG
 õppima	olen õppinud	V;ACT;PRS;PRF;POS;IND;1;SG
-õppima	ei olnud õpitudp	V;PASS;PST;PRF;NEG;IND
+õppima	ei olnud õpitud	V;PASS;PST;PRF;NEG;IND
 õppima	ärgu olgu õpitud	V;PASS;PRS;PRF;NEG;IMP
 
 õppimine	õppimiseni	N;TERM;SG
@@ -35538,7 +35538,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 ööbik	ööbikutelt	N;AT+ABL;PL
 
 öökima	olete öökinud	V;ACT;PRS;PRF;POS;IND;2;PL
-öökima	ei olevat öökinudp	V;ACT;PRS;PRF;NEG;QUOT
+öökima	ei olevat öökinud	V;ACT;PRS;PRF;NEG;QUOT
 öökima	oleks öögitud	V;PASS;PRS;PRF;POS;COND
 öökima	öökisin	V;ACT;PST;POS;IND;1;SG
 öökima	öögitakse	V;PASS;PRS;POS;IND
@@ -35547,7 +35547,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 öökima	ärgu öökigu	V;ACT;PRS;NEG;IMP;3;SG
 öökima	oli öögitud	V;PASS;PST;PRF;POS;IND
 öökima	öökisime	V;ACT;PST;POS;IND;1;PL
-öökima	ei olnud öökinudp	V;ACT;PST;PRF;NEG;IND
+öökima	ei olnud öökinud	V;ACT;PST;PRF;NEG;IND
 öökima	oleksid öökinud	V;ACT;PRS;PRF;POS;COND;2;SG
 öökima	olgu öökinud	V;ACT;PRS;PRF;POS;IMP;PL
 öökima	oli öökinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -35561,9 +35561,9 @@ ankur	ankrutelt	N;AT+ABL;PL
 öökima	olgu öökinud	V;ACT;PRS;PRF;POS;IMP;SG
 öökima	öögiti	V;PASS;PST;POS;IND
 öökima	ei öökivat	V;ACT;PRS;NEG;QUOT
-öökima	ei oleks öögitudp	V;PASS;PRS;PRF;NEG;COND
+öökima	ei oleks öögitud	V;PASS;PRS;PRF;NEG;COND
 öökima	ei öökinud	V;ACT;PST;NEG;IND
-öökima	ei olevat öögitudp	V;PASS;PRS;PRF;NEG;QUOT
+öökima	ei olevat öögitud	V;PASS;PRS;PRF;NEG;QUOT
 öökima	ei öögiks	V;ACT;PRS;PRF;POS;COND;1;SG
 öökima	öögitud	V.PTCP;PASS;PST
 öökima	olid öökinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -35582,7 +35582,7 @@ ankur	ankrutelt	N;AT+ABL;PL
 öökima	öögiks	V;ACT;PRS;POS;COND;3;SG
 öökima	öökigu	V;ACT;PRS;POS;IMP;3;PL
 öökima	ärgu olgu öökinud	V;ACT;PRS;PRF;NEG;IMP;SG
-öökima	ei ole öökinudp	V;ACT;PST;NEG;IND
+öökima	ei ole öökinud	V;ACT;PST;NEG;IND
 öökima	öögid	V;ACT;PRS;POS;IND;2;SG
 öökima	ära öögi	V;ACT;PRS;NEG;IMP;2;SG
 öökima	ei öögi	V;ACT;PRS;NEG;IND
@@ -35610,17 +35610,17 @@ ankur	ankrutelt	N;AT+ABL;PL
 öökima	öögime	V;ACT;PRS;POS;IND;1;PL
 öökima	öögin	V;ACT;PRS;POS;IND;1;SG
 öökima	ärgem öökigem	V;ACT;PRS;NEG;IMP;1;PL
-öökima	ei oleks öökinudp	V;ACT;PRS;PRF;NEG;COND
+öökima	ei oleks öökinud	V;ACT;PRS;PRF;NEG;COND
 öökima	oleksid öökinud	V;ACT;PRS;PRF;POS;COND;3;PL
 öökima	öökisite	V;ACT;PST;POS;IND;2;PL
 öökima	oleks öökinud	V;ACT;PRS;PRF;POS;COND;3;SG
 öökima	olin öökinud	V;ACT;PRS;PRF;POS;COND;1;SG
 öökima	oled öökinud	V;ACT;PRS;PRF;POS;IND;2;SG
 öökima	oli öökinud	V;ACT;PRS;PRF;POS;COND;3;SG
-öökima	ei ole öögitudp	V;PASS;PRS;PRF;NEG;IND
+öökima	ei ole öögitud	V;PASS;PRS;PRF;NEG;IND
 öökima	öögiksin	V;ACT;PRS;POS;COND;1;SG
 öökima	olen öökinud	V;ACT;PRS;PRF;POS;IND;1;SG
-öökima	ei olnud öögitudp	V;PASS;PST;PRF;NEG;IND
+öökima	ei olnud öögitud	V;PASS;PST;PRF;NEG;IND
 öökima	ärgu olgu öögitud	V;PASS;PRS;PRF;NEG;IMP
 
 ööklubi	ööklubini	N;TERM;SG
@@ -35686,7 +35686,7 @@ antimon	antimondesse	N;IN+ALL;PL
 antimon	antimondelt	N;AT+ABL;PL
 
 ühendama	olete ühendanud	V;ACT;PRS;PRF;POS;IND;2;PL
-ühendama	ei olevat ühendanudp	V;ACT;PRS;PRF;NEG;QUOT
+ühendama	ei olevat ühendanud	V;ACT;PRS;PRF;NEG;QUOT
 ühendama	oleks ühendatud	V;PASS;PRS;PRF;POS;COND
 ühendama	ühendasin	V;ACT;PST;POS;IND;1;SG
 ühendama	ühendatakse	V;PASS;PRS;POS;IND
@@ -35695,7 +35695,7 @@ antimon	antimondelt	N;AT+ABL;PL
 ühendama	ärgu ühendagu	V;ACT;PRS;NEG;IMP;3;SG
 ühendama	oli ühendatud	V;PASS;PST;PRF;POS;IND
 ühendama	ühendasime	V;ACT;PST;POS;IND;1;PL
-ühendama	ei olnud ühendanudp	V;ACT;PST;PRF;NEG;IND
+ühendama	ei olnud ühendanud	V;ACT;PST;PRF;NEG;IND
 ühendama	oleksid ühendanud	V;ACT;PRS;PRF;POS;COND;2;SG
 ühendama	olgu ühendanud	V;ACT;PRS;PRF;POS;IMP;PL
 ühendama	oli ühendanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -35709,9 +35709,9 @@ antimon	antimondelt	N;AT+ABL;PL
 ühendama	olgu ühendanud	V;ACT;PRS;PRF;POS;IMP;SG
 ühendama	ühendati	V;PASS;PST;POS;IND
 ühendama	ei ühendavat	V;ACT;PRS;NEG;QUOT
-ühendama	ei oleks ühendatudp	V;PASS;PRS;PRF;NEG;COND
+ühendama	ei oleks ühendatud	V;PASS;PRS;PRF;NEG;COND
 ühendama	ei ühendanud	V;ACT;PST;NEG;IND
-ühendama	ei olevat ühendatudp	V;PASS;PRS;PRF;NEG;QUOT
+ühendama	ei olevat ühendatud	V;PASS;PRS;PRF;NEG;QUOT
 ühendama	ei ühendaks	V;ACT;PRS;PRF;POS;COND;1;SG
 ühendama	ühendatud	V.PTCP;PASS;PST
 ühendama	olid ühendanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -35730,7 +35730,7 @@ antimon	antimondelt	N;AT+ABL;PL
 ühendama	ühendaks	V;ACT;PRS;POS;COND;3;SG
 ühendama	ühendagu	V;ACT;PRS;POS;IMP;3;PL
 ühendama	ärgu olgu ühendanud	V;ACT;PRS;PRF;NEG;IMP;SG
-ühendama	ei ole ühendanudp	V;ACT;PST;NEG;IND
+ühendama	ei ole ühendanud	V;ACT;PST;NEG;IND
 ühendama	ühendad	V;ACT;PRS;POS;IND;2;SG
 ühendama	ära ühenda	V;ACT;PRS;NEG;IMP;2;SG
 ühendama	ei ühenda	V;ACT;PRS;NEG;IND
@@ -35758,17 +35758,17 @@ antimon	antimondelt	N;AT+ABL;PL
 ühendama	ühendame	V;ACT;PRS;POS;IND;1;PL
 ühendama	ühendan	V;ACT;PRS;POS;IND;1;SG
 ühendama	ärgem ühendagem	V;ACT;PRS;NEG;IMP;1;PL
-ühendama	ei oleks ühendanudp	V;ACT;PRS;PRF;NEG;COND
+ühendama	ei oleks ühendanud	V;ACT;PRS;PRF;NEG;COND
 ühendama	oleksid ühendanud	V;ACT;PRS;PRF;POS;COND;3;PL
 ühendama	ühendasite	V;ACT;PST;POS;IND;2;PL
 ühendama	oleks ühendanud	V;ACT;PRS;PRF;POS;COND;3;SG
 ühendama	olin ühendanud	V;ACT;PRS;PRF;POS;COND;1;SG
 ühendama	oled ühendanud	V;ACT;PRS;PRF;POS;IND;2;SG
 ühendama	oli ühendanud	V;ACT;PRS;PRF;POS;COND;3;SG
-ühendama	ei ole ühendatudp	V;PASS;PRS;PRF;NEG;IND
+ühendama	ei ole ühendatud	V;PASS;PRS;PRF;NEG;IND
 ühendama	ühendaksin	V;ACT;PRS;POS;COND;1;SG
 ühendama	olen ühendanud	V;ACT;PRS;PRF;POS;IND;1;SG
-ühendama	ei olnud ühendatudp	V;PASS;PST;PRF;NEG;IND
+ühendama	ei olnud ühendatud	V;PASS;PST;PRF;NEG;IND
 ühendama	ärgu olgu ühendatud	V;PASS;PRS;PRF;NEG;IMP
 
 ükssarvik	ükssarvikuni	N;TERM;SG
@@ -35865,7 +35865,7 @@ antimon	antimondelt	N;AT+ABL;PL
 ümberlõikamine	ümberlõikamistelt	N;AT+ABL;PL
 
 üritama	olete üritanud	V;ACT;PRS;PRF;POS;IND;2;PL
-üritama	ei olevat üritanudp	V;ACT;PRS;PRF;NEG;QUOT
+üritama	ei olevat üritanud	V;ACT;PRS;PRF;NEG;QUOT
 üritama	oleks üritatud	V;PASS;PRS;PRF;POS;COND
 üritama	üritasin	V;ACT;PST;POS;IND;1;SG
 üritama	üritatakse	V;PASS;PRS;POS;IND
@@ -35874,7 +35874,7 @@ antimon	antimondelt	N;AT+ABL;PL
 üritama	ärgu üritagu	V;ACT;PRS;NEG;IMP;3;SG
 üritama	oli üritatud	V;PASS;PST;PRF;POS;IND
 üritama	üritasime	V;ACT;PST;POS;IND;1;PL
-üritama	ei olnud üritanudp	V;ACT;PST;PRF;NEG;IND
+üritama	ei olnud üritanud	V;ACT;PST;PRF;NEG;IND
 üritama	oleksid üritanud	V;ACT;PRS;PRF;POS;COND;2;SG
 üritama	olgu üritanud	V;ACT;PRS;PRF;POS;IMP;PL
 üritama	oli üritanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -35888,9 +35888,9 @@ antimon	antimondelt	N;AT+ABL;PL
 üritama	olgu üritanud	V;ACT;PRS;PRF;POS;IMP;SG
 üritama	üritati	V;PASS;PST;POS;IND
 üritama	ei üritavat	V;ACT;PRS;NEG;QUOT
-üritama	ei oleks üritatudp	V;PASS;PRS;PRF;NEG;COND
+üritama	ei oleks üritatud	V;PASS;PRS;PRF;NEG;COND
 üritama	ei üritanud	V;ACT;PST;NEG;IND
-üritama	ei olevat üritatudp	V;PASS;PRS;PRF;NEG;QUOT
+üritama	ei olevat üritatud	V;PASS;PRS;PRF;NEG;QUOT
 üritama	ei üritaks	V;ACT;PRS;PRF;POS;COND;1;SG
 üritama	üritatud	V.PTCP;PASS;PST
 üritama	olid üritanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -35909,7 +35909,7 @@ antimon	antimondelt	N;AT+ABL;PL
 üritama	üritaks	V;ACT;PRS;POS;COND;3;SG
 üritama	üritagu	V;ACT;PRS;POS;IMP;3;PL
 üritama	ärgu olgu üritanud	V;ACT;PRS;PRF;NEG;IMP;SG
-üritama	ei ole üritanudp	V;ACT;PST;NEG;IND
+üritama	ei ole üritanud	V;ACT;PST;NEG;IND
 üritama	üritad	V;ACT;PRS;POS;IND;2;SG
 üritama	ära ürita	V;ACT;PRS;NEG;IMP;2;SG
 üritama	ei ürita	V;ACT;PRS;NEG;IND
@@ -35937,17 +35937,17 @@ antimon	antimondelt	N;AT+ABL;PL
 üritama	üritame	V;ACT;PRS;POS;IND;1;PL
 üritama	üritan	V;ACT;PRS;POS;IND;1;SG
 üritama	ärgem üritagem	V;ACT;PRS;NEG;IMP;1;PL
-üritama	ei oleks üritanudp	V;ACT;PRS;PRF;NEG;COND
+üritama	ei oleks üritanud	V;ACT;PRS;PRF;NEG;COND
 üritama	oleksid üritanud	V;ACT;PRS;PRF;POS;COND;3;PL
 üritama	üritasite	V;ACT;PST;POS;IND;2;PL
 üritama	oleks üritanud	V;ACT;PRS;PRF;POS;COND;3;SG
 üritama	olin üritanud	V;ACT;PRS;PRF;POS;COND;1;SG
 üritama	oled üritanud	V;ACT;PRS;PRF;POS;IND;2;SG
 üritama	oli üritanud	V;ACT;PRS;PRF;POS;COND;3;SG
-üritama	ei ole üritatudp	V;PASS;PRS;PRF;NEG;IND
+üritama	ei ole üritatud	V;PASS;PRS;PRF;NEG;IND
 üritama	üritaksin	V;ACT;PRS;POS;COND;1;SG
 üritama	olen üritanud	V;ACT;PRS;PRF;POS;IND;1;SG
-üritama	ei olnud üritatudp	V;PASS;PST;PRF;NEG;IND
+üritama	ei olnud üritatud	V;PASS;PST;PRF;NEG;IND
 üritama	ärgu olgu üritatud	V;PASS;PRS;PRF;NEG;IMP
 
 üterbium	üterbiumini	N;TERM;SG
@@ -36199,7 +36199,7 @@ araablane	araablastesse	N;IN+ALL;PL
 araablane	araablastelt	N;AT+ABL;PL
 
 armastama	olete armastanud	V;ACT;PRS;PRF;POS;IND;2;PL
-armastama	ei olevat armastanudp	V;ACT;PRS;PRF;NEG;QUOT
+armastama	ei olevat armastanud	V;ACT;PRS;PRF;NEG;QUOT
 armastama	oleks armastatud	V;PASS;PRS;PRF;POS;COND
 armastama	armastasin	V;ACT;PST;POS;IND;1;SG
 armastama	armastatakse	V;PASS;PRS;POS;IND
@@ -36208,7 +36208,7 @@ armastama	armastatagu	V;PASS;PRS;POS;IMP
 armastama	ärgu armastagu	V;ACT;PRS;NEG;IMP;3;SG
 armastama	oli armastatud	V;PASS;PST;PRF;POS;IND
 armastama	armastasime	V;ACT;PST;POS;IND;1;PL
-armastama	ei olnud armastanudp	V;ACT;PST;PRF;NEG;IND
+armastama	ei olnud armastanud	V;ACT;PST;PRF;NEG;IND
 armastama	oleksid armastanud	V;ACT;PRS;PRF;POS;COND;2;SG
 armastama	olgu armastanud	V;ACT;PRS;PRF;POS;IMP;PL
 armastama	oli armastanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -36222,9 +36222,9 @@ armastama	ärgu armastagu	V;ACT;PRS;NEG;IMP;3;PL
 armastama	olgu armastanud	V;ACT;PRS;PRF;POS;IMP;SG
 armastama	armastati	V;PASS;PST;POS;IND
 armastama	ei armastavat	V;ACT;PRS;NEG;QUOT
-armastama	ei oleks armastatudp	V;PASS;PRS;PRF;NEG;COND
+armastama	ei oleks armastatud	V;PASS;PRS;PRF;NEG;COND
 armastama	ei armastanud	V;ACT;PST;NEG;IND
-armastama	ei olevat armastatudp	V;PASS;PRS;PRF;NEG;QUOT
+armastama	ei olevat armastatud	V;PASS;PRS;PRF;NEG;QUOT
 armastama	ei armastaks	V;ACT;PRS;PRF;POS;COND;1;SG
 armastama	armastatud	V.PTCP;PASS;PST
 armastama	olid armastanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -36243,7 +36243,7 @@ armastama	olgu armastatud	V;PASS;PRS;PRF;POS;IMP
 armastama	armastaks	V;ACT;PRS;POS;COND;3;SG
 armastama	armastagu	V;ACT;PRS;POS;IMP;3;PL
 armastama	ärgu olgu armastanud	V;ACT;PRS;PRF;NEG;IMP;SG
-armastama	ei ole armastanudp	V;ACT;PST;NEG;IND
+armastama	ei ole armastanud	V;ACT;PST;NEG;IND
 armastama	armastad	V;ACT;PRS;POS;IND;2;SG
 armastama	ära armasta	V;ACT;PRS;NEG;IMP;2;SG
 armastama	ei armasta	V;ACT;PRS;NEG;IND
@@ -36271,17 +36271,17 @@ armastama	ei armastata	V;PASS;PRS;NEG;IND
 armastama	armastame	V;ACT;PRS;POS;IND;1;PL
 armastama	armastan	V;ACT;PRS;POS;IND;1;SG
 armastama	ärgem armastagem	V;ACT;PRS;NEG;IMP;1;PL
-armastama	ei oleks armastanudp	V;ACT;PRS;PRF;NEG;COND
+armastama	ei oleks armastanud	V;ACT;PRS;PRF;NEG;COND
 armastama	oleksid armastanud	V;ACT;PRS;PRF;POS;COND;3;PL
 armastama	armastasite	V;ACT;PST;POS;IND;2;PL
 armastama	oleks armastanud	V;ACT;PRS;PRF;POS;COND;3;SG
 armastama	olin armastanud	V;ACT;PRS;PRF;POS;COND;1;SG
 armastama	oled armastanud	V;ACT;PRS;PRF;POS;IND;2;SG
 armastama	oli armastanud	V;ACT;PRS;PRF;POS;COND;3;SG
-armastama	ei ole armastatudp	V;PASS;PRS;PRF;NEG;IND
+armastama	ei ole armastatud	V;PASS;PRS;PRF;NEG;IND
 armastama	armastaksin	V;ACT;PRS;POS;COND;1;SG
 armastama	olen armastanud	V;ACT;PRS;PRF;POS;IND;1;SG
-armastama	ei olnud armastatudp	V;PASS;PST;PRF;NEG;IND
+armastama	ei olnud armastatud	V;PASS;PST;PRF;NEG;IND
 armastama	ärgu olgu armastatud	V;PASS;PRS;PRF;NEG;IMP
 
 armeenlane	armeenlaseni	N;TERM;SG
@@ -36316,7 +36316,7 @@ armeenlane	armeenlastesse	N;IN+ALL;PL
 armeenlane	armeenlastelt	N;AT+ABL;PL
 
 armuma	olete armunud	V;ACT;PRS;PRF;POS;IND;2;PL
-armuma	ei olevat armunudp	V;ACT;PRS;PRF;NEG;QUOT
+armuma	ei olevat armunud	V;ACT;PRS;PRF;NEG;QUOT
 armuma	oleks armutud	V;PASS;PRS;PRF;POS;COND
 armuma	armusin	V;ACT;PST;POS;IND;1;SG
 armuma	armutakse	V;PASS;PRS;POS;IND
@@ -36325,7 +36325,7 @@ armuma	armutagu	V;PASS;PRS;POS;IMP
 armuma	ärgu armugu	V;ACT;PRS;NEG;IMP;3;SG
 armuma	oli armutud	V;PASS;PST;PRF;POS;IND
 armuma	armusime	V;ACT;PST;POS;IND;1;PL
-armuma	ei olnud armunudp	V;ACT;PST;PRF;NEG;IND
+armuma	ei olnud armunud	V;ACT;PST;PRF;NEG;IND
 armuma	oleksid armunud	V;ACT;PRS;PRF;POS;COND;2;SG
 armuma	olgu armunud	V;ACT;PRS;PRF;POS;IMP;PL
 armuma	oli armunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -36339,9 +36339,9 @@ armuma	ärgu armugu	V;ACT;PRS;NEG;IMP;3;PL
 armuma	olgu armunud	V;ACT;PRS;PRF;POS;IMP;SG
 armuma	armuti	V;PASS;PST;POS;IND
 armuma	ei armuvat	V;ACT;PRS;NEG;QUOT
-armuma	ei oleks armutudp	V;PASS;PRS;PRF;NEG;COND
+armuma	ei oleks armutud	V;PASS;PRS;PRF;NEG;COND
 armuma	ei armunud	V;ACT;PST;NEG;IND
-armuma	ei olevat armutudp	V;PASS;PRS;PRF;NEG;QUOT
+armuma	ei olevat armutud	V;PASS;PRS;PRF;NEG;QUOT
 armuma	ei armuks	V;ACT;PRS;PRF;POS;COND;1;SG
 armuma	armutud	V.PTCP;PASS;PST
 armuma	olid armunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -36360,7 +36360,7 @@ armuma	olgu armutud	V;PASS;PRS;PRF;POS;IMP
 armuma	armuks	V;ACT;PRS;POS;COND;3;SG
 armuma	armugu	V;ACT;PRS;POS;IMP;3;PL
 armuma	ärgu olgu armunud	V;ACT;PRS;PRF;NEG;IMP;SG
-armuma	ei ole armunudp	V;ACT;PST;NEG;IND
+armuma	ei ole armunud	V;ACT;PST;NEG;IND
 armuma	armud	V;ACT;PRS;POS;IND;2;SG
 armuma	ära armu	V;ACT;PRS;NEG;IMP;2;SG
 armuma	ei armu	V;ACT;PRS;NEG;IND
@@ -36388,17 +36388,17 @@ armuma	ei armuta	V;PASS;PRS;NEG;IND
 armuma	armume	V;ACT;PRS;POS;IND;1;PL
 armuma	armun	V;ACT;PRS;POS;IND;1;SG
 armuma	ärgem armugem	V;ACT;PRS;NEG;IMP;1;PL
-armuma	ei oleks armunudp	V;ACT;PRS;PRF;NEG;COND
+armuma	ei oleks armunud	V;ACT;PRS;PRF;NEG;COND
 armuma	oleksid armunud	V;ACT;PRS;PRF;POS;COND;3;PL
 armuma	armusite	V;ACT;PST;POS;IND;2;PL
 armuma	oleks armunud	V;ACT;PRS;PRF;POS;COND;3;SG
 armuma	olin armunud	V;ACT;PRS;PRF;POS;COND;1;SG
 armuma	oled armunud	V;ACT;PRS;PRF;POS;IND;2;SG
 armuma	oli armunud	V;ACT;PRS;PRF;POS;COND;3;SG
-armuma	ei ole armutudp	V;PASS;PRS;PRF;NEG;IND
+armuma	ei ole armutud	V;PASS;PRS;PRF;NEG;IND
 armuma	armuksin	V;ACT;PRS;POS;COND;1;SG
 armuma	olen armunud	V;ACT;PRS;PRF;POS;IND;1;SG
-armuma	ei olnud armutudp	V;PASS;PST;PRF;NEG;IND
+armuma	ei olnud armutud	V;PASS;PST;PRF;NEG;IND
 armuma	ärgu olgu armutud	V;PASS;PRS;PRF;NEG;IMP
 
 artikkel	artiklini	N;TERM;SG
@@ -36464,7 +36464,7 @@ arutelu	aruteludesse	N;IN+ALL;PL
 arutelu	aruteludelt	N;AT+ABL;PL
 
 arutlema	olete arutlenud	V;ACT;PRS;PRF;POS;IND;2;PL
-arutlema	ei olevat arutlenudp	V;ACT;PRS;PRF;NEG;QUOT
+arutlema	ei olevat arutlenud	V;ACT;PRS;PRF;NEG;QUOT
 arutlema	oleks arutletud	V;PASS;PRS;PRF;POS;COND
 arutlema	arutlesin	V;ACT;PST;POS;IND;1;SG
 arutlema	arutletakse	V;PASS;PRS;POS;IND
@@ -36473,7 +36473,7 @@ arutlema	arutletagu	V;PASS;PRS;POS;IMP
 arutlema	ärgu arutlegu	V;ACT;PRS;NEG;IMP;3;SG
 arutlema	oli arutletud	V;PASS;PST;PRF;POS;IND
 arutlema	arutlesime	V;ACT;PST;POS;IND;1;PL
-arutlema	ei olnud arutlenudp	V;ACT;PST;PRF;NEG;IND
+arutlema	ei olnud arutlenud	V;ACT;PST;PRF;NEG;IND
 arutlema	oleksid arutlenud	V;ACT;PRS;PRF;POS;COND;2;SG
 arutlema	olgu arutlenud	V;ACT;PRS;PRF;POS;IMP;PL
 arutlema	oli arutlenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -36487,9 +36487,9 @@ arutlema	ärgu arutlegu	V;ACT;PRS;NEG;IMP;3;PL
 arutlema	olgu arutlenud	V;ACT;PRS;PRF;POS;IMP;SG
 arutlema	arutleti	V;PASS;PST;POS;IND
 arutlema	ei arutlevat	V;ACT;PRS;NEG;QUOT
-arutlema	ei oleks arutletudp	V;PASS;PRS;PRF;NEG;COND
+arutlema	ei oleks arutletud	V;PASS;PRS;PRF;NEG;COND
 arutlema	ei arutlenud	V;ACT;PST;NEG;IND
-arutlema	ei olevat arutletudp	V;PASS;PRS;PRF;NEG;QUOT
+arutlema	ei olevat arutletud	V;PASS;PRS;PRF;NEG;QUOT
 arutlema	ei arutleks	V;ACT;PRS;PRF;POS;COND;1;SG
 arutlema	arutletud	V.PTCP;PASS;PST
 arutlema	olid arutlenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -36508,7 +36508,7 @@ arutlema	olgu arutletud	V;PASS;PRS;PRF;POS;IMP
 arutlema	arutleks	V;ACT;PRS;POS;COND;3;SG
 arutlema	arutlegu	V;ACT;PRS;POS;IMP;3;PL
 arutlema	ärgu olgu arutlenud	V;ACT;PRS;PRF;NEG;IMP;SG
-arutlema	ei ole arutlenudp	V;ACT;PST;NEG;IND
+arutlema	ei ole arutlenud	V;ACT;PST;NEG;IND
 arutlema	arutled	V;ACT;PRS;POS;IND;2;SG
 arutlema	ära arutle	V;ACT;PRS;NEG;IMP;2;SG
 arutlema	ei arutle	V;ACT;PRS;NEG;IND
@@ -36536,21 +36536,21 @@ arutlema	ei arutleta	V;PASS;PRS;NEG;IND
 arutlema	arutleme	V;ACT;PRS;POS;IND;1;PL
 arutlema	arutlen	V;ACT;PRS;POS;IND;1;SG
 arutlema	ärgem arutlegem	V;ACT;PRS;NEG;IMP;1;PL
-arutlema	ei oleks arutlenudp	V;ACT;PRS;PRF;NEG;COND
+arutlema	ei oleks arutlenud	V;ACT;PRS;PRF;NEG;COND
 arutlema	oleksid arutlenud	V;ACT;PRS;PRF;POS;COND;3;PL
 arutlema	arutlesite	V;ACT;PST;POS;IND;2;PL
 arutlema	oleks arutlenud	V;ACT;PRS;PRF;POS;COND;3;SG
 arutlema	olin arutlenud	V;ACT;PRS;PRF;POS;COND;1;SG
 arutlema	oled arutlenud	V;ACT;PRS;PRF;POS;IND;2;SG
 arutlema	oli arutlenud	V;ACT;PRS;PRF;POS;COND;3;SG
-arutlema	ei ole arutletudp	V;PASS;PRS;PRF;NEG;IND
+arutlema	ei ole arutletud	V;PASS;PRS;PRF;NEG;IND
 arutlema	arutleksin	V;ACT;PRS;POS;COND;1;SG
 arutlema	olen arutlenud	V;ACT;PRS;PRF;POS;IND;1;SG
-arutlema	ei olnud arutletudp	V;PASS;PST;PRF;NEG;IND
+arutlema	ei olnud arutletud	V;PASS;PST;PRF;NEG;IND
 arutlema	ärgu olgu arutletud	V;PASS;PRS;PRF;NEG;IMP
 
 arvama	olete arvanud	V;ACT;PRS;PRF;POS;IND;2;PL
-arvama	ei olevat arvanudp	V;ACT;PRS;PRF;NEG;QUOT
+arvama	ei olevat arvanud	V;ACT;PRS;PRF;NEG;QUOT
 arvama	oleks arvatud	V;PASS;PRS;PRF;POS;COND
 arvama	arvasin	V;ACT;PST;POS;IND;1;SG
 arvama	arvatakse	V;PASS;PRS;POS;IND
@@ -36559,7 +36559,7 @@ arvama	arvatagu	V;PASS;PRS;POS;IMP
 arvama	ärgu arvaku	V;ACT;PRS;NEG;IMP;3;SG
 arvama	oli arvatud	V;PASS;PST;PRF;POS;IND
 arvama	arvasime	V;ACT;PST;POS;IND;1;PL
-arvama	ei olnud arvanudp	V;ACT;PST;PRF;NEG;IND
+arvama	ei olnud arvanud	V;ACT;PST;PRF;NEG;IND
 arvama	oleksid arvanud	V;ACT;PRS;PRF;POS;COND;2;SG
 arvama	olgu arvanud	V;ACT;PRS;PRF;POS;IMP;PL
 arvama	oli arvanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -36573,9 +36573,9 @@ arvama	ärgu arvaku	V;ACT;PRS;NEG;IMP;3;PL
 arvama	olgu arvanud	V;ACT;PRS;PRF;POS;IMP;SG
 arvama	arvati	V;PASS;PST;POS;IND
 arvama	ei arvavat	V;ACT;PRS;NEG;QUOT
-arvama	ei oleks arvatudp	V;PASS;PRS;PRF;NEG;COND
+arvama	ei oleks arvatud	V;PASS;PRS;PRF;NEG;COND
 arvama	ei arvanud	V;ACT;PST;NEG;IND
-arvama	ei olevat arvatudp	V;PASS;PRS;PRF;NEG;QUOT
+arvama	ei olevat arvatud	V;PASS;PRS;PRF;NEG;QUOT
 arvama	ei arvaks	V;ACT;PRS;PRF;POS;COND;1;SG
 arvama	arvatud	V.PTCP;PASS;PST
 arvama	olid arvanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -36594,7 +36594,7 @@ arvama	olgu arvatud	V;PASS;PRS;PRF;POS;IMP
 arvama	arvaks	V;ACT;PRS;POS;COND;3;SG
 arvama	arvaku	V;ACT;PRS;POS;IMP;3;PL
 arvama	ärgu olgu arvanud	V;ACT;PRS;PRF;NEG;IMP;SG
-arvama	ei ole arvanudp	V;ACT;PST;NEG;IND
+arvama	ei ole arvanud	V;ACT;PST;NEG;IND
 arvama	arvad	V;ACT;PRS;POS;IND;2;SG
 arvama	ära arva	V;ACT;PRS;NEG;IMP;2;SG
 arvama	ei arva	V;ACT;PRS;NEG;IND
@@ -36622,21 +36622,21 @@ arvama	ei arvata	V;PASS;PRS;NEG;IND
 arvama	arvame	V;ACT;PRS;POS;IND;1;PL
 arvama	arvan	V;ACT;PRS;POS;IND;1;SG
 arvama	ärgem arvakem	V;ACT;PRS;NEG;IMP;1;PL
-arvama	ei oleks arvanudp	V;ACT;PRS;PRF;NEG;COND
+arvama	ei oleks arvanud	V;ACT;PRS;PRF;NEG;COND
 arvama	oleksid arvanud	V;ACT;PRS;PRF;POS;COND;3;PL
 arvama	arvasite	V;ACT;PST;POS;IND;2;PL
 arvama	oleks arvanud	V;ACT;PRS;PRF;POS;COND;3;SG
 arvama	olin arvanud	V;ACT;PRS;PRF;POS;COND;1;SG
 arvama	oled arvanud	V;ACT;PRS;PRF;POS;IND;2;SG
 arvama	oli arvanud	V;ACT;PRS;PRF;POS;COND;3;SG
-arvama	ei ole arvatudp	V;PASS;PRS;PRF;NEG;IND
+arvama	ei ole arvatud	V;PASS;PRS;PRF;NEG;IND
 arvama	arvaksin	V;ACT;PRS;POS;COND;1;SG
 arvama	olen arvanud	V;ACT;PRS;PRF;POS;IND;1;SG
-arvama	ei olnud arvatudp	V;PASS;PST;PRF;NEG;IND
+arvama	ei olnud arvatud	V;PASS;PST;PRF;NEG;IND
 arvama	ärgu olgu arvatud	V;PASS;PRS;PRF;NEG;IMP
 
 arvutama	olete arvutanud	V;ACT;PRS;PRF;POS;IND;2;PL
-arvutama	ei olevat arvutanudp	V;ACT;PRS;PRF;NEG;QUOT
+arvutama	ei olevat arvutanud	V;ACT;PRS;PRF;NEG;QUOT
 arvutama	oleks arvutatud	V;PASS;PRS;PRF;POS;COND
 arvutama	arvutasin	V;ACT;PST;POS;IND;1;SG
 arvutama	arvutatakse	V;PASS;PRS;POS;IND
@@ -36645,7 +36645,7 @@ arvutama	arvutatagu	V;PASS;PRS;POS;IMP
 arvutama	ärgu arvutagu	V;ACT;PRS;NEG;IMP;3;SG
 arvutama	oli arvutatud	V;PASS;PST;PRF;POS;IND
 arvutama	arvutasime	V;ACT;PST;POS;IND;1;PL
-arvutama	ei olnud arvutanudp	V;ACT;PST;PRF;NEG;IND
+arvutama	ei olnud arvutanud	V;ACT;PST;PRF;NEG;IND
 arvutama	oleksid arvutanud	V;ACT;PRS;PRF;POS;COND;2;SG
 arvutama	olgu arvutanud	V;ACT;PRS;PRF;POS;IMP;PL
 arvutama	oli arvutanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -36659,9 +36659,9 @@ arvutama	ärgu arvutagu	V;ACT;PRS;NEG;IMP;3;PL
 arvutama	olgu arvutanud	V;ACT;PRS;PRF;POS;IMP;SG
 arvutama	arvutati	V;PASS;PST;POS;IND
 arvutama	ei arvutavat	V;ACT;PRS;NEG;QUOT
-arvutama	ei oleks arvutatudp	V;PASS;PRS;PRF;NEG;COND
+arvutama	ei oleks arvutatud	V;PASS;PRS;PRF;NEG;COND
 arvutama	ei arvutanud	V;ACT;PST;NEG;IND
-arvutama	ei olevat arvutatudp	V;PASS;PRS;PRF;NEG;QUOT
+arvutama	ei olevat arvutatud	V;PASS;PRS;PRF;NEG;QUOT
 arvutama	ei arvutaks	V;ACT;PRS;PRF;POS;COND;1;SG
 arvutama	arvutatud	V.PTCP;PASS;PST
 arvutama	olid arvutanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -36680,7 +36680,7 @@ arvutama	olgu arvutatud	V;PASS;PRS;PRF;POS;IMP
 arvutama	arvutaks	V;ACT;PRS;POS;COND;3;SG
 arvutama	arvutagu	V;ACT;PRS;POS;IMP;3;PL
 arvutama	ärgu olgu arvutanud	V;ACT;PRS;PRF;NEG;IMP;SG
-arvutama	ei ole arvutanudp	V;ACT;PST;NEG;IND
+arvutama	ei ole arvutanud	V;ACT;PST;NEG;IND
 arvutama	arvutad	V;ACT;PRS;POS;IND;2;SG
 arvutama	ära arvuta	V;ACT;PRS;NEG;IMP;2;SG
 arvutama	ei arvuta	V;ACT;PRS;NEG;IND
@@ -36708,17 +36708,17 @@ arvutama	ei arvutata	V;PASS;PRS;NEG;IND
 arvutama	arvutame	V;ACT;PRS;POS;IND;1;PL
 arvutama	arvutan	V;ACT;PRS;POS;IND;1;SG
 arvutama	ärgem arvutagem	V;ACT;PRS;NEG;IMP;1;PL
-arvutama	ei oleks arvutanudp	V;ACT;PRS;PRF;NEG;COND
+arvutama	ei oleks arvutanud	V;ACT;PRS;PRF;NEG;COND
 arvutama	oleksid arvutanud	V;ACT;PRS;PRF;POS;COND;3;PL
 arvutama	arvutasite	V;ACT;PST;POS;IND;2;PL
 arvutama	oleks arvutanud	V;ACT;PRS;PRF;POS;COND;3;SG
 arvutama	olin arvutanud	V;ACT;PRS;PRF;POS;COND;1;SG
 arvutama	oled arvutanud	V;ACT;PRS;PRF;POS;IND;2;SG
 arvutama	oli arvutanud	V;ACT;PRS;PRF;POS;COND;3;SG
-arvutama	ei ole arvutatudp	V;PASS;PRS;PRF;NEG;IND
+arvutama	ei ole arvutatud	V;PASS;PRS;PRF;NEG;IND
 arvutama	arvutaksin	V;ACT;PRS;POS;COND;1;SG
 arvutama	olen arvutanud	V;ACT;PRS;PRF;POS;IND;1;SG
-arvutama	ei olnud arvutatudp	V;PASS;PST;PRF;NEG;IND
+arvutama	ei olnud arvutatud	V;PASS;PST;PRF;NEG;IND
 arvutama	ärgu olgu arvutatud	V;PASS;PRS;PRF;NEG;IMP
 
 arvuti	arvutini	N;TERM;SG
@@ -36877,7 +36877,7 @@ aste	astetesse	N;IN+ALL;PL
 aste	astetelt	N;AT+ABL;PL
 
 astuma	olete astunud	V;ACT;PRS;PRF;POS;IND;2;PL
-astuma	ei olevat astunudp	V;ACT;PRS;PRF;NEG;QUOT
+astuma	ei olevat astunud	V;ACT;PRS;PRF;NEG;QUOT
 astuma	oleks astutud	V;PASS;PRS;PRF;POS;COND
 astuma	astusin	V;ACT;PST;POS;IND;1;SG
 astuma	astutakse	V;PASS;PRS;POS;IND
@@ -36886,7 +36886,7 @@ astuma	astutagu	V;PASS;PRS;POS;IMP
 astuma	ärgu astugu	V;ACT;PRS;NEG;IMP;3;SG
 astuma	oli astutud	V;PASS;PST;PRF;POS;IND
 astuma	astusime	V;ACT;PST;POS;IND;1;PL
-astuma	ei olnud astunudp	V;ACT;PST;PRF;NEG;IND
+astuma	ei olnud astunud	V;ACT;PST;PRF;NEG;IND
 astuma	oleksid astunud	V;ACT;PRS;PRF;POS;COND;2;SG
 astuma	olgu astunud	V;ACT;PRS;PRF;POS;IMP;PL
 astuma	oli astunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -36900,9 +36900,9 @@ astuma	ärgu astugu	V;ACT;PRS;NEG;IMP;3;PL
 astuma	olgu astunud	V;ACT;PRS;PRF;POS;IMP;SG
 astuma	astuti	V;PASS;PST;POS;IND
 astuma	ei astuvat	V;ACT;PRS;NEG;QUOT
-astuma	ei oleks astutudp	V;PASS;PRS;PRF;NEG;COND
+astuma	ei oleks astutud	V;PASS;PRS;PRF;NEG;COND
 astuma	ei astunud	V;ACT;PST;NEG;IND
-astuma	ei olevat astutudp	V;PASS;PRS;PRF;NEG;QUOT
+astuma	ei olevat astutud	V;PASS;PRS;PRF;NEG;QUOT
 astuma	ei astuks	V;ACT;PRS;PRF;POS;COND;1;SG
 astuma	astutud	V.PTCP;PASS;PST
 astuma	olid astunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -36921,7 +36921,7 @@ astuma	olgu astutud	V;PASS;PRS;PRF;POS;IMP
 astuma	astuks	V;ACT;PRS;POS;COND;3;SG
 astuma	astugu	V;ACT;PRS;POS;IMP;3;PL
 astuma	ärgu olgu astunud	V;ACT;PRS;PRF;NEG;IMP;SG
-astuma	ei ole astunudp	V;ACT;PST;NEG;IND
+astuma	ei ole astunud	V;ACT;PST;NEG;IND
 astuma	astud	V;ACT;PRS;POS;IND;2;SG
 astuma	ära astu	V;ACT;PRS;NEG;IMP;2;SG
 astuma	ei astu	V;ACT;PRS;NEG;IND
@@ -36949,21 +36949,21 @@ astuma	ei astuta	V;PASS;PRS;NEG;IND
 astuma	astume	V;ACT;PRS;POS;IND;1;PL
 astuma	astun	V;ACT;PRS;POS;IND;1;SG
 astuma	ärgem astugem	V;ACT;PRS;NEG;IMP;1;PL
-astuma	ei oleks astunudp	V;ACT;PRS;PRF;NEG;COND
+astuma	ei oleks astunud	V;ACT;PRS;PRF;NEG;COND
 astuma	oleksid astunud	V;ACT;PRS;PRF;POS;COND;3;PL
 astuma	astusite	V;ACT;PST;POS;IND;2;PL
 astuma	oleks astunud	V;ACT;PRS;PRF;POS;COND;3;SG
 astuma	olin astunud	V;ACT;PRS;PRF;POS;COND;1;SG
 astuma	oled astunud	V;ACT;PRS;PRF;POS;IND;2;SG
 astuma	oli astunud	V;ACT;PRS;PRF;POS;COND;3;SG
-astuma	ei ole astutudp	V;PASS;PRS;PRF;NEG;IND
+astuma	ei ole astutud	V;PASS;PRS;PRF;NEG;IND
 astuma	astuksin	V;ACT;PRS;POS;COND;1;SG
 astuma	olen astunud	V;ACT;PRS;PRF;POS;IND;1;SG
-astuma	ei olnud astutudp	V;PASS;PST;PRF;NEG;IND
+astuma	ei olnud astutud	V;PASS;PST;PRF;NEG;IND
 astuma	ärgu olgu astutud	V;PASS;PRS;PRF;NEG;IMP
 
 asuma	olete asunud	V;ACT;PRS;PRF;POS;IND;2;PL
-asuma	ei olevat asunudp	V;ACT;PRS;PRF;NEG;QUOT
+asuma	ei olevat asunud	V;ACT;PRS;PRF;NEG;QUOT
 asuma	oleks asutud	V;PASS;PRS;PRF;POS;COND
 asuma	asusin	V;ACT;PST;POS;IND;1;SG
 asuma	asutakse	V;PASS;PRS;POS;IND
@@ -36972,7 +36972,7 @@ asuma	asutagu	V;PASS;PRS;POS;IMP
 asuma	ärgu asugu	V;ACT;PRS;NEG;IMP;3;SG
 asuma	oli asutud	V;PASS;PST;PRF;POS;IND
 asuma	asusime	V;ACT;PST;POS;IND;1;PL
-asuma	ei olnud asunudp	V;ACT;PST;PRF;NEG;IND
+asuma	ei olnud asunud	V;ACT;PST;PRF;NEG;IND
 asuma	oleksid asunud	V;ACT;PRS;PRF;POS;COND;2;SG
 asuma	olgu asunud	V;ACT;PRS;PRF;POS;IMP;PL
 asuma	oli asunud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -36986,9 +36986,9 @@ asuma	ärgu asugu	V;ACT;PRS;NEG;IMP;3;PL
 asuma	olgu asunud	V;ACT;PRS;PRF;POS;IMP;SG
 asuma	asuti	V;PASS;PST;POS;IND
 asuma	ei asuvat	V;ACT;PRS;NEG;QUOT
-asuma	ei oleks asutudp	V;PASS;PRS;PRF;NEG;COND
+asuma	ei oleks asutud	V;PASS;PRS;PRF;NEG;COND
 asuma	ei asunud	V;ACT;PST;NEG;IND
-asuma	ei olevat asutudp	V;PASS;PRS;PRF;NEG;QUOT
+asuma	ei olevat asutud	V;PASS;PRS;PRF;NEG;QUOT
 asuma	ei asuks	V;ACT;PRS;PRF;POS;COND;1;SG
 asuma	asutud	V.PTCP;PASS;PST
 asuma	olid asunud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -37007,7 +37007,7 @@ asuma	olgu asutud	V;PASS;PRS;PRF;POS;IMP
 asuma	asuks	V;ACT;PRS;POS;COND;3;SG
 asuma	asugu	V;ACT;PRS;POS;IMP;3;PL
 asuma	ärgu olgu asunud	V;ACT;PRS;PRF;NEG;IMP;SG
-asuma	ei ole asunudp	V;ACT;PST;NEG;IND
+asuma	ei ole asunud	V;ACT;PST;NEG;IND
 asuma	asud	V;ACT;PRS;POS;IND;2;SG
 asuma	ära asu	V;ACT;PRS;NEG;IMP;2;SG
 asuma	ei asu	V;ACT;PRS;NEG;IND
@@ -37035,21 +37035,21 @@ asuma	ei asuta	V;PASS;PRS;NEG;IND
 asuma	asume	V;ACT;PRS;POS;IND;1;PL
 asuma	asun	V;ACT;PRS;POS;IND;1;SG
 asuma	ärgem asugem	V;ACT;PRS;NEG;IMP;1;PL
-asuma	ei oleks asunudp	V;ACT;PRS;PRF;NEG;COND
+asuma	ei oleks asunud	V;ACT;PRS;PRF;NEG;COND
 asuma	oleksid asunud	V;ACT;PRS;PRF;POS;COND;3;PL
 asuma	asusite	V;ACT;PST;POS;IND;2;PL
 asuma	oleks asunud	V;ACT;PRS;PRF;POS;COND;3;SG
 asuma	olin asunud	V;ACT;PRS;PRF;POS;COND;1;SG
 asuma	oled asunud	V;ACT;PRS;PRF;POS;IND;2;SG
 asuma	oli asunud	V;ACT;PRS;PRF;POS;COND;3;SG
-asuma	ei ole asutudp	V;PASS;PRS;PRF;NEG;IND
+asuma	ei ole asutud	V;PASS;PRS;PRF;NEG;IND
 asuma	asuksin	V;ACT;PRS;POS;COND;1;SG
 asuma	olen asunud	V;ACT;PRS;PRF;POS;IND;1;SG
-asuma	ei olnud asutudp	V;PASS;PST;PRF;NEG;IND
+asuma	ei olnud asutud	V;PASS;PST;PRF;NEG;IND
 asuma	ärgu olgu asutud	V;PASS;PRS;PRF;NEG;IMP
 
 austama	olete austanud	V;ACT;PRS;PRF;POS;IND;2;PL
-austama	ei olevat austanudp	V;ACT;PRS;PRF;NEG;QUOT
+austama	ei olevat austanud	V;ACT;PRS;PRF;NEG;QUOT
 austama	oleks austatud	V;PASS;PRS;PRF;POS;COND
 austama	austasin	V;ACT;PST;POS;IND;1;SG
 austama	austatakse	V;PASS;PRS;POS;IND
@@ -37058,7 +37058,7 @@ austama	austatagu	V;PASS;PRS;POS;IMP
 austama	ärgu austagu	V;ACT;PRS;NEG;IMP;3;SG
 austama	oli austatud	V;PASS;PST;PRF;POS;IND
 austama	austasime	V;ACT;PST;POS;IND;1;PL
-austama	ei olnud austanudp	V;ACT;PST;PRF;NEG;IND
+austama	ei olnud austanud	V;ACT;PST;PRF;NEG;IND
 austama	oleksid austanud	V;ACT;PRS;PRF;POS;COND;2;SG
 austama	olgu austanud	V;ACT;PRS;PRF;POS;IMP;PL
 austama	oli austanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -37072,9 +37072,9 @@ austama	ärgu austagu	V;ACT;PRS;NEG;IMP;3;PL
 austama	olgu austanud	V;ACT;PRS;PRF;POS;IMP;SG
 austama	austati	V;PASS;PST;POS;IND
 austama	ei austavat	V;ACT;PRS;NEG;QUOT
-austama	ei oleks austatudp	V;PASS;PRS;PRF;NEG;COND
+austama	ei oleks austatud	V;PASS;PRS;PRF;NEG;COND
 austama	ei austanud	V;ACT;PST;NEG;IND
-austama	ei olevat austatudp	V;PASS;PRS;PRF;NEG;QUOT
+austama	ei olevat austatud	V;PASS;PRS;PRF;NEG;QUOT
 austama	ei austaks	V;ACT;PRS;PRF;POS;COND;1;SG
 austama	austatud	V.PTCP;PASS;PST
 austama	olid austanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -37093,7 +37093,7 @@ austama	olgu austatud	V;PASS;PRS;PRF;POS;IMP
 austama	austaks	V;ACT;PRS;POS;COND;3;SG
 austama	austagu	V;ACT;PRS;POS;IMP;3;PL
 austama	ärgu olgu austanud	V;ACT;PRS;PRF;NEG;IMP;SG
-austama	ei ole austanudp	V;ACT;PST;NEG;IND
+austama	ei ole austanud	V;ACT;PST;NEG;IND
 austama	austad	V;ACT;PRS;POS;IND;2;SG
 austama	ära austa	V;ACT;PRS;NEG;IMP;2;SG
 austama	ei austa	V;ACT;PRS;NEG;IND
@@ -37121,17 +37121,17 @@ austama	ei austata	V;PASS;PRS;NEG;IND
 austama	austame	V;ACT;PRS;POS;IND;1;PL
 austama	austan	V;ACT;PRS;POS;IND;1;SG
 austama	ärgem austagem	V;ACT;PRS;NEG;IMP;1;PL
-austama	ei oleks austanudp	V;ACT;PRS;PRF;NEG;COND
+austama	ei oleks austanud	V;ACT;PRS;PRF;NEG;COND
 austama	oleksid austanud	V;ACT;PRS;PRF;POS;COND;3;PL
 austama	austasite	V;ACT;PST;POS;IND;2;PL
 austama	oleks austanud	V;ACT;PRS;PRF;POS;COND;3;SG
 austama	olin austanud	V;ACT;PRS;PRF;POS;COND;1;SG
 austama	oled austanud	V;ACT;PRS;PRF;POS;IND;2;SG
 austama	oli austanud	V;ACT;PRS;PRF;POS;COND;3;SG
-austama	ei ole austatudp	V;PASS;PRS;PRF;NEG;IND
+austama	ei ole austatud	V;PASS;PRS;PRF;NEG;IND
 austama	austaksin	V;ACT;PRS;POS;COND;1;SG
 austama	olen austanud	V;ACT;PRS;PRF;POS;IND;1;SG
-austama	ei olnud austatudp	V;PASS;PST;PRF;NEG;IND
+austama	ei olnud austatud	V;PASS;PST;PRF;NEG;IND
 austama	ärgu olgu austatud	V;PASS;PRS;PRF;NEG;IMP
 
 ava	avani	N;TERM;SG
@@ -37166,7 +37166,7 @@ ava	avadesseavusse	N;IN+ALL;PL
 ava	avadeltavult	N;AT+ABL;PL
 
 avama	olete avanud	V;ACT;PRS;PRF;POS;IND;2;PL
-avama	ei olevat avanudp	V;ACT;PRS;PRF;NEG;QUOT
+avama	ei olevat avanud	V;ACT;PRS;PRF;NEG;QUOT
 avama	oleks avatud	V;PASS;PRS;PRF;POS;COND
 avama	avasin	V;ACT;PST;POS;IND;1;SG
 avama	avatakse	V;PASS;PRS;POS;IND
@@ -37175,7 +37175,7 @@ avama	avatagu	V;PASS;PRS;POS;IMP
 avama	ärgu avagu	V;ACT;PRS;NEG;IMP;3;SG
 avama	oli avatud	V;PASS;PST;PRF;POS;IND
 avama	avasime	V;ACT;PST;POS;IND;1;PL
-avama	ei olnud avanudp	V;ACT;PST;PRF;NEG;IND
+avama	ei olnud avanud	V;ACT;PST;PRF;NEG;IND
 avama	oleksid avanud	V;ACT;PRS;PRF;POS;COND;2;SG
 avama	olgu avanud	V;ACT;PRS;PRF;POS;IMP;PL
 avama	oli avanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -37189,9 +37189,9 @@ avama	ärgu avagu	V;ACT;PRS;NEG;IMP;3;PL
 avama	olgu avanud	V;ACT;PRS;PRF;POS;IMP;SG
 avama	avati	V;PASS;PST;POS;IND
 avama	ei avavat	V;ACT;PRS;NEG;QUOT
-avama	ei oleks avatudp	V;PASS;PRS;PRF;NEG;COND
+avama	ei oleks avatud	V;PASS;PRS;PRF;NEG;COND
 avama	ei avanud	V;ACT;PST;NEG;IND
-avama	ei olevat avatudp	V;PASS;PRS;PRF;NEG;QUOT
+avama	ei olevat avatud	V;PASS;PRS;PRF;NEG;QUOT
 avama	ei avaks	V;ACT;PRS;PRF;POS;COND;1;SG
 avama	avatud	V.PTCP;PASS;PST
 avama	olid avanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -37210,7 +37210,7 @@ avama	olgu avatud	V;PASS;PRS;PRF;POS;IMP
 avama	avaks	V;ACT;PRS;POS;COND;3;SG
 avama	avagu	V;ACT;PRS;POS;IMP;3;PL
 avama	ärgu olgu avanud	V;ACT;PRS;PRF;NEG;IMP;SG
-avama	ei ole avanudp	V;ACT;PST;NEG;IND
+avama	ei ole avanud	V;ACT;PST;NEG;IND
 avama	avad	V;ACT;PRS;POS;IND;2;SG
 avama	ära ava	V;ACT;PRS;NEG;IMP;2;SG
 avama	ei ava	V;ACT;PRS;NEG;IND
@@ -37238,17 +37238,17 @@ avama	ei avata	V;PASS;PRS;NEG;IND
 avama	avame	V;ACT;PRS;POS;IND;1;PL
 avama	avan	V;ACT;PRS;POS;IND;1;SG
 avama	ärgem avagem	V;ACT;PRS;NEG;IMP;1;PL
-avama	ei oleks avanudp	V;ACT;PRS;PRF;NEG;COND
+avama	ei oleks avanud	V;ACT;PRS;PRF;NEG;COND
 avama	oleksid avanud	V;ACT;PRS;PRF;POS;COND;3;PL
 avama	avasite	V;ACT;PST;POS;IND;2;PL
 avama	oleks avanud	V;ACT;PRS;PRF;POS;COND;3;SG
 avama	olin avanud	V;ACT;PRS;PRF;POS;COND;1;SG
 avama	oled avanud	V;ACT;PRS;PRF;POS;IND;2;SG
 avama	oli avanud	V;ACT;PRS;PRF;POS;COND;3;SG
-avama	ei ole avatudp	V;PASS;PRS;PRF;NEG;IND
+avama	ei ole avatud	V;PASS;PRS;PRF;NEG;IND
 avama	avaksin	V;ACT;PRS;POS;COND;1;SG
 avama	olen avanud	V;ACT;PRS;PRF;POS;IND;1;SG
-avama	ei olnud avatudp	V;PASS;PST;PRF;NEG;IND
+avama	ei olnud avatud	V;PASS;PST;PRF;NEG;IND
 avama	ärgu olgu avatud	V;PASS;PRS;PRF;NEG;IMP
 
 baarium	baariumini	N;TERM;SG
@@ -37841,7 +37841,7 @@ eestlane	eestlastesse	N;IN+ALL;PL
 eestlane	eestlastelt	N;AT+ABL;PL
 
 ehitama	olete ehitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-ehitama	ei olevat ehitanudp	V;ACT;PRS;PRF;NEG;QUOT
+ehitama	ei olevat ehitanud	V;ACT;PRS;PRF;NEG;QUOT
 ehitama	oleks ehitatud	V;PASS;PRS;PRF;POS;COND
 ehitama	ehitasin	V;ACT;PST;POS;IND;1;SG
 ehitama	ehitatakse	V;PASS;PRS;POS;IND
@@ -37850,7 +37850,7 @@ ehitama	ehitatagu	V;PASS;PRS;POS;IMP
 ehitama	ärgu ehitagu	V;ACT;PRS;NEG;IMP;3;SG
 ehitama	oli ehitatud	V;PASS;PST;PRF;POS;IND
 ehitama	ehitasime	V;ACT;PST;POS;IND;1;PL
-ehitama	ei olnud ehitanudp	V;ACT;PST;PRF;NEG;IND
+ehitama	ei olnud ehitanud	V;ACT;PST;PRF;NEG;IND
 ehitama	oleksid ehitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 ehitama	olgu ehitanud	V;ACT;PRS;PRF;POS;IMP;PL
 ehitama	oli ehitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -37864,9 +37864,9 @@ ehitama	ärgu ehitagu	V;ACT;PRS;NEG;IMP;3;PL
 ehitama	olgu ehitanud	V;ACT;PRS;PRF;POS;IMP;SG
 ehitama	ehitati	V;PASS;PST;POS;IND
 ehitama	ei ehitavat	V;ACT;PRS;NEG;QUOT
-ehitama	ei oleks ehitatudp	V;PASS;PRS;PRF;NEG;COND
+ehitama	ei oleks ehitatud	V;PASS;PRS;PRF;NEG;COND
 ehitama	ei ehitanud	V;ACT;PST;NEG;IND
-ehitama	ei olevat ehitatudp	V;PASS;PRS;PRF;NEG;QUOT
+ehitama	ei olevat ehitatud	V;PASS;PRS;PRF;NEG;QUOT
 ehitama	ei ehitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 ehitama	ehitatud	V.PTCP;PASS;PST
 ehitama	olid ehitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -37885,7 +37885,7 @@ ehitama	olgu ehitatud	V;PASS;PRS;PRF;POS;IMP
 ehitama	ehitaks	V;ACT;PRS;POS;COND;3;SG
 ehitama	ehitagu	V;ACT;PRS;POS;IMP;3;PL
 ehitama	ärgu olgu ehitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-ehitama	ei ole ehitanudp	V;ACT;PST;NEG;IND
+ehitama	ei ole ehitanud	V;ACT;PST;NEG;IND
 ehitama	ehitad	V;ACT;PRS;POS;IND;2;SG
 ehitama	ära ehita	V;ACT;PRS;NEG;IMP;2;SG
 ehitama	ei ehita	V;ACT;PRS;NEG;IND
@@ -37913,17 +37913,17 @@ ehitama	ei ehitata	V;PASS;PRS;NEG;IND
 ehitama	ehitame	V;ACT;PRS;POS;IND;1;PL
 ehitama	ehitan	V;ACT;PRS;POS;IND;1;SG
 ehitama	ärgem ehitagem	V;ACT;PRS;NEG;IMP;1;PL
-ehitama	ei oleks ehitanudp	V;ACT;PRS;PRF;NEG;COND
+ehitama	ei oleks ehitanud	V;ACT;PRS;PRF;NEG;COND
 ehitama	oleksid ehitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 ehitama	ehitasite	V;ACT;PST;POS;IND;2;PL
 ehitama	oleks ehitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 ehitama	olin ehitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 ehitama	oled ehitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 ehitama	oli ehitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-ehitama	ei ole ehitatudp	V;PASS;PRS;PRF;NEG;IND
+ehitama	ei ole ehitatud	V;PASS;PRS;PRF;NEG;IND
 ehitama	ehitaksin	V;ACT;PRS;POS;COND;1;SG
 ehitama	olen ehitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-ehitama	ei olnud ehitatudp	V;PASS;PST;PRF;NEG;IND
+ehitama	ei olnud ehitatud	V;PASS;PST;PRF;NEG;IND
 ehitama	ärgu olgu ehitatud	V;PASS;PRS;PRF;NEG;IMP
 
 ehitis	ehitiseni	N;TERM;SG
@@ -37958,7 +37958,7 @@ ehitis	ehitistesse	N;IN+ALL;PL
 ehitis	ehitistelt	N;AT+ABL;PL
 
 ehtima	olete ehtinud	V;ACT;PRS;PRF;POS;IND;2;PL
-ehtima	ei olevat ehtinudp	V;ACT;PRS;PRF;NEG;QUOT
+ehtima	ei olevat ehtinud	V;ACT;PRS;PRF;NEG;QUOT
 ehtima	oleks ehitud	V;PASS;PRS;PRF;POS;COND
 ehtima	ehtisin	V;ACT;PST;POS;IND;1;SG
 ehtima	ehitakse	V;PASS;PRS;POS;IND
@@ -37967,7 +37967,7 @@ ehtima	ehitagu	V;PASS;PRS;POS;IMP
 ehtima	ärgu ehtigu	V;ACT;PRS;NEG;IMP;3;SG
 ehtima	oli ehitud	V;PASS;PST;PRF;POS;IND
 ehtima	ehtisime	V;ACT;PST;POS;IND;1;PL
-ehtima	ei olnud ehtinudp	V;ACT;PST;PRF;NEG;IND
+ehtima	ei olnud ehtinud	V;ACT;PST;PRF;NEG;IND
 ehtima	oleksid ehtinud	V;ACT;PRS;PRF;POS;COND;2;SG
 ehtima	olgu ehtinud	V;ACT;PRS;PRF;POS;IMP;PL
 ehtima	oli ehtinud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -37981,9 +37981,9 @@ ehtima	ärgu ehtigu	V;ACT;PRS;NEG;IMP;3;PL
 ehtima	olgu ehtinud	V;ACT;PRS;PRF;POS;IMP;SG
 ehtima	ehiti	V;PASS;PST;POS;IND
 ehtima	ei ehtivat	V;ACT;PRS;NEG;QUOT
-ehtima	ei oleks ehitudp	V;PASS;PRS;PRF;NEG;COND
+ehtima	ei oleks ehitud	V;PASS;PRS;PRF;NEG;COND
 ehtima	ei ehtinud	V;ACT;PST;NEG;IND
-ehtima	ei olevat ehitudp	V;PASS;PRS;PRF;NEG;QUOT
+ehtima	ei olevat ehitud	V;PASS;PRS;PRF;NEG;QUOT
 ehtima	ei ehiks	V;ACT;PRS;PRF;POS;COND;1;SG
 ehtima	ehitud	V.PTCP;PASS;PST
 ehtima	olid ehtinud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -38002,7 +38002,7 @@ ehtima	olgu ehitud	V;PASS;PRS;PRF;POS;IMP
 ehtima	ehiks	V;ACT;PRS;POS;COND;3;SG
 ehtima	ehtigu	V;ACT;PRS;POS;IMP;3;PL
 ehtima	ärgu olgu ehtinud	V;ACT;PRS;PRF;NEG;IMP;SG
-ehtima	ei ole ehtinudp	V;ACT;PST;NEG;IND
+ehtima	ei ole ehtinud	V;ACT;PST;NEG;IND
 ehtima	ehid	V;ACT;PRS;POS;IND;2;SG
 ehtima	ära ehi	V;ACT;PRS;NEG;IMP;2;SG
 ehtima	ei ehi	V;ACT;PRS;NEG;IND
@@ -38030,17 +38030,17 @@ ehtima	ei ehita	V;PASS;PRS;NEG;IND
 ehtima	ehime	V;ACT;PRS;POS;IND;1;PL
 ehtima	ehin	V;ACT;PRS;POS;IND;1;SG
 ehtima	ärgem ehtigem	V;ACT;PRS;NEG;IMP;1;PL
-ehtima	ei oleks ehtinudp	V;ACT;PRS;PRF;NEG;COND
+ehtima	ei oleks ehtinud	V;ACT;PRS;PRF;NEG;COND
 ehtima	oleksid ehtinud	V;ACT;PRS;PRF;POS;COND;3;PL
 ehtima	ehtisite	V;ACT;PST;POS;IND;2;PL
 ehtima	oleks ehtinud	V;ACT;PRS;PRF;POS;COND;3;SG
 ehtima	olin ehtinud	V;ACT;PRS;PRF;POS;COND;1;SG
 ehtima	oled ehtinud	V;ACT;PRS;PRF;POS;IND;2;SG
 ehtima	oli ehtinud	V;ACT;PRS;PRF;POS;COND;3;SG
-ehtima	ei ole ehitudp	V;PASS;PRS;PRF;NEG;IND
+ehtima	ei ole ehitud	V;PASS;PRS;PRF;NEG;IND
 ehtima	ehiksin	V;ACT;PRS;POS;COND;1;SG
 ehtima	olen ehtinud	V;ACT;PRS;PRF;POS;IND;1;SG
-ehtima	ei olnud ehitudp	V;PASS;PST;PRF;NEG;IND
+ehtima	ei olnud ehitud	V;PASS;PST;PRF;NEG;IND
 ehtima	ärgu olgu ehitud	V;PASS;PRS;PRF;NEG;IMP
 
 eine	eineni	N;TERM;SG
@@ -38106,7 +38106,7 @@ einsteinium	einst	N;IN+ALL;PL
 einsteinium	einst	N;AT+ABL;PL
 
 eitama	olete eitanud	V;ACT;PRS;PRF;POS;IND;2;PL
-eitama	ei olevat eitanudp	V;ACT;PRS;PRF;NEG;QUOT
+eitama	ei olevat eitanud	V;ACT;PRS;PRF;NEG;QUOT
 eitama	oleks eitatud	V;PASS;PRS;PRF;POS;COND
 eitama	eitasin	V;ACT;PST;POS;IND;1;SG
 eitama	eitatakse	V;PASS;PRS;POS;IND
@@ -38115,7 +38115,7 @@ eitama	eitatagu	V;PASS;PRS;POS;IMP
 eitama	ärgu eitagu	V;ACT;PRS;NEG;IMP;3;SG
 eitama	oli eitatud	V;PASS;PST;PRF;POS;IND
 eitama	eitasime	V;ACT;PST;POS;IND;1;PL
-eitama	ei olnud eitanudp	V;ACT;PST;PRF;NEG;IND
+eitama	ei olnud eitanud	V;ACT;PST;PRF;NEG;IND
 eitama	oleksid eitanud	V;ACT;PRS;PRF;POS;COND;2;SG
 eitama	olgu eitanud	V;ACT;PRS;PRF;POS;IMP;PL
 eitama	oli eitanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -38129,9 +38129,9 @@ eitama	ärgu eitagu	V;ACT;PRS;NEG;IMP;3;PL
 eitama	olgu eitanud	V;ACT;PRS;PRF;POS;IMP;SG
 eitama	eitati	V;PASS;PST;POS;IND
 eitama	ei eitavat	V;ACT;PRS;NEG;QUOT
-eitama	ei oleks eitatudp	V;PASS;PRS;PRF;NEG;COND
+eitama	ei oleks eitatud	V;PASS;PRS;PRF;NEG;COND
 eitama	ei eitanud	V;ACT;PST;NEG;IND
-eitama	ei olevat eitatudp	V;PASS;PRS;PRF;NEG;QUOT
+eitama	ei olevat eitatud	V;PASS;PRS;PRF;NEG;QUOT
 eitama	ei eitaks	V;ACT;PRS;PRF;POS;COND;1;SG
 eitama	eitatud	V.PTCP;PASS;PST
 eitama	olid eitanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -38150,7 +38150,7 @@ eitama	olgu eitatud	V;PASS;PRS;PRF;POS;IMP
 eitama	eitaks	V;ACT;PRS;POS;COND;3;SG
 eitama	eitagu	V;ACT;PRS;POS;IMP;3;PL
 eitama	ärgu olgu eitanud	V;ACT;PRS;PRF;NEG;IMP;SG
-eitama	ei ole eitanudp	V;ACT;PST;NEG;IND
+eitama	ei ole eitanud	V;ACT;PST;NEG;IND
 eitama	eitad	V;ACT;PRS;POS;IND;2;SG
 eitama	ära eita	V;ACT;PRS;NEG;IMP;2;SG
 eitama	ei eita	V;ACT;PRS;NEG;IND
@@ -38178,17 +38178,17 @@ eitama	ei eitata	V;PASS;PRS;NEG;IND
 eitama	eitame	V;ACT;PRS;POS;IND;1;PL
 eitama	eitan	V;ACT;PRS;POS;IND;1;SG
 eitama	ärgem eitagem	V;ACT;PRS;NEG;IMP;1;PL
-eitama	ei oleks eitanudp	V;ACT;PRS;PRF;NEG;COND
+eitama	ei oleks eitanud	V;ACT;PRS;PRF;NEG;COND
 eitama	oleksid eitanud	V;ACT;PRS;PRF;POS;COND;3;PL
 eitama	eitasite	V;ACT;PST;POS;IND;2;PL
 eitama	oleks eitanud	V;ACT;PRS;PRF;POS;COND;3;SG
 eitama	olin eitanud	V;ACT;PRS;PRF;POS;COND;1;SG
 eitama	oled eitanud	V;ACT;PRS;PRF;POS;IND;2;SG
 eitama	oli eitanud	V;ACT;PRS;PRF;POS;COND;3;SG
-eitama	ei ole eitatudp	V;PASS;PRS;PRF;NEG;IND
+eitama	ei ole eitatud	V;PASS;PRS;PRF;NEG;IND
 eitama	eitaksin	V;ACT;PRS;POS;COND;1;SG
 eitama	olen eitanud	V;ACT;PRS;PRF;POS;IND;1;SG
-eitama	ei olnud eitatudp	V;PASS;PST;PRF;NEG;IND
+eitama	ei olnud eitatud	V;PASS;PST;PRF;NEG;IND
 eitama	ärgu olgu eitatud	V;PASS;PRS;PRF;NEG;IMP
 
 eitav	eitavani	N;TERM;SG
@@ -38254,7 +38254,7 @@ ekvaator	ekvaatoritesse	N;IN+ALL;PL
 ekvaator	ekvaatoritelt	N;AT+ABL;PL
 
 elama	olete elanud	V;ACT;PRS;PRF;POS;IND;2;PL
-elama	ei olevat elanudp	V;ACT;PRS;PRF;NEG;QUOT
+elama	ei olevat elanud	V;ACT;PRS;PRF;NEG;QUOT
 elama	oleks elatud	V;PASS;PRS;PRF;POS;COND
 elama	elasin	V;ACT;PST;POS;IND;1;SG
 elama	elatakse	V;PASS;PRS;POS;IND
@@ -38263,7 +38263,7 @@ elama	elatagu	V;PASS;PRS;POS;IMP
 elama	ärgu elagu	V;ACT;PRS;NEG;IMP;3;SG
 elama	oli elatud	V;PASS;PST;PRF;POS;IND
 elama	elasime	V;ACT;PST;POS;IND;1;PL
-elama	ei olnud elanudp	V;ACT;PST;PRF;NEG;IND
+elama	ei olnud elanud	V;ACT;PST;PRF;NEG;IND
 elama	oleksid elanud	V;ACT;PRS;PRF;POS;COND;2;SG
 elama	olgu elanud	V;ACT;PRS;PRF;POS;IMP;PL
 elama	oli elanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -38277,9 +38277,9 @@ elama	ärgu elagu	V;ACT;PRS;NEG;IMP;3;PL
 elama	olgu elanud	V;ACT;PRS;PRF;POS;IMP;SG
 elama	elati	V;PASS;PST;POS;IND
 elama	ei elavat	V;ACT;PRS;NEG;QUOT
-elama	ei oleks elatudp	V;PASS;PRS;PRF;NEG;COND
+elama	ei oleks elatud	V;PASS;PRS;PRF;NEG;COND
 elama	ei elanud	V;ACT;PST;NEG;IND
-elama	ei olevat elatudp	V;PASS;PRS;PRF;NEG;QUOT
+elama	ei olevat elatud	V;PASS;PRS;PRF;NEG;QUOT
 elama	ei elaks	V;ACT;PRS;PRF;POS;COND;1;SG
 elama	elatud	V.PTCP;PASS;PST
 elama	olid elanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -38298,7 +38298,7 @@ elama	olgu elatud	V;PASS;PRS;PRF;POS;IMP
 elama	elaks	V;ACT;PRS;POS;COND;3;SG
 elama	elagu	V;ACT;PRS;POS;IMP;3;PL
 elama	ärgu olgu elanud	V;ACT;PRS;PRF;NEG;IMP;SG
-elama	ei ole elanudp	V;ACT;PST;NEG;IND
+elama	ei ole elanud	V;ACT;PST;NEG;IND
 elama	elad	V;ACT;PRS;POS;IND;2;SG
 elama	ära ela	V;ACT;PRS;NEG;IMP;2;SG
 elama	ei ela	V;ACT;PRS;NEG;IND
@@ -38326,17 +38326,17 @@ elama	ei elata	V;PASS;PRS;NEG;IND
 elama	elame	V;ACT;PRS;POS;IND;1;PL
 elama	elan	V;ACT;PRS;POS;IND;1;SG
 elama	ärgem elagem	V;ACT;PRS;NEG;IMP;1;PL
-elama	ei oleks elanudp	V;ACT;PRS;PRF;NEG;COND
+elama	ei oleks elanud	V;ACT;PRS;PRF;NEG;COND
 elama	oleksid elanud	V;ACT;PRS;PRF;POS;COND;3;PL
 elama	elasite	V;ACT;PST;POS;IND;2;PL
 elama	oleks elanud	V;ACT;PRS;PRF;POS;COND;3;SG
 elama	olin elanud	V;ACT;PRS;PRF;POS;COND;1;SG
 elama	oled elanud	V;ACT;PRS;PRF;POS;IND;2;SG
 elama	oli elanud	V;ACT;PRS;PRF;POS;COND;3;SG
-elama	ei ole elatudp	V;PASS;PRS;PRF;NEG;IND
+elama	ei ole elatud	V;PASS;PRS;PRF;NEG;IND
 elama	elaksin	V;ACT;PRS;POS;COND;1;SG
 elama	olen elanud	V;ACT;PRS;PRF;POS;IND;1;SG
-elama	ei olnud elatudp	V;PASS;PST;PRF;NEG;IND
+elama	ei olnud elatud	V;PASS;PST;PRF;NEG;IND
 elama	ärgu olgu elatud	V;PASS;PRS;PRF;NEG;IMP
 
 elav	elavani	N;TERM;SG
@@ -38464,7 +38464,7 @@ elutuba	elutubadesse	N;IN+ALL;PL
 elutuba	elutubadelt	N;AT+ABL;PL
 
 embama	olete emmanud	V;ACT;PRS;PRF;POS;IND;2;PL
-embama	ei olevat emmanudp	V;ACT;PRS;PRF;NEG;QUOT
+embama	ei olevat emmanud	V;ACT;PRS;PRF;NEG;QUOT
 embama	oleks emmatud	V;PASS;PRS;PRF;POS;COND
 embama	embasin	V;ACT;PST;POS;IND;1;SG
 embama	emmatakse	V;PASS;PRS;POS;IND
@@ -38473,7 +38473,7 @@ embama	emmatagu	V;PASS;PRS;POS;IMP
 embama	ärgu emmaku	V;ACT;PRS;NEG;IMP;3;SG
 embama	oli emmatud	V;PASS;PST;PRF;POS;IND
 embama	embasime	V;ACT;PST;POS;IND;1;PL
-embama	ei olnud emmanudp	V;ACT;PST;PRF;NEG;IND
+embama	ei olnud emmanud	V;ACT;PST;PRF;NEG;IND
 embama	oleksid emmanud	V;ACT;PRS;PRF;POS;COND;2;SG
 embama	olgu emmanud	V;ACT;PRS;PRF;POS;IMP;PL
 embama	oli emmanud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -38487,9 +38487,9 @@ embama	ärgu emmaku	V;ACT;PRS;NEG;IMP;3;PL
 embama	olgu emmanud	V;ACT;PRS;PRF;POS;IMP;SG
 embama	emmati	V;PASS;PST;POS;IND
 embama	ei embavat	V;ACT;PRS;NEG;QUOT
-embama	ei oleks emmatudp	V;PASS;PRS;PRF;NEG;COND
+embama	ei oleks emmatud	V;PASS;PRS;PRF;NEG;COND
 embama	ei emmanud	V;ACT;PST;NEG;IND
-embama	ei olevat emmatudp	V;PASS;PRS;PRF;NEG;QUOT
+embama	ei olevat emmatud	V;PASS;PRS;PRF;NEG;QUOT
 embama	ei embaks	V;ACT;PRS;PRF;POS;COND;1;SG
 embama	emmatud	V.PTCP;PASS;PST
 embama	olid emmanud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -38508,7 +38508,7 @@ embama	olgu emmatud	V;PASS;PRS;PRF;POS;IMP
 embama	embaks	V;ACT;PRS;POS;COND;3;SG
 embama	emmaku	V;ACT;PRS;POS;IMP;3;PL
 embama	ärgu olgu emmanud	V;ACT;PRS;PRF;NEG;IMP;SG
-embama	ei ole emmanudp	V;ACT;PST;NEG;IND
+embama	ei ole emmanud	V;ACT;PST;NEG;IND
 embama	embad	V;ACT;PRS;POS;IND;2;SG
 embama	ära emba	V;ACT;PRS;NEG;IMP;2;SG
 embama	ei emba	V;ACT;PRS;NEG;IND
@@ -38536,17 +38536,17 @@ embama	ei emmata	V;PASS;PRS;NEG;IND
 embama	embame	V;ACT;PRS;POS;IND;1;PL
 embama	emban	V;ACT;PRS;POS;IND;1;SG
 embama	ärgem emmakem	V;ACT;PRS;NEG;IMP;1;PL
-embama	ei oleks emmanudp	V;ACT;PRS;PRF;NEG;COND
+embama	ei oleks emmanud	V;ACT;PRS;PRF;NEG;COND
 embama	oleksid emmanud	V;ACT;PRS;PRF;POS;COND;3;PL
 embama	embasite	V;ACT;PST;POS;IND;2;PL
 embama	oleks emmanud	V;ACT;PRS;PRF;POS;COND;3;SG
 embama	olin emmanud	V;ACT;PRS;PRF;POS;COND;1;SG
 embama	oled emmanud	V;ACT;PRS;PRF;POS;IND;2;SG
 embama	oli emmanud	V;ACT;PRS;PRF;POS;COND;3;SG
-embama	ei ole emmatudp	V;PASS;PRS;PRF;NEG;IND
+embama	ei ole emmatud	V;PASS;PRS;PRF;NEG;IND
 embama	embaksin	V;ACT;PRS;POS;COND;1;SG
 embama	olen emmanud	V;ACT;PRS;PRF;POS;IND;1;SG
-embama	ei olnud emmatudp	V;PASS;PST;PRF;NEG;IND
+embama	ei olnud emmatud	V;PASS;PST;PRF;NEG;IND
 embama	ärgu olgu emmatud	V;PASS;PRS;PRF;NEG;IMP
 
 erbium	erbiumini	N;TERM;SG
@@ -38581,7 +38581,7 @@ erbium	erbiumdesse	N;IN+ALL;PL
 erbium	erbiumdelt	N;AT+ABL;PL
 
 erinema	olete erinenud	V;ACT;PRS;PRF;POS;IND;2;PL
-erinema	ei olevat erinenudp	V;ACT;PRS;PRF;NEG;QUOT
+erinema	ei olevat erinenud	V;ACT;PRS;PRF;NEG;QUOT
 erinema	oleks erinetud	V;PASS;PRS;PRF;POS;COND
 erinema	erinesin	V;ACT;PST;POS;IND;1;SG
 erinema	erinetakse	V;PASS;PRS;POS;IND
@@ -38590,7 +38590,7 @@ erinema	erinetagu	V;PASS;PRS;POS;IMP
 erinema	ärgu erinegu	V;ACT;PRS;NEG;IMP;3;SG
 erinema	oli erinetud	V;PASS;PST;PRF;POS;IND
 erinema	erinesime	V;ACT;PST;POS;IND;1;PL
-erinema	ei olnud erinenudp	V;ACT;PST;PRF;NEG;IND
+erinema	ei olnud erinenud	V;ACT;PST;PRF;NEG;IND
 erinema	oleksid erinenud	V;ACT;PRS;PRF;POS;COND;2;SG
 erinema	olgu erinenud	V;ACT;PRS;PRF;POS;IMP;PL
 erinema	oli erinenud	V;ACT;PRS;PRF;POS;COND;3;PL
@@ -38604,9 +38604,9 @@ erinema	ärgu erinegu	V;ACT;PRS;NEG;IMP;3;PL
 erinema	olgu erinenud	V;ACT;PRS;PRF;POS;IMP;SG
 erinema	erineti	V;PASS;PST;POS;IND
 erinema	ei erinevat	V;ACT;PRS;NEG;QUOT
-erinema	ei oleks erinetudp	V;PASS;PRS;PRF;NEG;COND
+erinema	ei oleks erinetud	V;PASS;PRS;PRF;NEG;COND
 erinema	ei erinenud	V;ACT;PST;NEG;IND
-erinema	ei olevat erinetudp	V;PASS;PRS;PRF;NEG;QUOT
+erinema	ei olevat erinetud	V;PASS;PRS;PRF;NEG;QUOT
 erinema	ei erineks	V;ACT;PRS;PRF;POS;COND;1;SG
 erinema	erinetud	V.PTCP;PASS;PST
 erinema	olid erinenud	V;ACT;PRS;PRF;POS;COND;2;SG
@@ -38625,7 +38625,7 @@ erinema	olgu erinetud	V;PASS;PRS;PRF;POS;IMP
 erinema	erineks	V;ACT;PRS;POS;COND;3;SG
 erinema	erinegu	V;ACT;PRS;POS;IMP;3;PL
 erinema	ärgu olgu erinenud	V;ACT;PRS;PRF;NEG;IMP;SG
-erinema	ei ole erinenudp	V;ACT;PST;NEG;IND
+erinema	ei ole erinenud	V;ACT;PST;NEG;IND
 erinema	erined	V;ACT;PRS;POS;IND;2;SG
 erinema	ära erine	V;ACT;PRS;NEG;IMP;2;SG
 erinema	ei erine	V;ACT;PRS;NEG;IND
@@ -38653,17 +38653,17 @@ erinema	ei erineta	V;PASS;PRS;NEG;IND
 erinema	erineme	V;ACT;PRS;POS;IND;1;PL
 erinema	erinen	V;ACT;PRS;POS;IND;1;SG
 erinema	ärgem erinegem	V;ACT;PRS;NEG;IMP;1;PL
-erinema	ei oleks erinenudp	V;ACT;PRS;PRF;NEG;COND
+erinema	ei oleks erinenud	V;ACT;PRS;PRF;NEG;COND
 erinema	oleksid erinenud	V;ACT;PRS;PRF;POS;COND;3;PL
 erinema	erinesite	V;ACT;PST;POS;IND;2;PL
 erinema	oleks erinenud	V;ACT;PRS;PRF;POS;COND;3;SG
 erinema	olin erinenud	V;ACT;PRS;PRF;POS;COND;1;SG
 erinema	oled erinenud	V;ACT;PRS;PRF;POS;IND;2;SG
 erinema	oli erinenud	V;ACT;PRS;PRF;POS;COND;3;SG
-erinema	ei ole erinetudp	V;PASS;PRS;PRF;NEG;IND
+erinema	ei ole erinetud	V;PASS;PRS;PRF;NEG;IND
 erinema	erineksin	V;ACT;PRS;POS;COND;1;SG
 erinema	olen erinenud	V;ACT;PRS;PRF;POS;IND;1;SG
-erinema	ei olnud erinetudp	V;PASS;PST;PRF;NEG;IND
+erinema	ei olnud erinetud	V;PASS;PST;PRF;NEG;IND
 erinema	ärgu olgu erinetud	V;PASS;PRS;PRF;NEG;IMP
 
 ester	estrini	N;TERM;SG


### PR DESCRIPTION
For some unknown reason there was noise in many of the endings (nud, tud) that they ended with `[tn]udp` instead of correct `[tn]ud`.